### PR TITLE
fix: expose ObjectPool as transitive dependency, bump to 0.8.2-beta

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Authors>Valtuutus</Authors>
-    <VersionPrefix>0.8.1-beta</VersionPrefix>
+    <VersionPrefix>0.8.2-beta</VersionPrefix>
     <PackageProjectUrl>https://github.com/valtuutus/valtuutus</PackageProjectUrl>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -17,7 +17,10 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Version 0.8.1-beta:
+    <PackageReleaseNotes>Version 0.8.2-beta:
+      FIX: Microsoft.Extensions.ObjectPool is now a proper transitive dependency — resolves TypeLoadException in Blazor WASM and other strict-linking environments
+
+Version 0.8.1-beta:
       FIX: Microsoft.Extensions.* packages now use open-ended version ranges [8.0.0,) instead of exact pins, resolving runtime version conflicts on .NET 10+
 
 Version 0.8.0-beta:

--- a/src/Valtuutus.Core/Valtuutus.Core.csproj
+++ b/src/Valtuutus.Core/Valtuutus.Core.csproj
@@ -10,9 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-      <PackageReference Include="Microsoft.Extensions.ObjectPool">
-          <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" />
       <PackageReference Include="OneOf" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Removes `<PrivateAssets>all</PrivateAssets>` from the `Microsoft.Extensions.ObjectPool` reference in `Valtuutus.Core.csproj`, making it a proper transitive dependency
- Bumps version to `0.8.2-beta`
- Adds release note entry

## Problem

`Microsoft.Extensions.ObjectPool` was marked `PrivateAssets=all`, which hides it from consumers' NuGet package graphs. On regular .NET runtimes this is harmless — the shared framework provides the assembly at runtime. But in **Blazor WASM** (and other strict-linking environments like NativeAOT), the linker only bundles assemblies that appear in the dependency graph. Since `ObjectPool` was invisible to it, the assembly was never included in the browser bundle, causing a `TypeLoadException` at runtime:

```
Could not load type of field 'Valtuutus.Core.Pools.ListPool`1[T]:_pool' due to:
Could not load file or assembly 'Microsoft.Extensions.ObjectPool, Version=8.0.0.0'
```

## Fix

`PrivateAssets=all` is intended for build-time-only tools (analyzers, source generators). `ListPool<T>` uses `DefaultObjectPool<T>` and `PooledObjectPolicy<T>` **at runtime**, so `ObjectPool` is a genuine runtime dependency. Removing the private-assets restriction makes it flow through to consumers automatically, which is the correct behaviour.

## Test plan

- [x] `dotnet build` — 0 errors, 76 warnings (pre-existing, unrelated)
- [x] `dotnet test` — 178/178 passing across net8.0, net9.0, net10.0