### PR TITLE
Update Bencher CLI usage

### DIFF
--- a/.github/workflows/post_pr_benchmarks.yml
+++ b/.github/workflows/post_pr_benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
           script: |
             let fs = require('fs');
             let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
-            core.exportVariable("PR_HEAD", `${prEvent.number}/merge`);
+            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
             core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
             core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
             core.exportVariable("PR_NUMBER", prEvent.number);
@@ -39,14 +39,14 @@ jobs:
           bencher run \
           --project valtuutus \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch '${{ env.PR_HEAD }}' \
-          --start-point '${{ env.PR_BASE }}' \
-          --start-point-hash '${{ env.PR_BASE_SHA }}' \
+          --branch "$PR_HEAD" \
+          --start-point "$PR_BASE" \
+          --start-point-hash "$PR_BASE_SHA" \
           --start-point-clone-thresholds \
           --start-point-reset \
           --testbed ubuntu-latest \
           --err \
           --adapter c_sharp_dot_net  \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \
-          --ci-number '${{ env.PR_NUMBER }}' \
+          --ci-number "$PR_NUMBER" \
           --file 'Valtuutus.Benchmarks.Benchmarks-report-full-compressed.json'


### PR DESCRIPTION
This changeset updates the Bencher CLI to the new recommended usage.

- Safer tracking from forks: https://bencher.dev/docs/how-to/github-actions/#pull-requests-from-forks