### PR TITLE
ci: track dev branch benchmarks as Bencher baseline

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -1,6 +1,8 @@
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - dev
 
 jobs:
   benchmark_base_branch:
@@ -30,7 +32,7 @@ jobs:
             bencher run \
             --project valtuutus \
             --token "$BENCHER_API_TOKEN" \
-            --branch main \
+            --branch "${{ github.ref_name }}" \
             --testbed ubuntu-latest \
             --threshold-measure latency \
             --threshold-test t_test \


### PR DESCRIPTION
## Summary

- Adds `dev` to the push trigger on `base_benchmarks.yml`
- Replaces the hardcoded `--branch main` with `--branch "${{ github.ref_name }}"` so each branch tracks its own Bencher baseline
- Without this, PRs targeting `dev` had no baseline data in Bencher — `--start-point dev` in `post_pr_benchmarks.yml` would find nothing to compare against