### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/Authorization Patterns.md
+++ b/Authorization Patterns.md
@@ -1,0 +1,258 @@
+# Authorization Patterns
+
+This page shows ready-made patterns for common authorization scenarios. Each pattern includes a complete schema, the relation tuples you'd write, and the checks you'd run.
+
+---
+
+## Role-Based Access Control (RBAC)
+
+Roles are modeled as relations. Permissions are union expressions over those relations.
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity organization {
+        relation admin @user;
+        relation member @user;
+        relation guest @user;
+
+        permission manage_billing := admin;
+        permission invite_member  := admin or member;
+        permission view_resources := admin or member or guest;
+    }
+""");
+```
+
+**Write tuples:**
+```csharp
+// alice is an admin of org-1
+await writer.Write([
+    new RelationTuple("organization", "org-1", "admin",  "user", "alice"),
+    new RelationTuple("organization", "org-1", "member", "user", "bob"),
+    new RelationTuple("organization", "org-1", "guest",  "user", "carol"),
+], [], ct);
+```
+
+**Check:**
+```csharp
+// true — alice is admin
+await checkEngine.Check(new CheckRequest("organization", "org-1", "manage_billing", "user", "alice"), ct);
+
+// false — bob is only a member
+await checkEngine.Check(new CheckRequest("organization", "org-1", "manage_billing", "user", "bob"), ct);
+```
+
+---
+
+## Hierarchical RBAC
+
+Permissions propagate through parent-child relationships. A user who is admin of an organization automatically has elevated rights on any resource that inherits from it.
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity organization {
+        relation admin @user;
+        relation member @user;
+    }
+    entity team {
+        relation parent @organization;
+        relation owner @user;
+        relation member @user;
+
+        // inherit admin from the parent organization
+        permission manage := owner or parent.admin;
+        permission view   := member or owner or parent.admin or parent.member;
+    }
+    entity project {
+        relation parent @team;
+        relation contributor @user;
+
+        permission edit   := contributor or parent.owner or parent.parent.admin;
+        permission view   := contributor or parent.member or parent.owner or parent.parent.member or parent.parent.admin;
+    }
+""");
+```
+
+**Write tuples:**
+```csharp
+await writer.Write([
+    new RelationTuple("organization", "org-1", "admin",  "user", "alice"),
+    new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+    new RelationTuple("team",         "team-1", "member", "user", "bob"),
+    new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+], [], ct);
+```
+
+**Check:**
+```csharp
+// true — alice is org admin, which propagates through team-1 to proj-1
+await checkEngine.Check(new CheckRequest("project", "proj-1", "edit", "user", "alice"), ct);
+
+// true — bob is a team member
+await checkEngine.Check(new CheckRequest("project", "proj-1", "view", "user", "bob"), ct);
+```
+
+---
+
+## Attribute-Based Access Control (ABAC)
+
+Attributes let you encode properties of entities (public/private, status, region) and use them directly in permission expressions.
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity document {
+        relation owner @user;
+        attribute public bool;
+        attribute status string;
+
+        // anyone can view public documents; only owners can view private ones
+        permission view := owner or public;
+
+        // edit requires ownership AND the document must be in draft status
+        permission edit := owner and isDraft(status);
+    }
+
+    fn isDraft(status string) => status == "draft";
+""");
+```
+
+**Write tuples and attributes:**
+```csharp
+await writer.Write(
+    [new RelationTuple("document", "doc-1", "owner", "user", "alice")],
+    [
+        new AttributeTuple("document", "doc-1", "public", JsonValue.Create(false)),
+        new AttributeTuple("document", "doc-1", "status", JsonValue.Create("draft")),
+    ],
+    ct);
+```
+
+**Check:**
+```csharp
+// true — alice is owner and doc is draft
+await checkEngine.Check(new CheckRequest("document", "doc-1", "edit", "user", "alice"), ct);
+
+// false — bob is not owner and doc is not public
+await checkEngine.Check(new CheckRequest("document", "doc-1", "view", "user", "bob"), ct);
+```
+
+> **Note:** If an attribute tuple does not exist for an entity, any attribute check in a permission expression evaluates to `false`.
+
+---
+
+## Combining RBAC and ABAC
+
+Relations and attributes compose freely. A common pattern is gating a role-based permission with an additional attribute check.
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity repository {
+        relation owner      @user;
+        relation maintainer @user;
+        attribute archived bool;
+
+        // push is blocked for everyone when the repo is archived
+        permission push := (owner or maintainer) and not(archived);
+    }
+""");
+```
+
+**Write:**
+```csharp
+await writer.Write(
+    [new RelationTuple("repository", "repo-1", "owner", "user", "alice")],
+    [new AttributeTuple("repository", "repo-1", "archived", JsonValue.Create(true))],
+    ct);
+```
+
+**Check:**
+```csharp
+// false — repo is archived, push is blocked even for the owner
+await checkEngine.Check(new CheckRequest("repository", "repo-1", "push", "user", "alice"), ct);
+```
+
+---
+
+## Multi-Tenancy
+
+Valtuutus does not have a built-in tenant column. The two supported approaches are described below.
+
+### Option 1: Tenant-per-database (strongest isolation)
+
+Give each tenant its own database. At request time, resolve the correct connection string for the tenant and pass it via `IDbDataWriterProvider` / `IDbDataReaderProvider`:
+
+```csharp
+// Register with a tenant-aware connection factory
+builder.Services.AddValtuutusCore(/* schema */)
+    .AddPostgres(sp =>
+    {
+        var tenantResolver = sp.GetRequiredService<ITenantResolver>();
+        return () =>
+        {
+            var connectionString = tenantResolver.GetConnectionString();
+            return new NpgsqlConnection(connectionString);
+        };
+    });
+```
+
+`ITenantResolver` is your own service — it could read the tenant from the current HTTP context, a claim, or a scoped dependency.
+
+Each tenant's data is fully isolated; there is no risk of cross-tenant data leakage at the database level.
+
+### Option 2: Tenant-per-schema (Postgres only)
+
+Postgres supports multiple schemas within a single database. Valtuutus lets you configure the schema name at DI registration time. By combining this with a schema-per-tenant convention and setting `search_path` on the connection, you get isolation with shared infrastructure:
+
+```csharp
+builder.Services.AddValtuutusCore(/* schema */)
+    .AddPostgres(sp =>
+    {
+        var tenantResolver = sp.GetRequiredService<ITenantResolver>();
+        return () =>
+        {
+            var conn = new NpgsqlConnection(sharedConnectionString);
+            // Direct Postgres to the tenant's schema
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{tenantResolver.GetSchemaName()}\"";
+            cmd.ExecuteNonQuery();
+            return conn;
+        };
+    });
+```
+
+Run the Valtuutus migration once per tenant schema when a new tenant is provisioned.
+
+### What is not currently supported
+
+Shared tables with a `tenant_id` column are not supported in the current data model. If you need this pattern, please open an issue — it would require a schema change to `relation_tuples` and `attributes`, and updated queries across all providers.
+
+---
+
+## Ownership transfer
+
+When ownership of a resource changes, delete the old owner tuple and write the new one in a single operation:
+
+```csharp
+SnapToken token = await writer.Delete(
+    new DeleteFilter
+    {
+        Relations = [new DeleteRelationsFilter
+        {
+            EntityType = "document",
+            EntityId   = "doc-1",
+            Relation   = "owner",
+            SubjectType = "user",
+            SubjectId   = "alice"
+        }]
+    }, ct);
+
+token = await writer.Write(
+    [new RelationTuple("document", "doc-1", "owner", "user", "bob")],
+    [], ct);
+```
+
+Pass the returned `token` on subsequent checks to guarantee read-after-write consistency.

--- a/Authorization Patterns.md
+++ b/Authorization Patterns.md
@@ -60,7 +60,6 @@ builder.Services.AddValtuutusCore("""
         relation owner @user;
         relation member @user;
 
-        // inherit admin from the parent organization
         permission manage := owner or parent.admin;
         permission view   := member or owner or parent.admin or parent.member;
     }
@@ -68,11 +67,14 @@ builder.Services.AddValtuutusCore("""
         relation parent @team;
         relation contributor @user;
 
-        permission edit   := contributor or parent.owner or parent.parent.admin;
-        permission view   := contributor or parent.member or parent.owner or parent.parent.member or parent.parent.admin;
+        // parent.manage and parent.view already encode the full team + org hierarchy
+        permission edit := contributor or parent.manage;
+        permission view := contributor or parent.view;
     }
 """);
 ```
+
+The dot notation resolves permissions, not just relations. `parent.manage` on `project` walks to the linked `team` and evaluates its `manage` permission — which itself already encodes `owner or parent.admin`. The full org → team → project hierarchy is expressed without repeating any logic.
 
 **Write tuples:**
 ```csharp

--- a/Authorization Patterns.md
+++ b/Authorization Patterns.md
@@ -180,67 +180,20 @@ await checkEngine.Check(new CheckRequest("repository", "repo-1", "push", "user",
 
 ## Multi-Tenancy
 
-Valtuutus does not have a built-in tenant column. The two supported approaches are described below.
-
-### Option 1: Tenant-per-database (strongest isolation)
-
-Give each tenant its own database. At request time, resolve the correct connection string for the tenant and pass it via `IDbDataWriterProvider` / `IDbDataReaderProvider`:
-
-```csharp
-// Register with a tenant-aware connection factory
-builder.Services.AddValtuutusCore(/* schema */)
-    .AddPostgres(sp =>
-    {
-        var tenantResolver = sp.GetRequiredService<ITenantResolver>();
-        return () =>
-        {
-            var connectionString = tenantResolver.GetConnectionString();
-            return new NpgsqlConnection(connectionString);
-        };
-    });
-```
-
-`ITenantResolver` is your own service — it could read the tenant from the current HTTP context, a claim, or a scoped dependency.
-
-Each tenant's data is fully isolated; there is no risk of cross-tenant data leakage at the database level.
-
-### Option 2: Tenant-per-schema
-
-Both Postgres and SQL Server support multiple schemas within a single database. Valtuutus lets you configure the schema name via `ValtuutusPostgresOptions` / `ValtuutusSqlServerOptions` at DI registration time, so each tenant's tables can live in their own schema.
-
-**Postgres** — schemas can be switched dynamically per request using `search_path` on the connection, which makes this pattern easy to implement in a multi-tenant DI setup:
+The recommended approach is **tenant-per-database**: give each tenant its own database and resolve the correct connection string at request time via the connection factory:
 
 ```csharp
 builder.Services.AddValtuutusCore(/* schema */)
     .AddPostgres(sp =>
     {
         var tenantResolver = sp.GetRequiredService<ITenantResolver>();
-        return () =>
-        {
-            var conn = new NpgsqlConnection(sharedConnectionString);
-            conn.Open();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = $"SET search_path TO \"{tenantResolver.GetSchemaName()}\"";
-            cmd.ExecuteNonQuery();
-            return conn;
-        };
+        return () => new NpgsqlConnection(tenantResolver.GetConnectionString());
     });
 ```
 
-**SQL Server** — does not have a `search_path` equivalent, so the schema name is configured statically at registration time. For SQL Server multi-tenancy, tenant-per-database (Option 1) is the more practical approach. If you do need schema isolation on SQL Server, provision one DI container (or named service registration) per tenant, each with its own `ValtuutusSqlServerOptions`:
+`ITenantResolver` is your own service — it could read the tenant from the current HTTP context, a claim, or a scoped dependency. Each tenant's data is fully isolated with no risk of cross-tenant leakage.
 
-```csharp
-builder.Services.AddValtuutusCore(/* schema */)
-    .AddSqlServer(
-        _ => () => new SqlConnection(sharedConnectionString),
-        new ValtuutusSqlServerOptions("tenant_a", "transactions", "relation_tuples", "attributes"));
-```
-
-Run the Valtuutus migration once per tenant schema when a new tenant is provisioned.
-
-### What is not currently supported
-
-Shared tables with a `tenant_id` column are not supported in the current data model. If you need this pattern, please open an issue — it would require a schema change to `relation_tuples` and `attributes`, and updated queries across all providers.
+> **Note:** Shared-table multi-tenancy (a `tenant_id` column on `relation_tuples` and `attributes`) is not currently supported. If this is a requirement for you, please open an issue.
 
 ---
 

--- a/Authorization Patterns.md
+++ b/Authorization Patterns.md
@@ -204,9 +204,11 @@ builder.Services.AddValtuutusCore(/* schema */)
 
 Each tenant's data is fully isolated; there is no risk of cross-tenant data leakage at the database level.
 
-### Option 2: Tenant-per-schema (Postgres only)
+### Option 2: Tenant-per-schema
 
-Postgres supports multiple schemas within a single database. Valtuutus lets you configure the schema name at DI registration time. By combining this with a schema-per-tenant convention and setting `search_path` on the connection, you get isolation with shared infrastructure:
+Both Postgres and SQL Server support multiple schemas within a single database. Valtuutus lets you configure the schema name via `ValtuutusPostgresOptions` / `ValtuutusSqlServerOptions` at DI registration time, so each tenant's tables can live in their own schema.
+
+**Postgres** — schemas can be switched dynamically per request using `search_path` on the connection, which makes this pattern easy to implement in a multi-tenant DI setup:
 
 ```csharp
 builder.Services.AddValtuutusCore(/* schema */)
@@ -216,7 +218,6 @@ builder.Services.AddValtuutusCore(/* schema */)
         return () =>
         {
             var conn = new NpgsqlConnection(sharedConnectionString);
-            // Direct Postgres to the tenant's schema
             conn.Open();
             using var cmd = conn.CreateCommand();
             cmd.CommandText = $"SET search_path TO \"{tenantResolver.GetSchemaName()}\"";
@@ -224,6 +225,15 @@ builder.Services.AddValtuutusCore(/* schema */)
             return conn;
         };
     });
+```
+
+**SQL Server** — does not have a `search_path` equivalent, so the schema name is configured statically at registration time. For SQL Server multi-tenancy, tenant-per-database (Option 1) is the more practical approach. If you do need schema isolation on SQL Server, provision one DI container (or named service registration) per tenant, each with its own `ValtuutusSqlServerOptions`:
+
+```csharp
+builder.Services.AddValtuutusCore(/* schema */)
+    .AddSqlServer(
+        _ => () => new SqlConnection(sharedConnectionString),
+        new ValtuutusSqlServerOptions("tenant_a", "transactions", "relation_tuples", "attributes"));
 ```
 
 Run the Valtuutus migration once per tenant schema when a new tenant is provisioned.

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -1,0 +1,105 @@
+# Getting Started
+
+This guide takes you from zero to a working authorization check in under 10 minutes.
+
+## 1. Install
+
+Pick the storage backend that fits your stack:
+
+```shell
+# PostgreSQL
+dotnet add package Valtuutus.Data.Postgres
+
+# SQL Server
+dotnet add package Valtuutus.Data.SqlServer
+
+# In-memory (great for tests and local development)
+dotnet add package Valtuutus.Data.InMemory
+```
+
+## 2. Run database migrations
+
+If you're using a relational provider, create the required tables before starting. Run the SQL script for your database:
+
+- [Postgres migration](src/Valtuutus.Data.Postgres/Database/migrations/20240221201712_initial.sql)
+- [SqlServer migration](src/Valtuutus.Data.SqlServer/Database/migrations/20240224120604_initial.sql)
+
+The InMemory provider needs no migration.
+
+## 3. Register Valtuutus in DI
+
+In `Program.cs` (or wherever you configure services), define your authorization schema and register a provider:
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity document {
+        relation owner @user;
+        relation viewer @user;
+        permission view := owner or viewer;
+        permission edit := owner;
+    }
+""")
+.AddPostgres(_ => () => new NpgsqlConnection(
+    builder.Configuration.GetConnectionString("PostgresDb")!));
+```
+
+For SQL Server, replace `.AddPostgres(...)` with `.AddSqlServer(...)`. For InMemory:
+
+```csharp
+.AddInMemory()
+```
+
+## 4. Write authorization data
+
+Inject `IDataWriterProvider` and write relation tuples that encode your access control facts. Here we say "user `alice` is the owner of document `readme`":
+
+```csharp
+public class DocumentService(IDataWriterProvider writer)
+{
+    public async Task CreateDocument(string documentId, string userId, CancellationToken ct)
+    {
+        // ... your document creation logic ...
+
+        // Record the ownership relation in Valtuutus
+        SnapToken token = await writer.Write(
+            [new RelationTuple("document", documentId, "owner", "user", userId)],
+            [],
+            ct);
+
+        // Store `token` alongside your resource if you need read-after-write consistency
+    }
+}
+```
+
+## 5. Check permissions
+
+Inject `ICheckEngine` and ask whether a user can perform an action:
+
+```csharp
+public class DocumentController(ICheckEngine checkEngine) : ControllerBase
+{
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(string id, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+        bool canView = await checkEngine.Check(
+            new CheckRequest("document", id, "view", "user", userId),
+            ct);
+
+        if (!canView)
+            return Forbid();
+
+        // ... return document ...
+    }
+}
+```
+
+## Next steps
+
+- [Modeling Authorization](Modeling%20Authorization.md) — learn how to express complex RBAC, ABAC, and relationship-based policies in the schema DSL
+- [Authorization Patterns](Authorization%20Patterns.md) — ready-made patterns for common use cases
+- [Using the Engines](Using%20the%20Engines.md) — full reference for Check, SubjectPermission, LookupSubject, and LookupEntity
+- [Storing Data](Storing%20Data.md) — writing, deleting, snap tokens, and the source generator
+- [Caching](Caching.md) — reduce database load with FusionCache

--- a/Modeling Authorization.md
+++ b/Modeling Authorization.md
@@ -31,7 +31,7 @@ builder.Services.AddValtuutusCore("""
         relation owner @user;
         relation maintainer @user @team#member;
         permission push := owner or maintainer and notArchived(archived);
-        permission read := public and (org.admin or owner or maintainer or org.member);
+        permission read := public and (parent.admin or owner or maintainer or parent.member);
         permission delete := parent.admin or owner;
    }
    
@@ -151,7 +151,7 @@ builder.Services.AddValtuutusCore("""
     ...
     entity repository {
         ...
-        permission read := org.admin and (owner or mantainer or org.member);
+        permission read := org.admin and (owner or maintainer or org.member);
     }
 """);
 ```
@@ -186,7 +186,17 @@ builder.Services.AddValtuutusCore("""
 | `not(owner or editor)` | User has neither `owner` nor `editor` |
 | `not(owner and editor)` | User is not simultaneously owner and editor |
 
-> **Note:** Negation is evaluated against the set of subjects/entities known in the data store. If no tuples or attributes exist for a given type, the complement may be empty.
+> **Important — data store requirement for lookup operations:**
+>
+> `not()` behaves differently depending on which engine is called:
+>
+> - **`Check()`** — works correctly regardless of whether the subject has any relation tuples. If a user has no `owner` tuple, `not(owner)` evaluates to `true` as expected.
+>
+> - **`LookupSubject` / `LookupEntity`** — the complement is computed from subjects/entities that are **already known in the data store** (i.e. have at least one relation tuple). Subjects with no tuples at all are invisible to the engine and will **not** be included in the result.
+>
+> **Practical consequence:** if you use `not(owner)` in a `LookupSubject` call to find all non-owners of a document, only users who already have *some* relation tuple (e.g. `viewer`, `editor`, etc.) will be considered. A user with no tuples at all won't appear in the results, even though they are technically not an owner.
+>
+> To ensure `not()` works correctly in lookup operations, make sure every subject that should participate in the permission model has at least one relation tuple stored for the relevant entity type.
 
 ## Attribute Based Permissions (ABAC)
 To support Attribute Based Access Control (ABAC) in Valtuutus, you can define attributes for entities and use them in your permissions.
@@ -204,7 +214,7 @@ builder.Services.AddValtuutusCore("""
     entity repository {
         ...
         attribute public bool;
-        permission read := org.admin and (owner or mantainer or org.member or public);
+        permission read := org.admin and (owner or maintainer or org.member or public);
     }
 """);
 ```
@@ -216,7 +226,7 @@ builder.Services.AddValtuutusCore("""
     entity repository {
         ...
         attribute status string;
-        permission write := org.admin and (owner or mantainer or org.member) and isActiveStatus(status);
+        permission write := org.admin and (owner or maintainer or org.member) and isActiveStatus(status);
    
     }
     fn isActiveStatus(status string) => status == "active";
@@ -261,7 +271,7 @@ Calling a function inside a permission is simple:
         ...
 """
 ```
-Functions can receive the number of parameters you want, currently there's no limit to it. There is no way to define a optional parameter.
+Functions can receive any number of parameters, currently there's no limit to it. There is no way to define a optional parameter.
 During a function call, you can use a special accessor, called `context`.
 You can get data from the context to use as a parameter to a function. For example:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The library is designed to be simple and easy to use. Each subset of functionali
 - [IDataWriterProvider](src/Valtuutus.Core/Data/IDataWriterProvider.cs): This is the provider that can write your relational or attribute data.
 - [IDbDataWriterProvider](src/Valtuutus.Data.Db/IDbDataWriterProvider.cs): Works similarly to `IDataWriterProvider`, with the addition of accepting a connection and transaction as parameters.
 - [Read here](Storing%20Data.md) about how the relational data is stored.
+- [Read here](Using%20the%20Engines.md) for engine usage examples (Check, SubjectPermission, LookupSubject, LookupEntity).
 
 ## LookupEntity — scoped queries and pagination
 
@@ -84,6 +85,20 @@ do
 } while (token is not null);
 ```
 
+## Documentation
+
+| Guide | Description |
+|---|---|
+| [Getting Started](Getting%20Started.md) | End-to-end quickstart — install, configure, write data, check permissions |
+| [Modeling Authorization](Modeling%20Authorization.md) | Schema DSL walkthrough with the GitHub example |
+| [Schema Reference](Schema%20Reference.md) | Complete reference for every keyword, operator, and type in the DSL |
+| [Authorization Patterns](Authorization%20Patterns.md) | Ready-made patterns: RBAC, hierarchical RBAC, ABAC, multi-tenancy |
+| [Using the Engines](Using%20the%20Engines.md) | Code examples for Check, SubjectPermission, LookupSubject, LookupEntity, depth |
+| [Storing Data](Storing%20Data.md) | Writing, deleting, snap tokens, source generator |
+| [Testing](Testing.md) | Unit-testing your authorization model with the InMemory provider |
+| [Caching](Caching.md) | Reducing database load with FusionCache |
+| [Telemetry](Telemetry.md) | OpenTelemetry activity sources, emitted spans, and what to monitor |
+
 ## Usage
 Install the package from NuGet:
 
@@ -133,7 +148,41 @@ If you are using a DB provider to store your data, please look at the scripts th
 - [SqlServer](src/Valtuutus.Data.SqlServer/Database/migrations/20240224120604_initial.sql)
 
 ## Schema and table name customization
-Our database providers allows the customization of schema and table names to your needs. When adding to dependency injection, checkout the optional parameter.
+
+Both relational providers accept an optional options object to customise the database schema and table names. Pass it as the second argument to `AddPostgres` or `AddSqlServer`:
+
+```csharp
+// Postgres — defaults: schema="public", tables="transactions", "relation_tuples", "attributes"
+builder.Services.AddValtuutusCore(/* schema */)
+    .AddPostgres(
+        _ => () => new NpgsqlConnection(connectionString),
+        new ValtuutusPostgresOptions(
+            schema:                 "authz",
+            transactionsTableName:  "transactions",
+            relationsTableName:     "relation_tuples",
+            attributesTableName:    "attributes"));
+
+// SQL Server — defaults: schema="dbo", same table names
+builder.Services.AddValtuutusCore(/* schema */)
+    .AddSqlServer(
+        _ => () => new SqlConnection(connectionString),
+        new ValtuutusSqlServerOptions(
+            schema:                 "authz",
+            transactionsTableName:  "transactions",
+            relationsTableName:     "relation_tuples",
+            attributesTableName:    "attributes"));
+```
+
+Make sure the migration script targets the same schema and table names you configure here.
+
+`ValtuutusPostgresOptions` also exposes two Npgsql-specific properties for automatic prepared statements:
+
+| Property | Default | Meaning |
+|---|---|---|
+| `MaxAutoPrepare` | `64` | Maximum number of statements Npgsql will auto-prepare |
+| `AutoPrepareMinUsages` | `2` | Minimum executions before a statement is prepared |
+
+These map directly to [Npgsql's prepared statement feature](https://www.npgsql.org/doc/prepare.html) and can improve performance for repeated queries under load.
 
 ## Using query concurrent limiting
 It is expected that you don't want to allow Valtuutus to expand queries while it has resources. The default limit is 5 concurrent queries for the same request. To change that, you can use the `AddConcurrentQueryLimit` method, for example:

--- a/Schema Reference.md
+++ b/Schema Reference.md
@@ -1,0 +1,213 @@
+# Schema Language Reference
+
+Valtuutus uses a custom DSL to define your authorization model. This page is the complete reference for every keyword, construct, and operator the language supports.
+
+---
+
+## Top-level declarations
+
+A schema is a sequence of `entity` and `fn` declarations. Order does not matter.
+
+```
+entity user {}
+entity document { ... }
+
+fn isActive(status string) => status == "active";
+```
+
+---
+
+## `entity`
+
+Declares a resource type that participates in the authorization model. An entity body may contain any combination of `relation`, `attribute`, and `permission` declarations.
+
+```
+entity <name> {
+    <relation | attribute | permission> *
+}
+```
+
+Entity names must be unique within the schema. An entity with no body (e.g. `entity user {}`) is valid and typically used to represent subjects.
+
+---
+
+## `relation`
+
+Declares a named edge between this entity and one or more other entity types.
+
+```
+relation <name> @<type> [@<type> ...] [#<relation>];
+```
+
+**Single type:**
+```
+relation owner @user;
+```
+
+**Multiple allowed types:**
+```
+relation member @user @service_account;
+```
+
+**Type with relation specifier (`@type#relation`):**
+
+Allows assigning a *user set* (all subjects that have a given relation to another entity) as the value of this relation. For example, "maintainer can be a user directly, or any member of a team":
+
+```
+relation maintainer @user @team#member;
+```
+
+When a tuple is written with a subject of `team#member`, the engine resolves that to all current members of the team at check time.
+
+---
+
+## `attribute`
+
+Declares a named property of this entity. Attribute values are stored alongside the entity and used in permission expressions.
+
+```
+attribute <name> <type>;
+```
+
+Supported types:
+
+| Type      | Example value | Notes |
+|-----------|--------------|-------|
+| `bool`    | `true`       | Can be used directly in a permission expression |
+| `string`  | `"active"`   | Requires a `fn` for comparison |
+| `int`     | `42`         | Requires a `fn` for comparison |
+| `decimal` | `3.14`       | Requires a `fn` for comparison |
+
+> If an attribute tuple has not been written for an entity, any attribute check in a permission expression evaluates to `false`.
+
+---
+
+## `permission`
+
+Declares a named boolean rule that the engines evaluate.
+
+```
+permission <name> := <expression>;
+```
+
+A permission expression can be:
+
+| Form | Meaning |
+|------|---------|
+| `relation_name` | Subject has this relation to the entity |
+| `attribute_name` | Attribute is `true` (bool only) |
+| `fn_name(arg, ...)` | Custom function call evaluates to `true` |
+| `parent_relation.permission_or_relation` | Traverse a relation to another entity and check a permission/relation there |
+| `a and b` | Both sides must be true (intersection) |
+| `a or b` | At least one side must be true (union) |
+| `not(expr)` | Negates the inner expression |
+
+Expressions compose freely:
+
+```
+permission view := owner or (parent.admin and not(archived));
+```
+
+**Traversal with dot notation**
+
+Use `<relation>.<permission>` to walk through a relation to another entity type and evaluate a permission there:
+
+```
+entity team {
+    relation parent @organization;
+    permission manage := parent.admin;   // "parent" is a relation; "admin" is a permission on organization
+}
+```
+
+Multiple hops are allowed:
+
+```
+permission view := parent.parent.admin;
+```
+
+---
+
+## `fn`
+
+Declares a pure function that can be called from a `permission` expression. Functions may not reference relations — they operate only on attribute values and context.
+
+```
+fn <name>(<param> <type> [, ...]) => <fn_expression>;
+```
+
+```
+fn isActive(status string)       => status == "active";
+fn inBudget(amount decimal)      => amount <= 1000.00;
+fn isAdult(age int)              => age >= 18;
+fn notArchived(archived bool)    => not(archived);
+```
+
+**Supported operators in `fn` expressions:**
+
+| Operator | Meaning | Works with |
+|----------|---------|-----------|
+| `==`     | Equals | all types |
+| `!=`     | Not equal | all types |
+| `>`      | Greater than | `int`, `decimal`, `string` |
+| `>=`     | Greater or equal | `int`, `decimal`, `string` |
+| `<`      | Less than | `int`, `decimal`, `string` |
+| `<=`     | Less or equal | `int`, `decimal`, `string` |
+| `and`    | Logical AND | both sides must be boolean |
+| `or`     | Logical OR | both sides must be boolean |
+| `not()`  | Logical NOT | inner must be boolean |
+
+Functions can accept any number of parameters. Optional parameters are not supported.
+
+---
+
+## `context` accessor
+
+Inside a `permission` expression or `fn` call, you can read runtime values from the request context using `context.<key>`:
+
+```
+permission push := owner or maintainer and notArchived(context.archived);
+```
+
+Supply context values on the request object:
+
+```csharp
+new CheckRequest(..., context: new Dictionary<string, object> { ["archived"] = false })
+```
+
+The runtime type of the value must match the declared `fn` parameter type (`bool`, `int`, `string`, `decimal`). A missing or null context key causes the check to evaluate as `false`.
+
+---
+
+## Complete example
+
+```
+entity user {}
+
+entity organization {
+    relation admin  @user;
+    relation member @user;
+}
+
+entity team {
+    relation parent @organization;
+    relation owner  @user;
+    relation member @user;
+
+    permission manage := owner or parent.admin;
+    permission view   := member or owner or parent.member or parent.admin;
+}
+
+entity document {
+    relation parent     @organization;
+    relation owner      @user;
+    relation maintainer @user @team#member;
+    attribute public    bool;
+    attribute status    string;
+
+    permission view   := owner or public or maintainer or parent.member or parent.admin;
+    permission edit   := owner or maintainer or parent.admin and isActive(status);
+    permission delete := owner or parent.admin;
+}
+
+fn isActive(status string) => status == "active";
+```

--- a/Storing Data.md
+++ b/Storing Data.md
@@ -159,12 +159,11 @@ On the consuming project, add the source generator from nuget:
 dotnet add package Valtuutus.Lang.SourceGen
 ```
 
-Then add your schema file with the `.vtt` extension to your `.csproj` as both an `EmbeddedResource` and an `AdditionalFiles` entry — both are required for the generator to run:
+Then add your schema file with the `.vtt` extension to your `.csproj` as an `EmbeddedResource`:
 
 ```xml
 <ItemGroup>
   <EmbeddedResource Include="schema.vtt" />
-  <AdditionalFiles Include="schema.vtt" />
 </ItemGroup>
 ```
 

--- a/Storing Data.md
+++ b/Storing Data.md
@@ -159,11 +159,12 @@ On the consuming project, add the source generator from nuget:
 dotnet add package Valtuutus.Lang.SourceGen
 ```
 
-Then add your schema as an **embedded resource** with the `.vtt` extension. In your `.csproj`:
+Then add your schema file with the `.vtt` extension to your `.csproj` as both an `EmbeddedResource` and an `AdditionalFiles` entry — both are required for the generator to run:
 
 ```xml
 <ItemGroup>
   <EmbeddedResource Include="schema.vtt" />
+  <AdditionalFiles Include="schema.vtt" />
 </ItemGroup>
 ```
 

--- a/Storing Data.md
+++ b/Storing Data.md
@@ -66,6 +66,90 @@ await writer.Write(connection, [new RelationTuple("document", "2", "owner", "use
 await writer.Write(connection, transaction, [new RelationTuple("document", "2", "owner", "user", "1")], [], default);
 ```
 
+## Deleting Authorization Data
+
+Relations and attributes can be deleted by calling `Delete` on `IDataWriterProvider` (or `IDbDataWriterProvider`). Like `Write`, `Delete` returns a `SnapToken` reflecting the state after the deletion.
+
+```csharp
+// Remove a specific relation tuple
+await writer.Delete(
+    new DeleteFilter
+    {
+        Relations =
+        [
+            new DeleteRelationsFilter
+            {
+                EntityType  = "document",
+                EntityId    = "2",
+                Relation    = "owner",
+                SubjectType = "user",
+                SubjectId   = "1"
+            }
+        ]
+    },
+    cancellationToken);
+```
+
+All fields on `DeleteRelationsFilter` are optional — only the filters you set are applied, making it easy to delete in bulk. For example, to remove all relations of a deleted document:
+
+```csharp
+await writer.Delete(
+    new DeleteFilter
+    {
+        Relations = [new DeleteRelationsFilter { EntityType = "document", EntityId = "2" }]
+    },
+    cancellationToken);
+```
+
+Attributes can be deleted the same way using `DeleteAttributesFilter`:
+
+```csharp
+await writer.Delete(
+    new DeleteFilter
+    {
+        Attributes =
+        [
+            new DeleteAttributesFilter
+            {
+                EntityType = "document",
+                EntityId   = "2",
+                Attribute  = "public"   // omit to delete all attributes for this entity
+            }
+        ]
+    },
+    cancellationToken);
+```
+
+You can mix relation and attribute deletions in a single `Delete` call by populating both `Relations` and `Attributes`.
+
+If using `IDbDataWriterProvider`, pass a connection (and optionally a transaction) as the first parameters — the signature is identical to `Write`.
+
+### How deletes work — soft deletes and data retention
+
+`Delete` does **not** physically remove rows. It performs an `UPDATE` that sets the `deleted_tx_id` column on matching rows. The engines filter out soft-deleted rows on every read.
+
+This means:
+- Tables grow over time as data accumulates. Deleting a relation tuple does not reclaim disk space.
+- Old soft-deleted rows must be periodically purged manually.
+
+To reclaim space in Postgres, run a query like:
+
+```sql
+DELETE FROM relation_tuples WHERE deleted_tx_id IS NOT NULL;
+DELETE FROM attributes       WHERE deleted_tx_id IS NOT NULL;
+```
+
+For SQL Server, the equivalent:
+
+```sql
+DELETE FROM relation_tuples WHERE deleted_tx_id IS NOT NULL;
+DELETE FROM attributes       WHERE deleted_tx_id IS NOT NULL;
+```
+
+After a bulk purge in Postgres, run `VACUUM ANALYZE` on both tables to update statistics and reclaim pages.
+
+How often to purge depends on your write volume. For high-throughput applications (frequent permission changes), consider scheduling a periodic purge job. For low-write applications, manual purges as needed are fine.
+
 ### Schema constants
 We understand that passing around arbitrary strings can lead to errors. We developed our source generator, that reads the schema and generates
 constants for Entity names, relations, permissions and attributes.
@@ -75,15 +159,105 @@ On the consuming project, add the source generator from nuget:
 dotnet add package Valtuutus.Lang.SourceGen
 ```
 
-Then you should add your schema as an embedded file ending with .vtt;
-The source generator will pick it up and generate the consts in the Valtuutus.Lang namespace.
+Then add your schema as an **embedded resource** with the `.vtt` extension. In your `.csproj`:
 
-### Snap Tokens
-In Valtuutus, each modification to the authorization data returns a snap token.
-```json
-{
-  "snapToken": "01J59G4294E1AR1AMCJTD0SPXW"
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="schema.vtt" />
+</ItemGroup>
+```
+
+The source generator picks it up at build time and generates a `SchemaConstsGen` class in the `Valtuutus.Lang` namespace. For example, given this schema:
+
+```
+entity user {}
+entity document {
+    relation owner @user;
+    attribute public bool;
+    permission view := owner or public;
+    permission edit := owner;
 }
 ```
-This token consists of an [ULID](https://github.com/ulid/spec) that can be used to get fresh or older results in access control queries.
+
+The generator produces:
+
+```csharp
+namespace Valtuutus.Lang;
+
+public static class SchemaConstsGen
+{
+    public static class User
+    {
+        public const string Name = "user";
+    }
+
+    public static class Document
+    {
+        public const string Name = "document";
+
+        public static class Attributes
+        {
+            public const string Public = "public";
+        }
+
+        public static class Relations
+        {
+            public const string Owner = "owner";
+        }
+
+        public static class Permissions
+        {
+            public const string View = "view";
+            public const string Edit = "edit";
+        }
+    }
+}
+```
+
+Use these constants instead of raw strings throughout your application:
+
+```csharp
+await writer.Write(
+    [new RelationTuple(
+        SchemaConstsGen.Document.Name,
+        "2",
+        SchemaConstsGen.Document.Relations.Owner,
+        SchemaConstsGen.User.Name,
+        "1")],
+    [],
+    cancellationToken);
+
+bool canView = await checkEngine.Check(
+    new CheckRequest(
+        SchemaConstsGen.Document.Name,
+        "2",
+        SchemaConstsGen.Document.Permissions.View,
+        SchemaConstsGen.User.Name,
+        "1"),
+    cancellationToken);
+```
+
+### Snap Tokens
+
+Every `Write` and `Delete` call returns a `SnapToken`:
+
+```csharp
+SnapToken token = await writer.Write(
+    [new RelationTuple("document", "2", "owner", "user", "1")],
+    [],
+    cancellationToken);
+// token.Value => "01J59G4294E1AR1AMCJTD0SPXW"
+```
+
+The token is a [ULID](https://github.com/ulid/spec) that encodes the point-in-time of the write. Pass it back on subsequent engine requests to guarantee **read-after-write consistency** — the engine will only read data at least as recent as that write:
+
+```csharp
+bool canView = await checkEngine.Check(
+    new CheckRequest("document", "2", "view", "user", "1", snapToken: token),
+    cancellationToken);
+```
+
+If you don't need strict consistency (e.g. read-heavy paths where eventual consistency is acceptable), omit the token entirely — the engine will use the latest available snapshot.
+
+A common pattern is to store the token alongside the resource in your application database after a write, then read it back and pass it on the next authorization check for that resource.
 

--- a/Telemetry.md
+++ b/Telemetry.md
@@ -1,0 +1,57 @@
+# Telemetry
+
+Valtuutus uses [OpenTelemetry](https://opentelemetry.io/) `ActivitySource` to emit distributed traces. Two sources are available, with different granularity:
+
+| Source name | Purpose |
+|---|---|
+| `"Valtuutus"` | Top-level spans for each public engine call — recommended for production |
+| `"Valtuutus.Internal"` | Granular internal spans for every internal step — useful for debugging |
+
+## Setup
+
+Subscribe to the sources you want when configuring OpenTelemetry:
+
+```csharp
+builder.Services
+    .AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("Valtuutus")           // top-level engine calls
+        // .AddSource("Valtuutus.Internal") // uncomment for detailed internal spans
+        .AddJaegerExporter()              // or any other exporter
+    );
+```
+
+For day-to-day production monitoring, subscribe only to `"Valtuutus"`. The internal source emits a span for every node traversed in the schema graph, which can be extremely noisy on complex schemas.
+
+## Emitted spans
+
+### `Check`
+- **Source:** `Valtuutus`
+- **Tags:** `CheckRequest` — the full request object
+- **Events:** `CheckFinished` with tag `CheckResult` (bool) — the final allow/deny decision
+
+### `SubjectPermission`
+- **Source:** `Valtuutus`
+- **Tags:** `SubjectPermissionRequest` — the full request object
+- **Events:** `SubjectPermissionFinished` — one tag per permission name, value is the bool result (e.g. `view = true`, `edit = false`)
+
+### `LookupSubject`
+- **Source:** `Valtuutus`
+- **Tags:** request attributes
+- **Events:** `LookupSubjectResult` — the set of matching subject IDs
+
+### `LookupEntity`
+- **Source:** `Valtuutus`
+- **Tags:** request attributes
+- **Events:** `LookupEntityResult` — the count of matching entity IDs
+
+### Internal spans (`Valtuutus.Internal`)
+The internal source emits a child span for every step the engine takes while traversing the schema graph: `CheckPermission`, `CheckAttribute`, `CheckExpression`, `NegateCheck`, `LookupNegate`, `LookupRelationLeaf`, `LookupRelationCore`, and others. These are useful when diagnosing unexpected `false` results or performance issues on specific paths.
+
+## What to monitor in production
+
+The top-level `Check`, `LookupSubject`, and `LookupEntity` spans give you:
+
+- **Latency** per engine call, broken down by entity type and permission
+- **The final result** via the `CheckFinished` / `LookupSubjectResult` / `LookupEntityResult` events
+- **Fan-out visibility** — because internal spans are children of the top-level span, enabling `Valtuutus.Internal` shows exactly how many DB calls a single engine call triggered and where time was spent

--- a/Testing.md
+++ b/Testing.md
@@ -1,0 +1,238 @@
+# Testing Your Authorization Model
+
+Valtuutus provides an InMemory provider that is ideal for unit and integration testing. It requires no Docker, no database, and resets between tests automatically by simply creating a new `ServiceProvider`.
+
+## Setup
+
+Install the InMemory package in your test project:
+
+```shell
+dotnet add package Valtuutus.Data.InMemory
+```
+
+## Basic test structure
+
+Each test creates a fresh `ServiceProvider`, writes the tuples and attributes it needs, and then calls the engine:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Xunit;
+
+public class DocumentPermissionTests
+{
+    private static ServiceProvider BuildServices() =>
+        new ServiceCollection()
+            .AddValtuutusCore("""
+                entity user {}
+                entity document {
+                    relation owner  @user;
+                    relation viewer @user;
+                    permission view := owner or viewer;
+                    permission edit := owner;
+                }
+            """)
+            .AddInMemory()
+            .Services
+            .BuildServiceProvider();
+
+    [Fact]
+    public async Task Owner_CanEditDocument()
+    {
+        await using var sp = BuildServices();
+        var writer = sp.GetRequiredService<IDataWriterProvider>();
+        var engine = sp.GetRequiredService<ICheckEngine>();
+
+        await writer.Write(
+            [new RelationTuple("document", "doc-1", "owner", "user", "alice")],
+            [],
+            CancellationToken.None);
+
+        var result = await engine.Check(
+            new CheckRequest("document", "doc-1", "edit", "user", "alice"),
+            CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Viewer_CannotEditDocument()
+    {
+        await using var sp = BuildServices();
+        var writer = sp.GetRequiredService<IDataWriterProvider>();
+        var engine = sp.GetRequiredService<ICheckEngine>();
+
+        await writer.Write(
+            [new RelationTuple("document", "doc-1", "viewer", "user", "bob")],
+            [],
+            CancellationToken.None);
+
+        var result = await engine.Check(
+            new CheckRequest("document", "doc-1", "edit", "user", "bob"),
+            CancellationToken.None);
+
+        Assert.False(result);
+    }
+}
+```
+
+Because a new `ServiceProvider` is created per test (or per test class), state never leaks between tests.
+
+## Testing attributes
+
+```csharp
+[Fact]
+public async Task PublicDocument_IsViewableByAnyone()
+{
+    await using var sp = new ServiceCollection()
+        .AddValtuutusCore("""
+            entity user {}
+            entity document {
+                attribute public bool;
+                relation owner @user;
+                permission view := owner or public;
+            }
+        """)
+        .AddInMemory()
+        .Services
+        .BuildServiceProvider();
+
+    var writer = sp.GetRequiredService<IDataWriterProvider>();
+    var engine = sp.GetRequiredService<ICheckEngine>();
+
+    // Write the attribute — no owner tuple
+    await writer.Write(
+        [],
+        [new AttributeTuple("document", "doc-1", "public", JsonValue.Create(true))],
+        CancellationToken.None);
+
+    var result = await engine.Check(
+        new CheckRequest("document", "doc-1", "view", "user", "anyone"),
+        CancellationToken.None);
+
+    Assert.True(result);
+}
+```
+
+## Testing with context
+
+```csharp
+[Fact]
+public async Task Push_IsBlocked_WhenContextSaysArchived()
+{
+    await using var sp = new ServiceCollection()
+        .AddValtuutusCore("""
+            entity user {}
+            entity repository {
+                relation owner @user;
+                permission push := owner and notArchived(context.archived);
+            }
+            fn notArchived(archived bool) => not(archived);
+        """)
+        .AddInMemory()
+        .Services
+        .BuildServiceProvider();
+
+    var writer = sp.GetRequiredService<IDataWriterProvider>();
+    var engine = sp.GetRequiredService<ICheckEngine>();
+
+    await writer.Write(
+        [new RelationTuple("repository", "repo-1", "owner", "user", "alice")],
+        [],
+        CancellationToken.None);
+
+    var result = await engine.Check(
+        new CheckRequest(
+            "repository", "repo-1", "push", "user", "alice",
+            context: new Dictionary<string, object> { ["archived"] = true }),
+        CancellationToken.None);
+
+    Assert.False(result);
+}
+```
+
+## Testing LookupSubject
+
+```csharp
+[Fact]
+public async Task LookupSubject_ReturnsAllViewers()
+{
+    await using var sp = new ServiceCollection()
+        .AddValtuutusCore("""
+            entity user {}
+            entity document {
+                relation viewer @user;
+                permission view := viewer;
+            }
+        """)
+        .AddInMemory()
+        .Services
+        .BuildServiceProvider();
+
+    var writer = sp.GetRequiredService<IDataWriterProvider>();
+    var lookupEngine = sp.GetRequiredService<ILookupSubjectEngine>();
+
+    await writer.Write([
+        new RelationTuple("document", "doc-1", "viewer", "user", "alice"),
+        new RelationTuple("document", "doc-1", "viewer", "user", "bob"),
+    ], [], CancellationToken.None);
+
+    var result = await lookupEngine.Lookup(
+        new LookupSubjectRequest("document", "view", "user", "doc-1"),
+        CancellationToken.None);
+
+    Assert.Equal(new HashSet<string> { "alice", "bob" }, result);
+}
+```
+
+## Sharing a schema across a test class
+
+If many tests share the same schema but need fresh data, use a factory method per test while building the provider only once for the schema string:
+
+```csharp
+public class CheckEngineTests
+{
+    private const string Schema = """
+        entity user {}
+        entity document {
+            relation owner @user;
+            permission view := owner;
+        }
+    """;
+
+    private async Task<(ICheckEngine engine, IDataWriterProvider writer, AsyncServiceScope scope)>
+        CreateAsync()
+    {
+        var sp = new ServiceCollection()
+            .AddValtuutusCore(Schema)
+            .AddInMemory()
+            .Services
+            .BuildServiceProvider();
+
+        var scope = sp.CreateAsyncScope();
+        var writer = scope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+        return (engine, writer, scope);
+    }
+
+    [Fact]
+    public async Task Test1()
+    {
+        var (engine, writer, scope) = await CreateAsync();
+        await using (scope)
+        {
+            await writer.Write([new RelationTuple("document", "1", "owner", "user", "alice")], [], default);
+            Assert.True(await engine.Check(new CheckRequest("document", "1", "view", "user", "alice"), default));
+        }
+    }
+}
+```
+
+## Tips
+
+- The InMemory provider is completely in-process — no network, no disk, no cleanup needed.
+- Each `ServiceProvider` instance is a fully independent data store. Creating a new one is the reset mechanism.
+- Use parameterized tests (`[Theory]` + `[MemberData]`) to cover many tuple/check combinations without boilerplate.
+- If you want to test snap token behavior, capture the `SnapToken` returned by `Write` and pass it to the engine request.

--- a/Using the Engines.md
+++ b/Using the Engines.md
@@ -1,0 +1,222 @@
+# Using the Engines
+
+This guide shows how to call each engine with real code examples. All examples use the following schema and assume it has been registered in DI:
+
+```csharp
+builder.Services.AddValtuutusCore("""
+    entity user {}
+    entity organization {
+        relation admin @user;
+        relation member @user;
+    }
+    entity document {
+        relation owner @user;
+        relation parent @organization;
+        relation maintainer @user @organization#member;
+        permission view := owner or parent.member or maintainer or parent.admin;
+        permission edit := owner or maintainer or parent.admin;
+        permission delete := owner or parent.admin;
+    }
+""");
+```
+
+Inject the engines through standard DI constructor injection:
+
+```csharp
+public class MyService(
+    ICheckEngine checkEngine,
+    ILookupSubjectEngine lookupSubjectEngine,
+    ILookupEntityEngine lookupEntityEngine)
+{ ... }
+```
+
+---
+
+## Snap Tokens and Read Consistency
+
+Every write operation returns a `SnapToken`:
+
+```csharp
+SnapToken token = await writer.Write(
+    [new RelationTuple("document", "2", "owner", "user", "1")],
+    [],
+    cancellationToken);
+```
+
+Pass this token back in engine requests to guarantee **read-after-write consistency** — the engine will only read data at least as recent as the write that produced the token:
+
+```csharp
+bool canView = await checkEngine.Check(
+    new CheckRequest("document", "2", "view", "user", "1", snapToken: token),
+    cancellationToken);
+```
+
+When you don't need this guarantee (e.g. read-heavy queries where eventual consistency is acceptable), omit the token or pass `null`:
+
+```csharp
+bool canView = await checkEngine.Check(
+    new CheckRequest("document", "2", "view", "user", "1"),
+    cancellationToken);
+```
+
+---
+
+## ICheckEngine
+
+### Check — can entity U perform action Y on resource Z?
+
+```csharp
+bool canEdit = await checkEngine.Check(
+    new CheckRequest(
+        entityType: "document",
+        entityId:   "2",
+        permission: "edit",
+        subjectType: "user",
+        subjectId:   "1"),
+    cancellationToken);
+```
+
+### Check with context
+
+When a permission expression references a function that reads `context.*` values, supply them via the `Context` dictionary:
+
+```csharp
+// Schema: permission push := owner or maintainer and notArchived(context.archived);
+bool canPush = await checkEngine.Check(
+    new CheckRequest(
+        entityType:  "repository",
+        entityId:    "42",
+        permission:  "push",
+        subjectType: "user",
+        subjectId:   "1",
+        context: new Dictionary<string, object> { ["archived"] = false }),
+    cancellationToken);
+```
+
+Pass the correct runtime type for each context value (`bool`, `int`, `string`, `decimal`) to avoid runtime errors.
+
+### SubjectPermission — what permissions does user U have on resource Z?
+
+Returns a dictionary of every permission defined on the entity and whether the subject has it:
+
+```csharp
+Dictionary<string, bool> permissions = await checkEngine.SubjectPermission(
+    new SubjectPermissionRequest
+    {
+        EntityType  = "document",
+        EntityId    = "2",
+        SubjectType = "user",
+        SubjectId   = "1"
+    },
+    cancellationToken);
+
+// permissions["view"]   => true
+// permissions["edit"]   => true
+// permissions["delete"] => false
+```
+
+---
+
+## ILookupSubjectEngine
+
+### Lookup — which subjects of type T have permission Y on entity X?
+
+```csharp
+HashSet<string> userIds = await lookupSubjectEngine.Lookup(
+    new LookupSubjectRequest(
+        entityType:  "document",
+        permission:  "view",
+        subjectType: "user",
+        entityId:    "2"),
+    cancellationToken);
+
+// userIds => { "1", "7", "42" }
+```
+
+> **Note:** For permissions that include `not()`, only subjects that already have at least one relation tuple in the data store are considered. See the [negation section](Modeling%20Authorization.md#negation) for details.
+
+---
+
+## ILookupEntityEngine
+
+### LookupEntity — which resources of type T can subject U perform action Y on?
+
+```csharp
+LookupEntityPage page = await lookupEntityEngine.LookupEntity(
+    new LookupEntityRequest(
+        entityType:  "document",
+        permission:  "view",
+        subjectType: "user",
+        subjectId:   "1"),
+    cancellationToken);
+
+// page.EntityIds         => ["2", "5", "9"]
+// page.ContinuationToken => null  (no more pages)
+```
+
+### Scoped query — constrain to a parent entity
+
+Use `EntityScope` to answer "which documents inside organization X can this user view?" — the same query you'd back a `GET /organizations/{orgId}/documents` endpoint with:
+
+```csharp
+LookupEntityPage page = await lookupEntityEngine.LookupEntity(
+    new LookupEntityRequest("document", "view", "user", "1")
+    {
+        Scope = new EntityScope(
+            Relation:    "parent",       // the relation on "document" that points to the parent
+            SubjectType: "organization", // the parent entity type
+            SubjectId:   "org-1"         // the specific parent to scope to
+        )
+    },
+    cancellationToken);
+```
+
+### Pagination
+
+Results are ordered lexicographically by entity ID. Use `PageSize` and `ContinuationToken` to page through large result sets. Reuse the same `SnapToken` across pages to ensure consistent results:
+
+```csharp
+string? continuationToken = null;
+do
+{
+    var page = await lookupEntityEngine.LookupEntity(
+        new LookupEntityRequest("document", "view", "user", "1")
+        {
+            Scope             = new EntityScope("parent", "organization", "org-1"),
+            PageSize          = 50,
+            ContinuationToken = continuationToken,
+            SnapToken         = snapToken
+        },
+        cancellationToken);
+
+    Process(page.EntityIds);
+    continuationToken = page.ContinuationToken;
+} while (continuationToken is not null);
+```
+
+---
+
+## Depth limit
+
+All engine requests carry a `Depth` property (default: `10`). Each time the engine recurses into a nested relation or permission, it decrements the depth counter. When it reaches zero, the engine **treats that branch as `false`** and stops recursing — it does not throw an exception.
+
+The depth counts traversal steps through the schema graph, not the number of tuples. A chain like `project → team → organization → user` consumes 3 depth units.
+
+**When to increase it:**
+
+Increase `Depth` if your schema has deeply nested hierarchies and you observe permissions returning `false` unexpectedly. As a rule of thumb, set it to at least the maximum number of relation hops in your longest permission chain, with some headroom:
+
+```csharp
+bool canView = await checkEngine.Check(
+    new CheckRequest("project", "proj-1", "view", "user", "alice")
+    {
+        Depth = 20   // increase from default 10 for deep hierarchies
+    },
+    cancellationToken);
+```
+
+**Setting a global default via `AddConcurrentQueryLimit`:**
+
+The depth default is per-request. If you consistently need a higher value, set it on every request in a thin wrapper or middleware rather than relying on the default.
+
+> **Note:** A very high depth limit on a complex schema with many tuples can cause fan-out into large numbers of concurrent queries. Use `AddConcurrentQueryLimit` to cap DB concurrency per request, and keep `Depth` as low as your schema requires.

--- a/src/Valtuutus.Lang.SourceGen/Valtuutus.Lang.SourceGen.csproj
+++ b/src/Valtuutus.Lang.SourceGen/Valtuutus.Lang.SourceGen.csproj
@@ -52,9 +52,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="Valtuutus.Lang.SourceGen.props" Pack="true">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </EmbeddedResource>
+        <None Include="Valtuutus.Lang.SourceGen.props" Pack="true" PackagePath="build/" />
     </ItemGroup>
 
 </Project>

--- a/src/Valtuutus.Lang.SourceGen/Valtuutus.Lang.SourceGen.props
+++ b/src/Valtuutus.Lang.SourceGen/Valtuutus.Lang.SourceGen.props
@@ -1,6 +1,6 @@
 <Project>
     <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
-    <ItemGroup>
+    <PropertyGroup>
         <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
-    </ItemGroup>
+    </PropertyGroup>
 </Project>

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -922,6 +922,122 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
         result.Should().BeFalse();
     }
 
+    /// <summary>
+    /// Verifies two-hop permission composition: project.edit := contributor or parent.manage,
+    /// where team.manage := owner or parent.admin and parent is an organization.
+    /// A user who is org admin should be able to edit the project without any direct project relation.
+    /// </summary>
+    [Fact]
+    public async Task Check_TwoHopNestedPermission_OrgAdminCanEditProject()
+    {
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+                relation member @user;
+            }
+            entity team {
+                relation parent @organization;
+                relation owner @user;
+                relation member @user;
+                permission manage := owner or parent.admin;
+                permission view   := member or owner or parent.admin or parent.member;
+            }
+            entity project {
+                relation parent @team;
+                relation contributor @user;
+                permission edit := contributor or parent.manage;
+                permission view := contributor or parent.view;
+            }
+            """;
+
+        var engine = await CreateEngine([
+            new RelationTuple("organization", "org-1", "admin",  "user", "alice"),
+            new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+            new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+        ], [], schema);
+
+        // alice is org admin → team.manage is true → project.edit is true
+        (await engine.Check(new CheckRequest("project", "proj-1", "edit", "user", "alice"), default))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Check_TwoHopNestedPermission_OrgMemberCanViewProject()
+    {
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+                relation member @user;
+            }
+            entity team {
+                relation parent @organization;
+                relation owner @user;
+                relation member @user;
+                permission manage := owner or parent.admin;
+                permission view   := member or owner or parent.admin or parent.member;
+            }
+            entity project {
+                relation parent @team;
+                relation contributor @user;
+                permission edit := contributor or parent.manage;
+                permission view := contributor or parent.view;
+            }
+            """;
+
+        var engine = await CreateEngine([
+            new RelationTuple("organization", "org-1", "member", "user", "bob"),
+            new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+            new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+        ], [], schema);
+
+        // bob is org member → team.view is true → project.view is true
+        (await engine.Check(new CheckRequest("project", "proj-1", "view", "user", "bob"), default))
+            .Should().BeTrue();
+
+        // bob is only an org member, not admin → team.manage is false → project.edit is false
+        (await engine.Check(new CheckRequest("project", "proj-1", "edit", "user", "bob"), default))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Check_TwoHopNestedPermission_UnrelatedUserCannotAccess()
+    {
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+                relation member @user;
+            }
+            entity team {
+                relation parent @organization;
+                relation owner @user;
+                relation member @user;
+                permission manage := owner or parent.admin;
+                permission view   := member or owner or parent.admin or parent.member;
+            }
+            entity project {
+                relation parent @team;
+                relation contributor @user;
+                permission edit := contributor or parent.manage;
+                permission view := contributor or parent.view;
+            }
+            """;
+
+        var engine = await CreateEngine([
+            new RelationTuple("organization", "org-1", "admin",  "user", "alice"),
+            new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+            new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+        ], [], schema);
+
+        // charlie has no relation to anything → both false
+        (await engine.Check(new CheckRequest("project", "proj-1", "edit", "user", "charlie"), default))
+            .Should().BeFalse();
+        (await engine.Check(new CheckRequest("project", "proj-1", "view", "user", "charlie"), default))
+            .Should().BeFalse();
+    }
+
     [Fact]
     public async Task Check_Not_Compound_Expression_Returns_True_When_Subject_Matches_Nothing_Inside()
     {

--- a/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
@@ -632,6 +632,100 @@ public abstract class BaseLookupEntityEngineSpecs : IAsyncLifetime
         page2.ContinuationToken.Should().BeNull();
     }
 
+    /// <summary>
+    /// Verifies two-hop permission composition in LookupEntity:
+    /// project.edit := contributor or parent.manage, where team.manage := owner or parent.admin.
+    /// LookupEntity for "edit" should return projects reachable via the full org→team→project chain.
+    /// </summary>
+    [Fact]
+    public async Task LookupEntity_TwoHopNestedPermission_OrgAdminCanEditAllLinkedProjects()
+    {
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+                relation member @user;
+            }
+            entity team {
+                relation parent @organization;
+                relation owner @user;
+                relation member @user;
+                permission manage := owner or parent.admin;
+                permission view   := member or owner or parent.admin or parent.member;
+            }
+            entity project {
+                relation parent @team;
+                relation contributor @user;
+                permission edit := contributor or parent.manage;
+                permission view := contributor or parent.view;
+            }
+            """;
+
+        var engine = await CreateEngine([
+            new RelationTuple("organization", "org-1",  "admin",  "user", "alice"),
+            new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+            new RelationTuple("team",         "team-2", "parent", "organization", "org-1"),
+            new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+            new RelationTuple("project",      "proj-2", "parent", "team", "team-2"),
+            // proj-3 belongs to a team in a different org — alice has no access
+            new RelationTuple("organization", "org-2",  "admin",  "user", "bob"),
+            new RelationTuple("team",         "team-3", "parent", "organization", "org-2"),
+            new RelationTuple("project",      "proj-3", "parent", "team", "team-3"),
+        ], [], schema);
+
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("project", "edit", "user", "alice"),
+            CancellationToken.None);
+
+        // alice is org-1 admin → team-1.manage and team-2.manage → proj-1 and proj-2
+        // proj-3 is under org-2 where alice has no role
+        result.EntityIds.Should().BeEquivalentTo(["proj-1", "proj-2"]);
+    }
+
+    [Fact]
+    public async Task LookupEntity_TwoHopNestedPermission_OrgMemberCanViewButNotEdit()
+    {
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+                relation member @user;
+            }
+            entity team {
+                relation parent @organization;
+                relation owner @user;
+                relation member @user;
+                permission manage := owner or parent.admin;
+                permission view   := member or owner or parent.admin or parent.member;
+            }
+            entity project {
+                relation parent @team;
+                relation contributor @user;
+                permission edit := contributor or parent.manage;
+                permission view := contributor or parent.view;
+            }
+            """;
+
+        var engine = await CreateEngine([
+            new RelationTuple("organization", "org-1",  "member", "user", "carol"),
+            new RelationTuple("team",         "team-1", "parent", "organization", "org-1"),
+            new RelationTuple("project",      "proj-1", "parent", "team", "team-1"),
+            new RelationTuple("project",      "proj-2", "parent", "team", "team-1"),
+        ], [], schema);
+
+        // carol is org member → team.view true → can view both projects
+        var viewResult = await engine.LookupEntity(
+            new LookupEntityRequest("project", "view", "user", "carol"),
+            CancellationToken.None);
+        viewResult.EntityIds.Should().BeEquivalentTo(["proj-1", "proj-2"]);
+
+        // carol is only org member, not admin → team.manage false → cannot edit
+        var editResult = await engine.LookupEntity(
+            new LookupEntityRequest("project", "edit", "user", "carol"),
+            CancellationToken.None);
+        editResult.EntityIds.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task LookupEntity_Not_Relation_Returns_Entities_User_Does_Not_Own()
     {


### PR DESCRIPTION
## Summary

- Fix incorrect relation accessor (`org.admin` → `parent.admin`) and typos (`mantainer`) in existing docs
- Clarify `not()` operator data store requirement for `LookupSubject`/`LookupEntity` vs `Check`
- New **Getting Started** guide — install, migrate, register, write, check in one place
- New **Schema Reference** — complete DSL language reference for every keyword, operator, and type
- New **Authorization Patterns** — RBAC, hierarchical RBAC (using permission composition), ABAC, RBAC+ABAC, multi-tenancy (tenant-per-DB only)
- New **Using the Engines** — `Check`, `SubjectPermission`, `LookupSubject`, `LookupEntity` with snap tokens, context, depth, scoped queries, and pagination
- New **Testing** — unit testing authorization models with the InMemory provider (xUnit examples)
- New **Telemetry** — `"Valtuutus"` vs `"Valtuutus.Internal"` activity sources, emitted spans and events, what to monitor in production
- **Storing Data**: deletion section, soft-delete/data retention note (tables never shrink), snap token usage pattern, source generator output example
- **README**: documentation index table, schema/table name customization with full `ValtuutusPostgresOptions`/`ValtuutusSqlServerOptions` reference including Npgsql prepared statement options
- **Hierarchical RBAC example** simplified to use permission composition (`parent.manage`) instead of raw relation traversal
- **Tests**: two-hop nested permission composition test cases added for `Check` and `LookupEntity`
- **fix(sourcegen)**: `Valtuutus.Lang.SourceGen` NuGet package now auto-imports its `.props` file from the `build/` folder — consuming projects only need `<EmbeddedResource Include="schema.vtt" />`, no `<AdditionalFiles>` tag required
- **Release notes**: `not()` negation and sourcegen fix added to `0.8.0-beta` changelog in `Directory.Build.props`

## Test plan
- [x] All existing tests pass (verified locally — 0 failures)
- [x] Code examples in new docs compile against current public API
- [x] Two-hop nested permission tests pass for Check and LookupEntity
- [x] Source generator unit and integration tests pass after packaging fix