### PR TITLE
feat: explain graph improvements and TTU fixes

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -143,6 +143,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         var result = await CheckInternal(req, new CheckMemo(), root, cancellationToken);
         root.Result = result;
+        FlattenExpressionTree(root);
         activity?.AddEvent(new ActivityEvent("ExplainFinished",
             tags: new ActivityTagsCollection(CreateCheckResultAttributes(result))));
         return new CheckExplainResult { Result = result, Root = root };
@@ -644,11 +645,6 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
 
     private async Task<bool> CheckRelation(CheckRequest req, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
-        if (!string.IsNullOrEmpty(req.SubjectType)
-            && !schema.IsSubjectTypeAllowedInRelation(req.EntityType, req.Permission,
-                req.SubjectType, req.SubjectRelation))
-            return false;
-
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
         if (node is not null) node.Type = CheckNodeType.Relation;
 
@@ -767,9 +763,9 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             var opName = child.ExpressionNode!.Operation switch
             {
-                PermissionOperation.Union => "OR",
-                PermissionOperation.Intersect => "AND",
-                PermissionOperation.Negate => "NOT",
+                PermissionOperation.Union => "or",
+                PermissionOperation.Intersect => "and",
+                PermissionOperation.Negate => "not",
                 _ => "expression"
             };
             return (CheckNodeType.Expression, opName);
@@ -782,6 +778,35 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         return perm.IsIndirect
             ? (CheckNodeType.TupleToUserSet, perm.Permission)
             : (CheckNodeType.Permission, perm.Permission);
+    }
+
+    // Flatten consecutive same-named Expression nodes so e.g. "a or b or c" (parsed as a
+    // left-associative binary tree) renders as one OR node with three children instead of two nested ORs.
+    private static void FlattenExpressionTree(CheckNode node)
+    {
+        foreach (var child in node.Children)
+            FlattenExpressionTree(child);
+
+        if (node.Type != CheckNodeType.Expression) return;
+
+        bool changed = false;
+        for (var i = 0; i < node._children.Count; i++)
+        {
+            if (node._children[i].Type == CheckNodeType.Expression && node._children[i].Name == node.Name)
+            { changed = true; break; }
+        }
+        if (!changed) return;
+
+        var flat = new List<CheckNode>(node._children.Count + 2);
+        foreach (var child in node._children)
+        {
+            if (child.Type == CheckNodeType.Expression && child.Name == node.Name)
+                flat.AddRange(child._children);
+            else
+                flat.Add(child);
+        }
+        node._children.Clear();
+        node._children.AddRange(flat);
     }
 
     private static bool AllSameSubjectType(ReadOnlySpan<RelationTuple> relations, string expectedType)

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -140,7 +140,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             tags: CreateCheckSpanAttributes(req));
 
         await SnapTokenUtils.LoadLatestSnapToken(reader, req, cancellationToken);
-        var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission };
+        var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         var result = await CheckInternal(req, new CheckMemo(), root, cancellationToken);
         root.Result = result;
         activity?.AddEvent(new ActivityEvent("ExplainFinished",
@@ -263,11 +263,42 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
         return permNode.ExpressionNode!.Operation switch
         {
-            PermissionOperation.Intersect => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: false, ct),
-            PermissionOperation.Union => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: true, ct),
+            PermissionOperation.Intersect => CheckExpressionWithWrapper(req, permNode, memo, node, "and", isUnion: false, ct),
+            PermissionOperation.Union => CheckExpressionWithWrapper(req, permNode, memo, node, "or", isUnion: true, ct),
             PermissionOperation.Negate => NegateCheck(req, permNode.ExpressionNode!.Children[0], memo, node, ct),
             _ => throw new InvalidOperationException()
         };
+    }
+
+    private async Task<bool> CheckExpressionWithWrapper(CheckRequest req, PermissionNode permNode, CheckMemo memo, CheckNode? node, string opName, bool isUnion, CancellationToken ct)
+    {
+        using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        CheckNode? exprNode;
+        bool owned;
+        if (node is not null && node.Type == CheckNodeType.Expression)
+        {
+            // Reuse the pre-allocated expression node from the parent's CheckExpressionChild call.
+            // The parent will add it to its own parent after WhenAll, so we must not double-add.
+            exprNode = node;
+            owned = false;
+        }
+        else if (node is not null)
+        {
+            exprNode = new CheckNode { Type = CheckNodeType.Expression, Name = opName, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
+            owned = true;
+        }
+        else
+        {
+            exprNode = null;
+            owned = false;
+        }
+        var result = await CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, exprNode, isUnion, ct);
+        if (exprNode is not null)
+        {
+            exprNode.Result = result;
+            if (owned) node!._children.Add(exprNode);
+        }
+        return result;
     }
 
     private async Task<bool> NegateCheck(CheckRequest req, PermissionNode child, CheckMemo memo, CheckNode? node, CancellationToken ct)
@@ -278,7 +309,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         if (node is not null)
         {
             var (type, name) = GetNodeInfo(child);
-            childNode = new CheckNode { Type = type, Name = name };
+            childNode = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         }
 
         var inner = child.Type == PermissionNodeType.Expression
@@ -308,7 +339,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             if (node is not null)
             {
                 var (type, name) = GetNodeInfo(only);
-                childNode = new CheckNode { Type = type, Name = name };
+                childNode = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
             var result = await (only.Type == PermissionNodeType.Expression
                 ? CheckExpression(req, only, memo, childNode, ct)
@@ -328,7 +359,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             for (var i = 0; i < count; i++)
             {
                 var (type, name) = GetNodeInfo(children[i]);
-                childNodes[i] = new CheckNode { Type = type, Name = name };
+                childNodes[i] = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
         }
 
@@ -454,17 +485,17 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
-        CheckNode? childNode = parentNode is null ? null
-            : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+        // If parentNode already represents this relation (same name — created by GetNodeInfo in CheckExpressionChild
+        // or by the caller in CheckTupleToUserSet), pass it directly to avoid a duplicate node.
+        // Hot path (parentNode is null) is also handled here with no allocations.
+        if (parentNode is null || parentNode.Name == computedUserSetRelation)
+            return await CheckInternal(req with { Permission = computedUserSetRelation }, memo, parentNode, ct);
 
+        // Node represents a different permission (e.g. "delete" resolving to "owner") — create a child.
+        var childNode = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         var result = await CheckInternal(req with { Permission = computedUserSetRelation }, memo, childNode, ct);
-
-        if (childNode is not null)
-        {
-            childNode.Result = result;
-            parentNode!._children.Add(childNode);
-        }
-
+        childNode.Result = result;
+        parentNode._children.Add(childNode);
         return result;
     }
 
@@ -516,7 +547,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             var only = relations[0];
             CheckNode? childNode = node is null ? null
-                : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+                : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = only.SubjectType, EntityId = only.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
             var singleResult = await CheckComputedUserSet(new CheckRequest
             {
@@ -566,7 +597,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         CheckNode[]? childNodes = node is null ? null : new CheckNode[relations.Count];
         if (childNodes is not null)
             for (var i = 0; i < relations.Count; i++)
-                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = relations[i].SubjectType, EntityId = relations[i].SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
         var tasks = new Task<bool>[relations.Count];
         for (var i = 0; i < relations.Count; i++)
@@ -654,7 +685,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             ref readonly var only = ref indirectRelations.AsSpan()[0];
             CheckNode? childNode = node is null ? null
-                : new CheckNode { Type = CheckNodeType.Permission, Name = only.SubjectRelation ?? only.SubjectType };
+                : new CheckNode { Type = CheckNodeType.Permission, Name = only.SubjectRelation ?? only.SubjectType, EntityType = only.SubjectType, EntityId = only.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
             var singleResult = await CheckInternal(new CheckRequest
             {
@@ -683,7 +714,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             for (var i = 0; i < indirectRelations.Count; i++)
             {
                 ref readonly var r = ref indirectRelations.AsSpan()[i];
-                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType };
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType, EntityType = r.SubjectType, EntityId = r.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
 
         var tasks = new Task<bool>[indirectRelations.Count];

--- a/src/Valtuutus.Core/Engines/Check/CheckNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckNode.cs
@@ -16,6 +16,10 @@ public sealed class CheckNode
     public required string Name { get; init; }
     public bool Result { get; internal set; }
     public string? Detail { get; internal set; }
+    public string? EntityType { get; internal set; }
+    public string? EntityId { get; internal set; }
+    public string? SubjectType { get; internal set; }
+    public string? SubjectId { get; internal set; }
     public IReadOnlyList<CheckNode> Children => _children;
     internal readonly List<CheckNode> _children = [];
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
@@ -131,10 +131,12 @@ public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
 
         result.Result.Should().BeFalse();
         result.Root.Name.Should().Be("comment");
-        // Binary parse: exactly 2 top-level children
-        result.Root.Children.Should().HaveCount(2);
+        // Intersect wraps children under a single "and" expression node
+        result.Root.Children.Should().HaveCount(1);
+        result.Root.Children[0].Name.Should().Be("and");
+        result.Root.Children[0].Type.Should().Be(CheckNodeType.Expression);
         // member resolves false (no tuple), public resolves true or short-circuited
-        result.Root.Children.Should().Contain(n => n.Name == "member" && !n.Result);
+        result.Root.Children[0].Children.Should().Contain(n => n.Name == "member" && !n.Result);
     }
 
     [Fact]
@@ -448,6 +450,52 @@ public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
         ttuNode.Should().NotBeNull();
         ttuNode!.Result.Should().BeTrue();
         ttuNode.Children.Count.Should().BeGreaterThanOrEqualTo(2, "one child per relation tuple in the parallel path");
+    }
+
+    [Fact]
+    public async Task Explain_UnionFailed_NoDuplicatedNodes()
+    {
+        // read := viewer or editor or admin — three-way union, none granted
+        const string schema = """
+            entity user {}
+            entity resource {
+                relation viewer @user;
+                relation editor @user;
+                relation admin @user;
+                permission read := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine([], [], schema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "res-1",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+
+        // Each relation should appear exactly once — no duplicate nodes with the same name.
+        var allNodes = CollectAllNodes(result.Root);
+        var nameGroups = allNodes.GroupBy(n => n.Name).Where(g => g.Count() > 1).ToList();
+        nameGroups.Should().BeEmpty("each relation name should appear at most once in the tree");
+
+        // All three leaf relations must be present and failed.
+        foreach (var rel in new[] { "viewer", "editor", "admin" })
+        {
+            var node = FindNode(result.Root, n => n.Name == rel);
+            node.Should().NotBeNull($"{rel} node should exist in tree");
+            node!.Result.Should().BeFalse();
+        }
+    }
+
+    private static List<CheckNode> CollectAllNodes(CheckNode root)
+    {
+        var result = new List<CheckNode> { root };
+        foreach (var child in root.Children)
+            result.AddRange(CollectAllNodes(child));
+        return result;
     }
 
     private static CheckNode? FindNodeByType(CheckNode root, CheckNodeType type)

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
@@ -490,6 +490,57 @@ public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task Explain_RbacTupleToUserSet_ShowsRoleChildNodes()
+    {
+        // RBAC schema: admin/editor/viewer are @role#assignee (tuple-to-userset)
+        // alice is assignee of admin_role, which has admin on resource:api
+        const string rbacSchema = """
+            entity user {}
+            entity role {
+                relation assignee @user;
+            }
+            entity resource {
+                relation admin  @role#assignee;
+                relation editor @role#assignee;
+                relation viewer @role#assignee;
+                permission manage := admin;
+                permission write  := editor or admin;
+                permission read   := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("role", "admin_role", "assignee", "user", "alice"),
+                new RelationTuple("role", "editor_role", "assignee", "user", "bob"),
+                new RelationTuple("role", "viewer_role", "assignee", "user", "charlie"),
+                new RelationTuple("resource", "api", "admin", "role", "admin_role", "assignee"),
+                new RelationTuple("resource", "api", "editor", "role", "editor_role", "assignee"),
+                new RelationTuple("resource", "api", "viewer", "role", "viewer_role", "assignee"),
+            ],
+            [], rbacSchema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "api",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+
+        // admin is a plain relation reference (not TTU notation), so its node type is Relation.
+        // It resolves via the indirect sub-relation path: admin @role#assignee → checks role:admin_role#assignee.
+        var adminNode = FindNode(result.Root, n => n.Name == "admin" && n.Type == CheckNodeType.Relation);
+        adminNode.Should().NotBeNull("admin Relation node should exist");
+        adminNode!.Children.Should().NotBeEmpty("admin should have a child showing role:admin_role was checked via sub-relation path");
+
+        var childOfAdmin = adminNode.Children[0];
+        childOfAdmin.EntityType.Should().Be("role");
+        childOfAdmin.EntityId.Should().Be("admin_role");
+        childOfAdmin.Result.Should().BeTrue();
+    }
+
     private static List<CheckNode> CollectAllNodes(CheckNode root)
     {
         var result = new List<CheckNode> { root };

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -765,6 +765,40 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
         result.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task Check_RbacViaSubRelation_ReturnsTrue()
+    {
+        // admin @role#assignee — "user" is not a direct entity, reaches via sub-relation path.
+        // Regression test: IsSubjectTypeAllowedInRelation was blocking this path early.
+        const string rbacSchema = """
+            entity user {}
+            entity role {
+                relation assignee @user;
+            }
+            entity resource {
+                relation admin  @role#assignee;
+                relation editor @role#assignee;
+                relation viewer @role#assignee;
+                permission read := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("role", "admin_role", "assignee", "user", "alice"),
+                new RelationTuple("resource", "api", "admin", "role", "admin_role", "assignee"),
+            ],
+            [], rbacSchema);
+
+        var result = await engine.Check(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "api",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, default);
+
+        result.Should().BeTrue();
+    }
+
     public static TheoryData<string, decimal?, bool> ContextAccessTheoryData = new()
     {
         {"withdraw_amount", 500.0m, true},


### PR DESCRIPTION
## Summary

- Add OR/AND wrapper nodes, entity/subject context, and fix duplicate nodes in explain graph
- More information in explain output; fix wrongly terminated TTU in ReBAC cases

## Changes

- Inject intermediate `Expression("OR"/"AND")` nodes so union/intersect branches are visible as a tree
- Add `EntityType`, `EntityId`, `SubjectType`, `SubjectId` to `CheckNode` for richer context
- Fix duplicate nodes: `CheckComputedUserSet` no longer creates an extra child when the caller already pre-allocated a node for the same relation
- Reuse pre-allocated `Expression` nodes from `CheckExpressionChild` to avoid double-nesting `OR→OR`
- Fix wrongly terminated TTU traversal in ReBAC cases