### PR TITLE
fix: expose ObjectPool as transitive dependency, bump to 0.8.2-beta

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Authors>Valtuutus</Authors>
-    <VersionPrefix>0.8.1-beta</VersionPrefix>
+    <VersionPrefix>0.8.2-beta</VersionPrefix>
     <PackageProjectUrl>https://github.com/valtuutus/valtuutus</PackageProjectUrl>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -17,7 +17,10 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Version 0.8.1-beta:
+    <PackageReleaseNotes>Version 0.8.2-beta:
+      FIX: Microsoft.Extensions.ObjectPool is now a proper transitive dependency — resolves TypeLoadException in Blazor WASM and other strict-linking environments
+
+Version 0.8.1-beta:
       FIX: Microsoft.Extensions.* packages now use open-ended version ranges [8.0.0,) instead of exact pins, resolving runtime version conflicts on .NET 10+
 
 Version 0.8.0-beta:

--- a/src/Valtuutus.Core/Valtuutus.Core.csproj
+++ b/src/Valtuutus.Core/Valtuutus.Core.csproj
@@ -10,9 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-      <PackageReference Include="Microsoft.Extensions.ObjectPool">
-          <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" />
       <PackageReference Include="OneOf" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION

Microsoft.Extensions.ObjectPool was marked PrivateAssets=all, hiding it from consumers' package graphs. On regular .NET this is harmless because the shared framework provides the assembly at runtime, but in Blazor WASM and other strict-linking environments the linker never includes it, causing a TypeLoadException when ListPool<T> is first used.

Removing PrivateAssets=all makes ObjectPool a declared transitive dependency so it is always present in the consumer's output.