### PR TITLE
FIX: Microsoft.Extensions.* packages now use open-ended version range…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Authors>Valtuutus</Authors>
-    <VersionPrefix>0.8.0-beta</VersionPrefix>
+    <VersionPrefix>0.8.1-beta</VersionPrefix>
     <PackageProjectUrl>https://github.com/valtuutus/valtuutus</PackageProjectUrl>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -17,7 +17,10 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Version 0.8.0-beta:
+    <PackageReleaseNotes>Version 0.8.1-beta:
+      FIX: Microsoft.Extensions.* packages now use open-ended version ranges [8.0.0,) instead of exact pins, resolving runtime version conflicts on .NET 10+
+
+Version 0.8.0-beta:
       BREAKING: Dropped netstandard2.0 — targets are net8.0, net9.0, net10.0
       BREAKING: LookupEntity now returns LookupEntityPage instead of HashSet&lt;string&gt;
       BREAKING: IDataReaderProvider methods gain a required EntityScope? scope parameter

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="FastMember" Version="1.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="Ulid" Version="1.3.4" />
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="[6.0.1,)" />
     <PackageVersion Include="Dapper" Version="[2.1.66,)" />
     <PackageVersion Include="Dapper.SqlBuilder" Version="[2.1.66,)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[9.0.3,)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.3,)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.0,)" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="FastMember" Version="1.5.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.4.5" />


### PR DESCRIPTION
…s [8.0.0,) instead of exact pins (#159)

* fix: use open-ended version ranges for Microsoft.Extensions.* packages

Pins like 9.0.3 caused runtime version conflicts on .NET 10 because the shared framework ships its own ObjectPool/DI version. Switching to [8.0.0,) lets NuGet resolve the framework-provided version on each TFM (net8/9/10+).

Bumps version to 0.8.1-beta.

* docs: add 0.8.1-beta release notes