### PR TITLE
FIX: Setting default depth limit for LookupEntityRequest.cs

### DIFF
--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityRequest.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityRequest.cs
@@ -24,6 +24,6 @@ public record LookupEntityRequest : IWithDepth, IWithSnapToken
     public required string SubjectType { get; init; }
     public required string SubjectId { get; init; }
     public SnapToken? SnapToken { get; set; }
-    public int Depth { get; set; }
+    public int Depth { get; set; } = 10;
     public IDictionary<string, object> Context { get; set; } = new Dictionary<string, object>();
 }

--- a/tests/Valtuutus.Tests.Shared/LookupEntityEngineSpecList.cs
+++ b/tests/Valtuutus.Tests.Shared/LookupEntityEngineSpecList.cs
@@ -284,6 +284,21 @@ public static class LookupEntityEngineSpecList
                 Depth = 2
             },
             new HashSet<string>() { TestsConsts.Workspaces.PublicWorkspace }
+        },
+        {
+            [
+                new(TestsConsts.Groups.Identifier, TestsConsts.Groups.Developers, "member", TestsConsts.Users.Identifier, TestsConsts.Users.Alice),
+                new(TestsConsts.Workspaces.Identifier, TestsConsts.Workspaces.PublicWorkspace, "group_members", TestsConsts.Groups.Identifier, TestsConsts.Groups.Developers),
+            ],
+            [],
+            new LookupEntityRequest()
+            {
+                EntityType = TestsConsts.Workspaces.Identifier,
+                Permission = "view",
+                SubjectType = TestsConsts.Users.Identifier,
+                SubjectId = TestsConsts.Users.Alice,
+            },
+            new HashSet<string>() { TestsConsts.Workspaces.PublicWorkspace }
         }
     };
 }


### PR DESCRIPTION
Fixes #89 