### PR TITLE
fix: address actionable Sonar code smells from PR #148

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -190,7 +190,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 Attribute = req.Permission,
                 EntityId = req.EntityId,
                 EntityType = req.EntityType,
-                SnapToken = req.SnapToken.Value
+                SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, ct);
 
         if (attribute is null)
@@ -297,7 +297,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 Attributes = attributeArguments,
                 EntityId = req.EntityId,
                 EntityType = req.EntityType,
-                SnapToken = req.SnapToken.Value
+                SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, null, ct);
 
         using var paramToArg = fn.CreateParamToArgMap(node.Args);
@@ -351,7 +351,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                         tupleSetRelation,
                         subEntityType, computedUserSetRelation,
                         req.SubjectType!, req.SubjectId!,
-                        req.SnapToken.Value, ct);
+                        req.SnapToken ?? SnapToken.MinValue, ct);
                 }
             }
         }
@@ -362,7 +362,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 EntityId = req.EntityId,
                 EntityType = req.EntityType,
                 Relation = tupleSetRelation,
-                SnapToken = req.SnapToken.Value
+                SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, ct);
 
         if (relations.Count == 0) return false;
@@ -392,7 +392,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             try
             {
                 return await reader.HasAnyDirectRelation(firstSubjectType, entityIds, computedUserSetRelation,
-                    req.SubjectId!, req.SnapToken.Value, ct);
+                    req.SubjectId!, req.SnapToken ?? SnapToken.MinValue, ct);
             }
             finally
             {
@@ -448,7 +448,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             EntityId = req.EntityId,
             EntityType = req.EntityType,
             Relation = req.Permission,
-            SnapToken = req.SnapToken.Value
+            SnapToken = req.SnapToken ?? SnapToken.MinValue
         };
 
         var hasDirect = await reader.HasDirectRelation(filter, req.SubjectId!, ct);

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -204,8 +204,8 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
         return node.ExpressionNode!.Operation switch
         {
-            PermissionOperation.Intersect => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, ct, isUnion: false),
-            PermissionOperation.Union => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, ct, isUnion: true),
+            PermissionOperation.Intersect => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, isUnion: false, ct),
+            PermissionOperation.Union => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, isUnion: true, ct),
             PermissionOperation.Negate => NegateCheck(req, node.ExpressionNode!.Children[0], memo, ct),
             _ => throw new InvalidOperationException()
         };
@@ -220,7 +220,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         return !result;
     }
 
-    private async Task<bool> CheckExpressionChild(CheckRequest req, List<PermissionNode> children, CheckMemo memo, CancellationToken ct, bool isUnion)
+    private async Task<bool> CheckExpressionChild(CheckRequest req, List<PermissionNode> children, CheckMemo memo, bool isUnion, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -301,7 +301,7 @@ public sealed class LookupEntityEngine(
             {
                 Attributes = attributeArguments,
                 EntityType = req.EntityType,
-                SnapToken = req.SnapToken.Value
+                SnapToken = req.SnapToken ?? SnapToken.MinValue
             },
             entityIds,
             ct);
@@ -353,7 +353,7 @@ public sealed class LookupEntityEngine(
                 {
                     Attributes = state.attributeArguments,
                     EntityType = state.req.EntityType,
-                    SnapToken = state.req.SnapToken.Value
+                    SnapToken = state.req.SnapToken ?? SnapToken.MinValue
                 }, state.req.Scope, state.ct),
             (reader, attributeArguments, req, ct));
         var attributes = await attributesTask;
@@ -417,7 +417,7 @@ public sealed class LookupEntityEngine(
                     if (!computedRel.HasSubRelationPaths && computedRel.EntityTypes.Contains(req.FinalSubjectType))
                     {
                         buffer[count++] = JoinedLookup(
-                            new EntityRelationFilter { EntityType = req.EntityType, Relation = tupleSetRelation, SnapToken = req.SnapToken.Value },
+                            new EntityRelationFilter { EntityType = req.EntityType, Relation = tupleSetRelation, SnapToken = req.SnapToken ?? SnapToken.MinValue },
                             entity.Type, computedUserSetRelation,
                             req.FinalSubjectType, req.FinalSubjectId, req.Scope, ct);
                         continue;
@@ -479,7 +479,7 @@ public sealed class LookupEntityEngine(
                 {
                     EntityType = req.EntityType,
                     Relation = scope.Relation,
-                    SnapToken = req.SnapToken.Value
+                    SnapToken = req.SnapToken ?? SnapToken.MinValue
                 },
                 [scope.SubjectId],
                 scope.SubjectType,
@@ -494,7 +494,7 @@ public sealed class LookupEntityEngine(
         var attrs = await reader.GetAttributes(
             new EntityAttributeFilter
             {
-                Attribute = attribute.Name, EntityType = req.EntityType, SnapToken = req.SnapToken.Value
+                Attribute = attribute.Name, EntityType = req.EntityType, SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, ct);
         var result = ListPool<LookupEntityResult>.Rent();
         foreach (var a in attrs)
@@ -545,7 +545,7 @@ public sealed class LookupEntityEngine(
                     if (!subRelation.HasSubRelationPaths && subRelation.EntityTypes.Contains(req.FinalSubjectType))
                     {
                         buffer[count++] = JoinedLookup(
-                            new EntityRelationFilter { EntityType = req.EntityType, Relation = relation.Name, SnapToken = req.SnapToken.Value },
+                            new EntityRelationFilter { EntityType = req.EntityType, Relation = relation.Name, SnapToken = req.SnapToken ?? SnapToken.MinValue },
                             relationEntity.Type, relationEntity.Relation!,
                             req.FinalSubjectType, req.FinalSubjectId, req.Scope, ct);
                         continue;
@@ -595,7 +595,7 @@ public sealed class LookupEntityEngine(
         using var relations = await reader.GetRelationsWithSubjectsIds(
             new EntityRelationFilter
             {
-                Relation = req.Permission, EntityType = req.EntityType, SnapToken = req.SnapToken.Value
+                Relation = req.Permission, EntityType = req.EntityType, SnapToken = req.SnapToken ?? SnapToken.MinValue
             },
             req.SubjectsIds,
             req.SubjectType,
@@ -680,7 +680,7 @@ public sealed class LookupEntityEngine(
             ListPool<LookupEntityResult>.Return(matching);
         }
 
-        var complementIds = await reader.GetEntityIdsExcluding(req.EntityType, excludeIds, req.SnapToken!.Value, ct);
+        var complementIds = await reader.GetEntityIdsExcluding(req.EntityType, excludeIds, req.SnapToken ?? SnapToken.MinValue, ct);
 
         var result = ListPool<LookupEntityResult>.Rent();
         foreach (var id in complementIds)

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -151,15 +151,15 @@ public sealed class LookupEntityEngine(
     {
         return node.Operation switch
         {
-            PermissionOperation.Intersect => LookupExpressionChildren(req, node.Children, ct, isUnion: false),
-            PermissionOperation.Union => LookupExpressionChildren(req, node.Children, ct, isUnion: true),
+            PermissionOperation.Intersect => LookupExpressionChildren(req, node.Children, isUnion: false, ct),
+            PermissionOperation.Union => LookupExpressionChildren(req, node.Children, isUnion: true, ct),
             PermissionOperation.Negate => LookupNegate(req, node.Children[0], ct),
             _ => throw new InvalidOperationException()
         };
     }
 
     private async Task<List<LookupEntityResult>> LookupExpressionChildren(LookupEntityRequestInternal req,
-        List<PermissionNode> children, CancellationToken ct, bool isUnion)
+        List<PermissionNode> children, bool isUnion, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 

--- a/src/Valtuutus.Core/Pools/CancellationTokenSourcePool.cs
+++ b/src/Valtuutus.Core/Pools/CancellationTokenSourcePool.cs
@@ -17,7 +17,7 @@ internal static class CancellationTokenSourcePool
     internal static void Return(CancellationTokenSource cts) => _pool.Return(cts);
 }
 
-file class CtsPooledObjectPolicy : PooledObjectPolicy<CancellationTokenSource>
+file sealed class CtsPooledObjectPolicy : PooledObjectPolicy<CancellationTokenSource>
 {
     public override CancellationTokenSource Create() => new();
 

--- a/src/Valtuutus.Core/Schemas/Schema.cs
+++ b/src/Valtuutus.Core/Schemas/Schema.cs
@@ -120,7 +120,7 @@ public record Schema
         }
         else if (entity.Relations.TryGetValue(name, out var rel))
         {
-            result = ComputeRelation(rel, entityType, entities, cache, inProgress);
+            result = ComputeRelation(rel, entities, cache, inProgress);
         }
         else if (entity.Permissions.TryGetValue(name, out var perm))
         {
@@ -138,7 +138,7 @@ public record Schema
         return result;
     }
 
-    private static HashSet<string>? ComputeRelation(Relation rel, string entityType,
+    private static HashSet<string>? ComputeRelation(Relation rel,
         FrozenDictionary<string, Entity> entities,
         Dictionary<(string, string), HashSet<string>?> cache,
         HashSet<(string, string)> inProgress)

--- a/src/Valtuutus.Data.InMemory/AttributesStore.cs
+++ b/src/Valtuutus.Data.InMemory/AttributesStore.cs
@@ -154,13 +154,15 @@ internal sealed class AttributesStore : IDisposable
     {
         using var _ = Write();
         foreach (var f in filters)
-        foreach (var e in _all)
         {
-            if (e.DeletedTxId is not null) continue;
-            if (!string.IsNullOrWhiteSpace(f.EntityId) && f.EntityId != e.Attribute.EntityId) continue;
-            if (!string.IsNullOrWhiteSpace(f.EntityType) && f.EntityType != e.Attribute.EntityType) continue;
-            if (!string.IsNullOrWhiteSpace(f.Attribute) && f.Attribute != e.Attribute.Attribute) continue;
-            e.DeletedTxId = transactId;
+            foreach (var e in _all)
+            {
+                if (e.DeletedTxId is not null) continue;
+                if (!string.IsNullOrWhiteSpace(f.EntityId) && f.EntityId != e.Attribute.EntityId) continue;
+                if (!string.IsNullOrWhiteSpace(f.EntityType) && f.EntityType != e.Attribute.EntityType) continue;
+                if (!string.IsNullOrWhiteSpace(f.Attribute) && f.Attribute != e.Attribute.Attribute) continue;
+                e.DeletedTxId = transactId;
+            }
         }
     }
 

--- a/src/Valtuutus.Data.InMemory/RelationsStore.cs
+++ b/src/Valtuutus.Data.InMemory/RelationsStore.cs
@@ -288,16 +288,18 @@ internal sealed class RelationsStore : IDisposable
     {
         using var _ = Write();
         foreach (var f in filters)
-        foreach (var e in _all)
         {
-            if (e.DeletedTxId is not null) continue;
-            if (!string.IsNullOrWhiteSpace(f.EntityId) && f.EntityId != e.Relation.EntityId) continue;
-            if (!string.IsNullOrWhiteSpace(f.EntityType) && f.EntityType != e.Relation.EntityType) continue;
-            if (!string.IsNullOrWhiteSpace(f.SubjectId) && f.SubjectId != e.Relation.SubjectId) continue;
-            if (!string.IsNullOrWhiteSpace(f.SubjectType) && f.SubjectType != e.Relation.SubjectType) continue;
-            if (!string.IsNullOrWhiteSpace(f.SubjectRelation) && f.SubjectRelation != e.Relation.SubjectRelation) continue;
-            if (!string.IsNullOrWhiteSpace(f.Relation) && f.Relation != e.Relation.Relation) continue;
-            e.DeletedTxId = transactId;
+            foreach (var e in _all)
+            {
+                if (e.DeletedTxId is not null) continue;
+                if (!string.IsNullOrWhiteSpace(f.EntityId) && f.EntityId != e.Relation.EntityId) continue;
+                if (!string.IsNullOrWhiteSpace(f.EntityType) && f.EntityType != e.Relation.EntityType) continue;
+                if (!string.IsNullOrWhiteSpace(f.SubjectId) && f.SubjectId != e.Relation.SubjectId) continue;
+                if (!string.IsNullOrWhiteSpace(f.SubjectType) && f.SubjectType != e.Relation.SubjectType) continue;
+                if (!string.IsNullOrWhiteSpace(f.SubjectRelation) && f.SubjectRelation != e.Relation.SubjectRelation) continue;
+                if (!string.IsNullOrWhiteSpace(f.Relation) && f.Relation != e.Relation.Relation) continue;
+                e.DeletedTxId = transactId;
+            }
         }
     }
 

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -46,9 +46,7 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
     private static string? _hasDirectRelationSql;
     private static string? _hasAnyDirectRelationSql;
     private static string? _getIndirectRelationsSql;
-    private static string? _getRelationsWithSingleSubjectSql;
     private static string? _getRelationsWithSingleSubjectSnapSql;
-    private static string? _getRelationsWithMultiSubjectSql;
     private static string? _getRelationsWithMultiSubjectSnapSql;
     private static string? _getRelationsJoinedSql;
     private static string? _hasTupleToUserSetRelationSql;
@@ -156,7 +154,7 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
         _hotPathDataSource = GetOrCreateDataSource(probeConnection.ConnectionString, dbOptions);
     }
 
-    private static void InitializeQueries(IValtuutusDbOptions dbOptions)
+    private static void InitializeQueries(ValtuutusPostgresOptions dbOptions)
     {
         if (_formattedSelectAttributes == null || _formattedSelectRelations == null ||
             _formattedGetLatestSnapTokenQuery == null || _formattedSelect1Attribute == null)
@@ -184,12 +182,8 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
                         $"SELECT EXISTS(SELECT 1 FROM {relationsTable} WHERE {SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = ANY(@entity_ids) AND relation = @relation AND subject_id = @subject_id AND subject_relation = '')";
                     _getIndirectRelationsSql =
                         $"SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation FROM {relationsTable} WHERE {SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND relation = @relation AND subject_relation <> ''";
-                    _getRelationsWithSingleSubjectSql =
-                        $"SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation FROM {relationsTable} WHERE entity_type = @entity_type AND relation = @relation AND subject_type = @subject_type AND subject_id = @subject_id";
                     _getRelationsWithSingleSubjectSnapSql =
                         $"SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation FROM {relationsTable} WHERE {SnapTokenPredicate} AND entity_type = @entity_type AND relation = @relation AND subject_type = @subject_type AND subject_id = @subject_id";
-                    _getRelationsWithMultiSubjectSql =
-                        $"SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation FROM {relationsTable} WHERE entity_type = @entity_type AND relation = @relation AND subject_type = @subject_type AND subject_id = ANY(@subject_ids)";
                     _getRelationsWithMultiSubjectSnapSql =
                         $"SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation FROM {relationsTable} WHERE {SnapTokenPredicate} AND entity_type = @entity_type AND relation = @relation AND subject_type = @subject_type AND subject_id = ANY(@subject_ids)";
                     _getRelationsJoinedSql = $"""

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -561,14 +561,14 @@ internal sealed class SqlServerDataReaderProvider : RateLimiterExecuter, IDataRe
                             if (scopeRelations.Contains(tuple.EntityId))
                                 filtered.Add(tuple);
                         }
-                        multi.Dispose();
-                        return filtered;
                     }
                     catch
                     {
                         filtered.Dispose();
                         throw;
                     }
+                    multi.Dispose();
+                    return filtered;
                 }
 
                 return multi;


### PR DESCRIPTION
## Summary

- **CA1068**: `CancellationToken` moved to last position in `CheckExpressionChild` (CheckEngine) and `LookupExpressionChildren` (LookupEntityEngine) — private methods only, no public API change
- **S4487**: removed dead private fields `_getRelationsWithSingleSubjectSql` and `_getRelationsWithMultiSubjectSql` from `PostgresDataReaderProvider` (assigned but never read)
- **CA1859**: `InitializeQueries` parameter narrowed from `IValtuutusDbOptions` to `ValtuutusPostgresOptions` — private method, avoids interface dispatch
- **S1172**: removed unused `entityType` parameter from `Schema.ComputeRelation` — private method
- **S3260**: `CtsPooledObjectPolicy` marked `sealed` — file-scoped class, never derived
- **S3973**: added curly braces to nested `foreach` in `AttributesStore.Delete` and `RelationsStore.Delete`
- **S3966**: moved `multi.Dispose()` outside the inner `try` in `SqlServerDataReaderProvider` to eliminate the theoretical double-disposal path
- **CS8629 (×12)**: replaced `req.SnapToken.Value` with `req.SnapToken ?? SnapToken.MinValue` in `CheckEngine` and `LookupEntityEngine` — mirrors the fallback already used by `LoadLatestSnapToken`; `LookupSubjectEngine` CS8629s left as-is (engine deferred)

Skipped as false positives: S2681 (intentional `ContinueWith` lambdas), S3267 (LINQ preference), S3265 (NpgsqlDbType bitwise is Npgsql's intentional API), S3776 (cognitive complexity), S107 (too many params on interface — breaking change)

## Test plan
- [x] No public or internal API surface changed (verified via diff)
- [x] InMemory tests pass (176 × 3 TFMs)
- [x] Lang tests pass (58 × 3 TFMs)
- [x] SourceGen unit and integration tests pass
- [x] Postgres / SqlServer integration tests (require Docker — run in CI)