### PR TITLE
chore: release v0.9.0-beta

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -9,7 +9,7 @@ jobs:
     name: Continuous Benchmarking with Bencher
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             6.x
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           path: ${{ github.workspace }}/**/TestResults/**/*
           retention-days: 5
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.20.0
+        uses: EnricoMi/publish-unit-test-result-action@v2.23.0
         if: always()
         with:
           trx_files: "${{ github.workspace }}/**/*.trx"

--- a/.github/workflows/post_pr_benchmarks.yml
+++ b/.github/workflows/post_pr_benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
           name: ${{ env.PR_EVENT }}
           run_id: ${{ github.event.workflow_run.id }}
       - name: Export PR Event Data
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             let fs = require('fs');

--- a/.github/workflows/post_pr_benchmarks.yml
+++ b/.github/workflows/post_pr_benchmarks.yml
@@ -14,12 +14,12 @@ jobs:
       PR_EVENT: event.json
     steps:
       - name: Download Benchmark Results
-        uses: dawidd6/action-download-artifact@v19
+        uses: dawidd6/action-download-artifact@v20
         with:
           name: ${{ env.BENCHMARK_RESULTS }}
           run_id: ${{ github.event.workflow_run.id }}
       - name: Download PR Event
-        uses: dawidd6/action-download-artifact@v19
+        uses: dawidd6/action-download-artifact@v20
         with:
           name: ${{ env.PR_EVENT }}
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Continuous Benchmarking with Bencher
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.0.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup dotnet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           dotnet tool install -g Cake.Tool        
       - name: Cache NuGet Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: nuget-${{ hashFiles('Directory.Packages.props') }}
           path: ~/.nuget/packages   

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ The implementation is inspired on [permify](https://github.com/Permify/permify) 
 
 ## Functionality
 The library is designed to be simple and easy to use. Each subset of functionality is divided in engines. The engines are:
-- [ICheckEngine](src/Valtuutus.Core/Engines/Check/ICheckEngine.cs): The engine that handles the answering of two questions:
+- [ICheckEngine](src/Valtuutus.Core/Engines/Check/ICheckEngine.cs): The engine that handles the answering of three questions:
   - `Can entity U perform action Y in resource Z`? For that, use the `Check` function.
   - `What permissions entity U have in resource Z`? For that, use the `SubjectPermission` function.
+  - `Why did that permission check succeed or fail?` For that, use the `Explain` function — returns a full resolution tree showing every evaluated relation, attribute, and expression.
 - [ILookupSubjectEngine](src/Valtuutus.Core/Engines/LookupSubject/ILookupSubjectEngine.cs): The engine that can answer: `Which subjects of type T have permission Y on entity:X?` For that, use the `Lookup` function.
 - [ILookupEntityEngine](src/Valtuutus.Core/Engines/LookupEntity/ILookupEntityEngine.cs): The engine that can answer: `Which resources of type T can entity:X have permission Y?` For that, use the `LookupEntity` function. Supports **scoped queries** and **cursor pagination** — see below.
 - [IDataWriterProvider](src/Valtuutus.Core/Data/IDataWriterProvider.cs): This is the provider that can write your relational or attribute data.
 - [IDbDataWriterProvider](src/Valtuutus.Data.Db/IDbDataWriterProvider.cs): Works similarly to `IDataWriterProvider`, with the addition of accepting a connection and transaction as parameters.
 - [Read here](Storing%20Data.md) about how the relational data is stored.
-- [Read here](Using%20the%20Engines.md) for engine usage examples (Check, SubjectPermission, LookupSubject, LookupEntity).
+- [Read here](Using%20the%20Engines.md) for engine usage examples (Check, Explain, SubjectPermission, LookupSubject, LookupEntity).
 
 ## LookupEntity — scoped queries and pagination
 
@@ -93,7 +94,7 @@ do
 | [Modeling Authorization](Modeling%20Authorization.md) | Schema DSL walkthrough with the GitHub example |
 | [Schema Reference](Schema%20Reference.md) | Complete reference for every keyword, operator, and type in the DSL |
 | [Authorization Patterns](Authorization%20Patterns.md) | Ready-made patterns: RBAC, hierarchical RBAC, ABAC, multi-tenancy |
-| [Using the Engines](Using%20the%20Engines.md) | Code examples for Check, SubjectPermission, LookupSubject, LookupEntity, depth |
+| [Using the Engines](Using%20the%20Engines.md) | Code examples for Check, Explain, SubjectPermission, LookupSubject, LookupEntity, depth |
 | [Storing Data](Storing%20Data.md) | Writing, deleting, snap tokens, source generator |
 | [Testing](Testing.md) | Unit-testing your authorization model with the InMemory provider |
 | [Caching](Caching.md) | Reducing database load with FusionCache |

--- a/Using the Engines.md
+++ b/Using the Engines.md
@@ -95,6 +95,71 @@ bool canPush = await checkEngine.Check(
 
 Pass the correct runtime type for each context value (`bool`, `int`, `string`, `decimal`) to avoid runtime errors.
 
+### Explain — why was a permission granted or denied?
+
+`Explain` walks the same graph as `Check` but returns a full resolution tree showing every evaluated relation, attribute, function, and expression — including which branches short-circuited and which results came from the memo cache.
+
+```csharp
+CheckExplainResult explain = await checkEngine.Explain(
+    new CheckRequest(
+        entityType:  "document",
+        entityId:    "2",
+        permission:  "edit",
+        subjectType: "user",
+        subjectId:   "1"),
+    cancellationToken);
+
+Console.WriteLine(explain.Result); // true / false
+
+void Print(CheckNode node, int indent = 0)
+{
+    var prefix = new string(' ', indent * 2);
+    Console.WriteLine($"{prefix}[{node.Type}] {node.Name} => {node.Result}" +
+                      (node.Detail is not null ? $" ({node.Detail})" : ""));
+    foreach (var child in node.Children)
+        Print(child, indent + 1);
+}
+
+Print(explain.Root);
+```
+
+Example output for `edit := (owner or maintainer or parent.admin) and ...` where alice is a direct owner:
+
+```
+[Permission] edit => True
+  [Expression] AND => True
+    [Expression] OR => True
+      [Relation] owner => True (direct tuple)
+      [Relation] maintainer => False (skipped (evaluation stopped after a success))
+      [TupleToUserSet] parent => False (skipped (evaluation stopped after a success))
+    ...
+```
+
+#### Node types
+
+| `CheckNodeType` | Meaning |
+|---|---|
+| `Permission` | A named permission or relation being evaluated |
+| `Expression` | A binary `AND` / `OR` / `NOT` expression node |
+| `Relation` | A direct relation tuple lookup |
+| `TupleToUserSet` | An indirect lookup via a related entity (e.g. `parent.admin`) |
+| `Attribute` | A boolean attribute lookup |
+| `Function` | A custom `fn` call |
+
+#### Detail strings
+
+| Detail | Meaning |
+|---|---|
+| `"direct tuple"` | A matching relation tuple was found |
+| `"no matching tuple"` | No relation tuple exists |
+| `"attribute=True"` / `"attribute=False"` | The attribute value that was read |
+| `"fn result=True"` / `"fn result=False"` | The return value of a custom function |
+| `"memoized"` | Result was served from the per-request memo cache |
+| `"skipped (evaluation stopped after a success)"` | Branch was not evaluated because an OR sibling already returned true |
+| `"skipped (evaluation stopped after a failure)"` | Branch was not evaluated because an AND sibling already returned false |
+
+> **Performance note:** `Explain` allocates a `CheckNode` tree on every call. Use `Check` on hot paths; reserve `Explain` for debugging, audit logging, or developer tooling.
+
 ### SubjectPermission — what permissions does user U have on resource Z?
 
 Returns a dictionary of every permission defined on the entity and whether the subject has it:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,8 +19,6 @@
   <PropertyGroup>
     <PackageReleaseNotes>Version 0.9.0-beta:
       NEW: ICheckEngine.Explain() — returns a full resolution tree showing why a permission check passed or failed
-      FIX: TTU (tuple-to-userset) nodes now correctly terminate in ReBAC explain graphs
-      NEW: Explain graph improvements — OR/AND wrapper nodes, entity/subject context, and deduplication of nodes
 
 Version 0.8.2-beta:
       FIX: Microsoft.Extensions.ObjectPool is now a proper transitive dependency — resolves TypeLoadException in Blazor WASM and other strict-linking environments

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,6 +19,7 @@
   <PropertyGroup>
     <PackageReleaseNotes>Version 0.9.0-beta:
       NEW: ICheckEngine.Explain() — returns a full resolution tree showing why a permission check passed or failed
+      FIX: TTU (tuple-to-userset) nodes now correctly terminate in ReBAC explain graphs
 
 Version 0.8.2-beta:
       FIX: Microsoft.Extensions.ObjectPool is now a proper transitive dependency — resolves TypeLoadException in Blazor WASM and other strict-linking environments

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Authors>Valtuutus</Authors>
-    <VersionPrefix>0.8.2-beta</VersionPrefix>
+    <VersionPrefix>0.9.0-beta</VersionPrefix>
     <PackageProjectUrl>https://github.com/valtuutus/valtuutus</PackageProjectUrl>
     <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -17,7 +17,12 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Version 0.8.2-beta:
+    <PackageReleaseNotes>Version 0.9.0-beta:
+      NEW: ICheckEngine.Explain() — returns a full resolution tree showing why a permission check passed or failed
+      FIX: TTU (tuple-to-userset) nodes now correctly terminate in ReBAC explain graphs
+      NEW: Explain graph improvements — OR/AND wrapper nodes, entity/subject context, and deduplication of nodes
+
+Version 0.8.2-beta:
       FIX: Microsoft.Extensions.ObjectPool is now a proper transitive dependency — resolves TypeLoadException in Blazor WASM and other strict-linking environments
 
 Version 0.8.1-beta:

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -57,6 +57,14 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Task<bool> GetOrAdd(CheckMemoKey key, Task<bool> task)
             => _cache.GetOrAdd(key, task);
+
+        public Task<bool> GetOrAdd(CheckMemoKey key, Func<Task<bool>> factory, out bool added)
+        {
+            Task<bool>? factoryResult = null;
+            var task = _cache.GetOrAdd(key, _ => { factoryResult = factory(); return factoryResult; });
+            added = factoryResult is not null && ReferenceEquals(task, factoryResult);
+            return task;
+        }
     }
 
     //<inheritdoc/>
@@ -125,6 +133,21 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         return dict;
     }
 
+    //<inheritdoc/>
+    public async Task<CheckExplainResult> Explain(CheckRequest req, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity(ActivityKind.Internal,
+            tags: CreateCheckSpanAttributes(req));
+
+        await SnapTokenUtils.LoadLatestSnapToken(reader, req, cancellationToken);
+        var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission };
+        var result = await CheckInternal(req, new CheckMemo(), root, cancellationToken);
+        root.Result = result;
+        activity?.AddEvent(new ActivityEvent("ExplainFinished",
+            tags: new ActivityTagsCollection(CreateCheckResultAttributes(result))));
+        return new CheckExplainResult { Result = result, Root = root };
+    }
+
     private static IEnumerable<KeyValuePair<string, object?>> CreateSubjectPermissionResultAttributes(
         Dictionary<string, bool> result)
     {
@@ -139,9 +162,15 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
     }
 
     private Task<bool> CheckInternal(CheckRequest req, CheckMemo memo, CancellationToken ct)
+        => CheckInternal(req, memo, null, ct);
+
+    private Task<bool> CheckInternal(CheckRequest req, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         if (req.CheckDepthLimit())
+        {
+            if (node is not null) node.Detail = "depth limit reached";
             return Task.FromResult(false);
+        }
 
         if (!string.IsNullOrEmpty(req.SubjectRelation)
             && req.SubjectType == req.EntityType
@@ -151,39 +180,64 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
 
         if (!string.IsNullOrEmpty(req.SubjectType)
             && !schema.CanSubjectTypeReach(req.EntityType, req.Permission, req.SubjectType))
+        {
+            if (node is not null) node.Detail = "subject type cannot reach permission";
             return Task.FromResult(false);
+        }
 
         req.DecreaseDepth();
 
         var key = new CheckMemoKey(req.EntityType, req.EntityId, req.Permission, req.SubjectType, req.SubjectId);
-        if (memo.TryGet(key, out var cached))
-            return cached;
 
-        var task = schema.GetRelationType(req.EntityType, req.Permission) switch
+        if (node is null)
         {
-            RelationType.DirectRelation => CheckRelation(req, memo, ct),
-            RelationType.Permission => CheckPermission(req, schema.GetPermission(req.EntityType, req.Permission), memo, ct),
-            RelationType.Attribute => CheckAttribute(req, ct),
-            _ => Task.FromResult(false)
-        };
+            if (memo.TryGet(key, out var cached)) return cached!;
+            var task = schema.GetRelationType(req.EntityType, req.Permission) switch
+            {
+                RelationType.DirectRelation => CheckRelation(req, memo, null, ct),
+                RelationType.Permission => CheckPermission(req, schema.GetPermission(req.EntityType, req.Permission), memo, null, ct),
+                RelationType.Attribute => CheckAttribute(req, null, ct),
+                _ => Task.FromResult(false)
+            };
+            return memo.GetOrAdd(key, task);
+        }
+        else
+        {
+            var memoTask = memo.GetOrAdd(key, () => schema.GetRelationType(req.EntityType, req.Permission) switch
+            {
+                RelationType.DirectRelation => CheckRelation(req, memo, node, ct),
+                RelationType.Permission => CheckPermission(req, schema.GetPermission(req.EntityType, req.Permission), memo, node, ct),
+                RelationType.Attribute => CheckAttribute(req, node, ct),
+                _ => Task.FromResult(false)
+            }, out bool added);
 
-        return memo.GetOrAdd(key, task);
+            if (!added)
+            {
+                node.Type = CheckNodeType.Permission;
+                node.Detail = "memoized";
+                return memoTask.ContinueWith(
+                    static (t, s) => { ((CheckNode)s!).Result = t.Result; return t.Result; },
+                    node, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+            }
+
+            return memoTask;
+        }
     }
 
-    private Task<bool> CheckPermission(CheckRequest req, Permission permission, CheckMemo memo, CancellationToken ct)
+    private Task<bool> CheckPermission(CheckRequest req, Permission permission, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity("CheckPermission");
-
         var permissionNode = permission!.Tree;
-
         return permissionNode.Type == PermissionNodeType.Expression
-            ? CheckExpression(req, permissionNode, memo, ct)
-            : CheckLeaf(req, permissionNode, memo, ct);
+            ? CheckExpression(req, permissionNode, memo, node, ct)
+            : CheckLeaf(req, permissionNode, memo, node, ct);
     }
 
-    private async Task<bool> CheckAttribute(CheckRequest req, CancellationToken ct)
+    private async Task<bool> CheckAttribute(CheckRequest req, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        if (node is not null) node.Type = CheckNodeType.Attribute;
+
         var attribute = await reader.GetAttribute(
             new EntityAttributeFilter
             {
@@ -194,62 +248,108 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             }, ct);
 
         if (attribute is null)
+        {
+            if (node is not null) node.Detail = "attribute=False";
             return false;
+        }
 
-        return attribute.Value.GetValue<bool>();
+        var val = attribute.Value.GetValue<bool>();
+        if (node is not null) node.Detail = $"attribute={val}";
+        return val;
     }
 
-    private Task<bool> CheckExpression(CheckRequest req, PermissionNode node, CheckMemo memo, CancellationToken ct)
+    private Task<bool> CheckExpression(CheckRequest req, PermissionNode permNode, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
-        return node.ExpressionNode!.Operation switch
+        return permNode.ExpressionNode!.Operation switch
         {
-            PermissionOperation.Intersect => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, isUnion: false, ct),
-            PermissionOperation.Union => CheckExpressionChild(req, node.ExpressionNode!.Children, memo, isUnion: true, ct),
-            PermissionOperation.Negate => NegateCheck(req, node.ExpressionNode!.Children[0], memo, ct),
+            PermissionOperation.Intersect => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: false, ct),
+            PermissionOperation.Union => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: true, ct),
+            PermissionOperation.Negate => NegateCheck(req, permNode.ExpressionNode!.Children[0], memo, node, ct),
             _ => throw new InvalidOperationException()
         };
     }
 
-    private async Task<bool> NegateCheck(CheckRequest req, PermissionNode child, CheckMemo memo, CancellationToken ct)
+    private async Task<bool> NegateCheck(CheckRequest req, PermissionNode child, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
-        var result = child.Type == PermissionNodeType.Expression
-            ? await CheckExpression(req, child, memo, ct)
-            : await CheckLeaf(req, child, memo, ct);
-        return !result;
+
+        CheckNode? childNode = null;
+        if (node is not null)
+        {
+            var (type, name) = GetNodeInfo(child);
+            childNode = new CheckNode { Type = type, Name = name };
+        }
+
+        var inner = child.Type == PermissionNodeType.Expression
+            ? await CheckExpression(req, child, memo, childNode, ct)
+            : await CheckLeaf(req, child, memo, childNode, ct);
+
+        if (childNode is not null)
+        {
+            childNode.Result = inner;
+            node!._children.Add(childNode);
+        }
+
+        return !inner;
     }
 
-    private async Task<bool> CheckExpressionChild(CheckRequest req, List<PermissionNode> children, CheckMemo memo, bool isUnion, CancellationToken ct)
+    private async Task<bool> CheckExpressionChild(CheckRequest req, List<PermissionNode> children, CheckMemo memo, CheckNode? node, bool isUnion, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
         var count = children.Count;
         if (count == 0) return !isUnion;
+
         if (count == 1)
         {
             var only = children[0];
-            return await (only.Type == PermissionNodeType.Expression
-                ? CheckExpression(req, only, memo, ct)
-                : CheckLeaf(req, only, memo, ct));
+            CheckNode? childNode = null;
+            if (node is not null)
+            {
+                var (type, name) = GetNodeInfo(only);
+                childNode = new CheckNode { Type = type, Name = name };
+            }
+            var result = await (only.Type == PermissionNodeType.Expression
+                ? CheckExpression(req, only, memo, childNode, ct)
+                : CheckLeaf(req, only, memo, childNode, ct));
+            if (childNode is not null)
+            {
+                childNode.Result = result;
+                node!._children.Add(childNode);
+            }
+            return result;
+        }
+
+        CheckNode[]? childNodes = null;
+        if (node is not null)
+        {
+            childNodes = new CheckNode[count];
+            for (var i = 0; i < count; i++)
+            {
+                var (type, name) = GetNodeInfo(children[i]);
+                childNodes[i] = new CheckNode { Type = type, Name = name };
+            }
         }
 
         using var pooledCts = CancellationTokenSourcePool.Rent(ct);
         var cancellationToken = pooledCts.Token;
         var innerCts = pooledCts.InnerSource;
 
+        var rawTasks = new Task<bool>[count];
         var tasks = new Task<bool>[count];
         for (var i = 0; i < count; i++)
         {
             var child = children[i];
-            var rawTask = child.Type == PermissionNodeType.Expression
-                ? CheckExpression(req, child, memo, cancellationToken)
-                : CheckLeaf(req, child, memo, cancellationToken);
+            var childNode = childNodes?[i];
+            rawTasks[i] = child.Type == PermissionNodeType.Expression
+                ? CheckExpression(req, child, memo, childNode, cancellationToken)
+                : CheckLeaf(req, child, memo, childNode, cancellationToken);
             tasks[i] = isUnion
-                ? rawTask.ContinueWith(
+                ? rawTasks[i].ContinueWith(
                     static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                     innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current)
-                : rawTask.ContinueWith(
+                : rawTasks[i].ContinueWith(
                     static (t, s) => { if (!t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                     innerCts, cancellationToken, TaskContinuationOptions.NotOnFaulted, TaskScheduler.Current);
         }
@@ -257,39 +357,61 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         try
         {
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            if (childNodes is not null)
+                for (var i = 0; i < count; i++)
+                {
+                    childNodes[i].Result = results[i];
+                    node!._children.Add(childNodes[i]);
+                }
             return isUnion ? results.AsSpan().Contains(true) : !results.AsSpan().Contains(false);
         }
         catch (OperationCanceledException)
         {
+            if (childNodes is not null)
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    if (rawTasks[i].IsCompletedSuccessfully)
+                        childNodes[i].Result = rawTasks[i].Result;
+                    else
+                        childNodes[i].Detail = isUnion
+                            ? "skipped (evaluation stopped after a success)"
+                            : "skipped (evaluation stopped after a failure)";
+                    node!._children.Add(childNodes[i]);
+                }
+            }
             return isUnion;
         }
     }
 
-    private Task<bool> CheckLeaf(CheckRequest req, PermissionNode node, CheckMemo memo, CancellationToken ct)
+    private Task<bool> CheckLeaf(CheckRequest req, PermissionNode permNode, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
-
-        return node.LeafNode!.Type switch
+        return permNode.LeafNode!.Type switch
         {
-            PermissionNodeLeafType.Permission => CheckLeafPermission(req, node.LeafNode!.PermissionNode!, memo, ct),
-            PermissionNodeLeafType.Expression => CheckLeafFn(req, node.LeafNode!.ExpressionNode!, ct),
+            PermissionNodeLeafType.Permission => CheckLeafPermission(req, permNode.LeafNode!.PermissionNode!, memo, node, ct),
+            PermissionNodeLeafType.Expression => CheckLeafFn(req, permNode.LeafNode!.ExpressionNode!, node, ct),
             _ => throw new InvalidOperationException()
         };
     }
 
-    private async Task<bool> CheckLeafFn(CheckRequest req, PermissionNodeLeafExp node, CancellationToken ct)
+    private async Task<bool> CheckLeafFn(CheckRequest req, PermissionNodeLeafExp leafExp, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        if (node is not null) node.Type = CheckNodeType.Function;
 
-        var fn = schema.Functions[node.FunctionName];
+        var fn = schema.Functions[leafExp.FunctionName];
 
         if (fn is null)
             throw new InvalidOperationException();
 
-        if (!node.IsContextValid(req.Context))
+        if (!leafExp.IsContextValid(req.Context))
+        {
+            if (node is not null) node.Detail = "fn result=False (invalid context)";
             return false;
+        }
 
-        var attributeArguments = node.GetArgsAttributesNames();
+        var attributeArguments = leafExp.GetArgsAttributesNames();
 
         var attributes = await reader.GetAttributes(
             new EntityAttributesFilter
@@ -300,7 +422,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, null, ct);
 
-        using var paramToArg = fn.CreateParamToArgMap(node.Args);
+        using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
 
         using var fnArgs = paramToArg.ToLambdaArgs(
             static (arg, state) =>
@@ -313,24 +435,41 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             (attributes, req.EntityId, req.EntityType, schema),
             req.Context);
 
-        return fn.Lambda(fnArgs.Dictionary);
+        var result = fn.Lambda(fnArgs.Dictionary);
+        if (node is not null) node.Detail = $"fn result={result}";
+        return result;
     }
 
-    private Task<bool> CheckLeafPermission(CheckRequest req, PermissionNodeLeafPermission node, CheckMemo memo, CancellationToken ct)
+    private Task<bool> CheckLeafPermission(CheckRequest req, PermissionNodeLeafPermission leafPerm, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
-        if (node.IsIndirect)
-            return CheckTupleToUserSet(req, node.UserSet!, node.ComputedUserSet!, memo, ct);
-        return CheckComputedUserSet(req, node.Permission, memo, ct);
+        if (leafPerm.IsIndirect)
+        {
+            if (node is not null) node.Type = CheckNodeType.TupleToUserSet;
+            return CheckTupleToUserSet(req, leafPerm.UserSet!, leafPerm.ComputedUserSet!, memo, node, ct);
+        }
+        return CheckComputedUserSet(req, leafPerm.Permission, memo, node, ct);
     }
 
-    private Task<bool> CheckComputedUserSet(CheckRequest req, string computedUserSetRelation, CheckMemo memo, CancellationToken ct)
+    private async Task<bool> CheckComputedUserSet(CheckRequest req, string computedUserSetRelation, CheckMemo memo, CheckNode? parentNode, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
-        return CheckInternal(req with { Permission = computedUserSetRelation }, memo, ct);
+
+        CheckNode? childNode = parentNode is null ? null
+            : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+
+        var result = await CheckInternal(req with { Permission = computedUserSetRelation }, memo, childNode, ct);
+
+        if (childNode is not null)
+        {
+            childNode.Result = result;
+            parentNode!._children.Add(childNode);
+        }
+
+        return result;
     }
 
     private async Task<bool> CheckTupleToUserSet(CheckRequest req, string tupleSetRelation,
-        string computedUserSetRelation, CheckMemo memo, CancellationToken ct)
+        string computedUserSetRelation, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
@@ -346,12 +485,14 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 var computedRel = schema.GetRelation(subEntityType, computedUserSetRelation);
                 if (!computedRel.HasSubRelationPaths && computedRel.EntityTypes.Contains(req.SubjectType))
                 {
-                    return await reader.HasTupleToUserSetRelation(
+                    var fastResult = await reader.HasTupleToUserSetRelation(
                         req.EntityType, req.EntityId,
                         tupleSetRelation,
                         subEntityType, computedUserSetRelation,
                         req.SubjectType!, req.SubjectId!,
                         req.SnapToken ?? SnapToken.MinValue, ct);
+                    if (node is not null) node.Detail = fastResult ? "fast-path: direct join found" : "fast-path: no join found";
+                    return fastResult;
                 }
             }
         }
@@ -365,11 +506,19 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, ct);
 
-        if (relations.Count == 0) return false;
+        if (relations.Count == 0)
+        {
+            if (node is not null) node.Detail = "no matching tuples";
+            return false;
+        }
+
         if (relations.Count == 1)
         {
             var only = relations[0];
-            return await CheckComputedUserSet(new CheckRequest
+            CheckNode? childNode = node is null ? null
+                : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+
+            var singleResult = await CheckComputedUserSet(new CheckRequest
             {
                 EntityType = only.SubjectType,
                 EntityId = only.SubjectId,
@@ -377,7 +526,14 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, computedUserSetRelation, memo, ct);
+            }, computedUserSetRelation, memo, childNode, ct);
+
+            if (childNode is not null)
+            {
+                childNode.Result = singleResult;
+                node!._children.Add(childNode);
+            }
+            return singleResult;
         }
 
         var firstSubjectType = relations.AsSpan()[0].SubjectType;
@@ -391,8 +547,10 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             Array.Clear(entityIds, relations.Count, entityIds.Length - relations.Count);
             try
             {
-                return await reader.HasAnyDirectRelation(firstSubjectType, entityIds, computedUserSetRelation,
+                var batchResult = await reader.HasAnyDirectRelation(firstSubjectType, entityIds, computedUserSetRelation,
                     req.SubjectId!, req.SnapToken ?? SnapToken.MinValue, ct);
+                if (node is not null) node.Detail = batchResult ? "batch: direct relation found" : "batch: no direct relation";
+                return batchResult;
             }
             finally
             {
@@ -405,10 +563,16 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         var cancellationToken = pooledCts.Token;
         var innerCts = pooledCts.InnerSource;
 
+        CheckNode[]? childNodes = node is null ? null : new CheckNode[relations.Count];
+        if (childNodes is not null)
+            for (var i = 0; i < relations.Count; i++)
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+
         var tasks = new Task<bool>[relations.Count];
         for (var i = 0; i < relations.Count; i++)
         {
             var relation = relations[i];
+            var childNode = childNodes?[i];
             tasks[i] = CheckComputedUserSet(new CheckRequest
             {
                 EntityType = relation.SubjectType,
@@ -417,7 +581,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, computedUserSetRelation, memo, cancellationToken)
+            }, computedUserSetRelation, memo, childNode, cancellationToken)
             .ContinueWith(
                 static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                 innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
@@ -426,15 +590,28 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         try
         {
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            if (childNodes is not null)
+                for (var i = 0; i < childNodes.Length; i++)
+                {
+                    childNodes[i].Result = results[i];
+                    node!._children.Add(childNodes[i]);
+                }
             return results.AsSpan().Contains(true);
         }
         catch (OperationCanceledException)
         {
+            if (childNodes is not null)
+                for (var i = 0; i < childNodes.Length; i++)
+                {
+                    if (tasks[i].IsCompletedSuccessfully)
+                        childNodes[i].Result = tasks[i].Result;
+                    node!._children.Add(childNodes[i]);
+                }
             return true;
         }
     }
 
-    private async Task<bool> CheckRelation(CheckRequest req, CheckMemo memo, CancellationToken ct)
+    private async Task<bool> CheckRelation(CheckRequest req, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
         if (!string.IsNullOrEmpty(req.SubjectType)
             && !schema.IsSubjectTypeAllowedInRelation(req.EntityType, req.Permission,
@@ -442,6 +619,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             return false;
 
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        if (node is not null) node.Type = CheckNodeType.Relation;
 
         var filter = new RelationTupleFilter
         {
@@ -452,18 +630,33 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         };
 
         var hasDirect = await reader.HasDirectRelation(filter, req.SubjectId!, ct);
-        if (hasDirect) return true;
+        if (hasDirect)
+        {
+            if (node is not null) node.Detail = "direct tuple";
+            return true;
+        }
 
         if (!schema.GetRelation(req.EntityType, req.Permission).HasSubRelationPaths)
+        {
+            if (node is not null) node.Detail = "no matching tuple";
             return false;
+        }
 
         using var indirectRelations = await reader.GetIndirectRelations(filter, ct);
 
-        if (indirectRelations.Count == 0) return false;
+        if (indirectRelations.Count == 0)
+        {
+            if (node is not null) node.Detail = "no matching tuple";
+            return false;
+        }
+
         if (indirectRelations.Count == 1)
         {
             ref readonly var only = ref indirectRelations.AsSpan()[0];
-            return await CheckInternal(new CheckRequest
+            CheckNode? childNode = node is null ? null
+                : new CheckNode { Type = CheckNodeType.Permission, Name = only.SubjectRelation ?? only.SubjectType };
+
+            var singleResult = await CheckInternal(new CheckRequest
             {
                 EntityType = only.SubjectType,
                 EntityId = only.SubjectId,
@@ -471,18 +664,34 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, memo, ct);
+            }, memo, childNode, ct);
+
+            if (childNode is not null)
+            {
+                childNode.Result = singleResult;
+                node!._children.Add(childNode);
+            }
+            return singleResult;
         }
 
         using var pooledCts = CancellationTokenSourcePool.Rent(ct);
         var cancellationToken = pooledCts.Token;
         var innerCts = pooledCts.InnerSource;
 
+        CheckNode[]? childNodes = node is null ? null : new CheckNode[indirectRelations.Count];
+        if (childNodes is not null)
+            for (var i = 0; i < indirectRelations.Count; i++)
+            {
+                ref readonly var r = ref indirectRelations.AsSpan()[i];
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType };
+            }
+
         var tasks = new Task<bool>[indirectRelations.Count];
         var count = 0;
         foreach (ref readonly var relation in indirectRelations.AsSpan())
         {
-            tasks[count++] = CheckInternal(new CheckRequest
+            var childNode = childNodes?[count];
+            tasks[count] = CheckInternal(new CheckRequest
             {
                 EntityType = relation.SubjectType,
                 EntityId = relation.SubjectId,
@@ -490,21 +699,58 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, memo, cancellationToken)
+            }, memo, childNode, cancellationToken)
             .ContinueWith(
                 static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                 innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
+            count++;
         }
 
         try
         {
             var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            if (childNodes is not null)
+                for (var i = 0; i < childNodes.Length; i++)
+                {
+                    childNodes[i].Result = results[i];
+                    node!._children.Add(childNodes[i]);
+                }
             return results.AsSpan().Contains(true);
         }
         catch (OperationCanceledException)
         {
+            if (childNodes is not null)
+                for (var i = 0; i < childNodes.Length; i++)
+                {
+                    if (tasks[i].IsCompletedSuccessfully)
+                        childNodes[i].Result = tasks[i].Result;
+                    node!._children.Add(childNodes[i]);
+                }
             return true;
         }
+    }
+
+    private static (CheckNodeType type, string name) GetNodeInfo(PermissionNode child)
+    {
+        if (child.Type == PermissionNodeType.Expression)
+        {
+            var opName = child.ExpressionNode!.Operation switch
+            {
+                PermissionOperation.Union => "OR",
+                PermissionOperation.Intersect => "AND",
+                PermissionOperation.Negate => "NOT",
+                _ => "expression"
+            };
+            return (CheckNodeType.Expression, opName);
+        }
+
+        if (child.LeafNode!.Type == PermissionNodeLeafType.Expression)
+            return (CheckNodeType.Function, child.LeafNode!.ExpressionNode!.FunctionName);
+
+        var perm = child.LeafNode!.PermissionNode!;
+        return perm.IsIndirect
+            ? (CheckNodeType.TupleToUserSet, perm.Permission)
+            : (CheckNodeType.Permission, perm.Permission);
     }
 
     private static bool AllSameSubjectType(ReadOnlySpan<RelationTuple> relations, string expectedType)

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -140,9 +140,10 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             tags: CreateCheckSpanAttributes(req));
 
         await SnapTokenUtils.LoadLatestSnapToken(reader, req, cancellationToken);
-        var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission };
+        var root = new CheckNode { Type = CheckNodeType.Permission, Name = req.Permission, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         var result = await CheckInternal(req, new CheckMemo(), root, cancellationToken);
         root.Result = result;
+        FlattenExpressionTree(root);
         activity?.AddEvent(new ActivityEvent("ExplainFinished",
             tags: new ActivityTagsCollection(CreateCheckResultAttributes(result))));
         return new CheckExplainResult { Result = result, Root = root };
@@ -263,11 +264,42 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
         return permNode.ExpressionNode!.Operation switch
         {
-            PermissionOperation.Intersect => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: false, ct),
-            PermissionOperation.Union => CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, node, isUnion: true, ct),
+            PermissionOperation.Intersect => CheckExpressionWithWrapper(req, permNode, memo, node, "and", isUnion: false, ct),
+            PermissionOperation.Union => CheckExpressionWithWrapper(req, permNode, memo, node, "or", isUnion: true, ct),
             PermissionOperation.Negate => NegateCheck(req, permNode.ExpressionNode!.Children[0], memo, node, ct),
             _ => throw new InvalidOperationException()
         };
+    }
+
+    private async Task<bool> CheckExpressionWithWrapper(CheckRequest req, PermissionNode permNode, CheckMemo memo, CheckNode? node, string opName, bool isUnion, CancellationToken ct)
+    {
+        using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        CheckNode? exprNode;
+        bool owned;
+        if (node is not null && node.Type == CheckNodeType.Expression)
+        {
+            // Reuse the pre-allocated expression node from the parent's CheckExpressionChild call.
+            // The parent will add it to its own parent after WhenAll, so we must not double-add.
+            exprNode = node;
+            owned = false;
+        }
+        else if (node is not null)
+        {
+            exprNode = new CheckNode { Type = CheckNodeType.Expression, Name = opName, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
+            owned = true;
+        }
+        else
+        {
+            exprNode = null;
+            owned = false;
+        }
+        var result = await CheckExpressionChild(req, permNode.ExpressionNode!.Children, memo, exprNode, isUnion, ct);
+        if (exprNode is not null)
+        {
+            exprNode.Result = result;
+            if (owned) node!._children.Add(exprNode);
+        }
+        return result;
     }
 
     private async Task<bool> NegateCheck(CheckRequest req, PermissionNode child, CheckMemo memo, CheckNode? node, CancellationToken ct)
@@ -278,7 +310,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         if (node is not null)
         {
             var (type, name) = GetNodeInfo(child);
-            childNode = new CheckNode { Type = type, Name = name };
+            childNode = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         }
 
         var inner = child.Type == PermissionNodeType.Expression
@@ -308,7 +340,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             if (node is not null)
             {
                 var (type, name) = GetNodeInfo(only);
-                childNode = new CheckNode { Type = type, Name = name };
+                childNode = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
             var result = await (only.Type == PermissionNodeType.Expression
                 ? CheckExpression(req, only, memo, childNode, ct)
@@ -328,7 +360,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             for (var i = 0; i < count; i++)
             {
                 var (type, name) = GetNodeInfo(children[i]);
-                childNodes[i] = new CheckNode { Type = type, Name = name };
+                childNodes[i] = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
         }
 
@@ -454,17 +486,17 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
-        CheckNode? childNode = parentNode is null ? null
-            : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+        // If parentNode already represents this relation (same name — created by GetNodeInfo in CheckExpressionChild
+        // or by the caller in CheckTupleToUserSet), pass it directly to avoid a duplicate node.
+        // Hot path (parentNode is null) is also handled here with no allocations.
+        if (parentNode is null || parentNode.Name == computedUserSetRelation)
+            return await CheckInternal(req with { Permission = computedUserSetRelation }, memo, parentNode, ct);
 
+        // Node represents a different permission (e.g. "delete" resolving to "owner") — create a child.
+        var childNode = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
         var result = await CheckInternal(req with { Permission = computedUserSetRelation }, memo, childNode, ct);
-
-        if (childNode is not null)
-        {
-            childNode.Result = result;
-            parentNode!._children.Add(childNode);
-        }
-
+        childNode.Result = result;
+        parentNode._children.Add(childNode);
         return result;
     }
 
@@ -516,7 +548,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             var only = relations[0];
             CheckNode? childNode = node is null ? null
-                : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+                : new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = only.SubjectType, EntityId = only.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
             var singleResult = await CheckComputedUserSet(new CheckRequest
             {
@@ -566,7 +598,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         CheckNode[]? childNodes = node is null ? null : new CheckNode[relations.Count];
         if (childNodes is not null)
             for (var i = 0; i < relations.Count; i++)
-                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation };
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = relations[i].SubjectType, EntityId = relations[i].SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
         var tasks = new Task<bool>[relations.Count];
         for (var i = 0; i < relations.Count; i++)
@@ -613,11 +645,6 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
 
     private async Task<bool> CheckRelation(CheckRequest req, CheckMemo memo, CheckNode? node, CancellationToken ct)
     {
-        if (!string.IsNullOrEmpty(req.SubjectType)
-            && !schema.IsSubjectTypeAllowedInRelation(req.EntityType, req.Permission,
-                req.SubjectType, req.SubjectRelation))
-            return false;
-
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
         if (node is not null) node.Type = CheckNodeType.Relation;
 
@@ -654,7 +681,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             ref readonly var only = ref indirectRelations.AsSpan()[0];
             CheckNode? childNode = node is null ? null
-                : new CheckNode { Type = CheckNodeType.Permission, Name = only.SubjectRelation ?? only.SubjectType };
+                : new CheckNode { Type = CheckNodeType.Permission, Name = only.SubjectRelation ?? only.SubjectType, EntityType = only.SubjectType, EntityId = only.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
             var singleResult = await CheckInternal(new CheckRequest
             {
@@ -683,7 +710,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             for (var i = 0; i < indirectRelations.Count; i++)
             {
                 ref readonly var r = ref indirectRelations.AsSpan()[i];
-                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType };
+                childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType, EntityType = r.SubjectType, EntityId = r.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
 
         var tasks = new Task<bool>[indirectRelations.Count];
@@ -736,9 +763,9 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             var opName = child.ExpressionNode!.Operation switch
             {
-                PermissionOperation.Union => "OR",
-                PermissionOperation.Intersect => "AND",
-                PermissionOperation.Negate => "NOT",
+                PermissionOperation.Union => "or",
+                PermissionOperation.Intersect => "and",
+                PermissionOperation.Negate => "not",
                 _ => "expression"
             };
             return (CheckNodeType.Expression, opName);
@@ -751,6 +778,35 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         return perm.IsIndirect
             ? (CheckNodeType.TupleToUserSet, perm.Permission)
             : (CheckNodeType.Permission, perm.Permission);
+    }
+
+    // Flatten consecutive same-named Expression nodes so e.g. "a or b or c" (parsed as a
+    // left-associative binary tree) renders as one OR node with three children instead of two nested ORs.
+    private static void FlattenExpressionTree(CheckNode node)
+    {
+        foreach (var child in node.Children)
+            FlattenExpressionTree(child);
+
+        if (node.Type != CheckNodeType.Expression) return;
+
+        bool changed = false;
+        for (var i = 0; i < node._children.Count; i++)
+        {
+            if (node._children[i].Type == CheckNodeType.Expression && node._children[i].Name == node.Name)
+            { changed = true; break; }
+        }
+        if (!changed) return;
+
+        var flat = new List<CheckNode>(node._children.Count + 2);
+        foreach (var child in node._children)
+        {
+            if (child.Type == CheckNodeType.Expression && child.Name == node.Name)
+                flat.AddRange(child._children);
+            else
+                flat.Add(child);
+        }
+        node._children.Clear();
+        node._children.AddRange(flat);
     }
 
     private static bool AllSameSubjectType(ReadOnlySpan<RelationTuple> relations, string expectedType)

--- a/src/Valtuutus.Core/Engines/Check/CheckNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckNode.cs
@@ -1,0 +1,27 @@
+namespace Valtuutus.Core.Engines.Check;
+
+public enum CheckNodeType
+{
+    Permission,
+    Expression,
+    Relation,
+    TupleToUserSet,
+    Attribute,
+    Function
+}
+
+public sealed class CheckNode
+{
+    public CheckNodeType Type { get; internal set; }
+    public required string Name { get; init; }
+    public bool Result { get; internal set; }
+    public string? Detail { get; internal set; }
+    public IReadOnlyList<CheckNode> Children => _children;
+    internal readonly List<CheckNode> _children = [];
+}
+
+public sealed class CheckExplainResult
+{
+    public required bool Result { get; init; }
+    public required CheckNode Root { get; init; }
+}

--- a/src/Valtuutus.Core/Engines/Check/CheckNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckNode.cs
@@ -16,6 +16,10 @@ public sealed class CheckNode
     public required string Name { get; init; }
     public bool Result { get; internal set; }
     public string? Detail { get; internal set; }
+    public string? EntityType { get; internal set; }
+    public string? EntityId { get; internal set; }
+    public string? SubjectType { get; internal set; }
+    public string? SubjectId { get; internal set; }
     public IReadOnlyList<CheckNode> Children => _children;
     internal readonly List<CheckNode> _children = [];
 }

--- a/src/Valtuutus.Core/Engines/Check/ICheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/ICheckEngine.cs
@@ -18,4 +18,13 @@ public interface ICheckEngine
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A dictionary containing every permission for the entity and if the subject has access to it.</returns>
     Task<Dictionary<string, bool>> SubjectPermission(SubjectPermissionRequest req, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Walks the schema graph like Check(), but returns a full resolution tree explaining
+    /// which relations, attributes, and expressions determined the result.
+    /// </summary>
+    /// <param name="req">Same request as Check().</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The boolean result plus a tree of every evaluated node.</returns>
+    Task<CheckExplainResult> Explain(CheckRequest req, CancellationToken cancellationToken);
 }

--- a/src/Valtuutus.Data.Caching/CachedCheckEngine.cs
+++ b/src/Valtuutus.Data.Caching/CachedCheckEngine.cs
@@ -37,6 +37,10 @@ public sealed class CachedCheckEngine : ICheckEngine
         return await _cache.GetOrSetAsync(GetSubjectPermissionCacheKey(req), ct => _engine.SubjectPermission(req, ct), TimeSpan.FromMinutes(5), cancellationToken);
     }
     
+    /// <inheritdoc />
+    public Task<CheckExplainResult> Explain(CheckRequest req, CancellationToken cancellationToken)
+        => _engine.Explain(req, cancellationToken);
+
     private static string GetCheckCacheKey(CheckRequest req)
     {
         return $"check:{req.EntityType}:{req.EntityId}:{req.Permission}:{req.SubjectType}:{req.SubjectId}:{req.SubjectRelation}:{req.SnapToken}";

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -124,12 +124,14 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<string>> GetEntityIdsExcluding(string entityType, System.Collections.Generic.IReadOnlyCollection<string> excludeIds, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetIndirectRelations(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken?> GetLatestSnapToken(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelations(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsJoined(Valtuutus.Core.Data.EntityRelationFilter mainFilter, string subEntityType, string subRelation, string subjectType, string subjectId, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsWithEntityIds(Valtuutus.Core.Data.EntityRelationFilter entityRelationFilter, string subjectType, System.Collections.Generic.IEnumerable<string> entityIds, string? subjectRelation, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsWithSubjectsIds(Valtuutus.Core.Data.EntityRelationFilter entityFilter, string[] subjectsIds, string subjectType, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<string>> GetSubjectIdsExcluding(string subjectType, System.Collections.Generic.IReadOnlyCollection<string> excludeIds, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasAnyDirectRelation(string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
@@ -171,7 +173,41 @@ namespace Valtuutus.Core.Engines.Check
     {
         public CheckEngine(Valtuutus.Core.Data.IDataReaderProvider reader, Valtuutus.Core.Schemas.Schema schema) { }
         public System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckExplainResult
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckExplainResult() { }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public bool Result { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckNode
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckNode() { }
+        public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
+        public string? Detail { get; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public string Name { get; init; }
+        public bool Result { get; }
+        public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
+    }
+    public enum CheckNodeType
+    {
+        Permission = 0,
+        Expression = 1,
+        Relation = 2,
+        TupleToUserSet = 3,
+        Attribute = 4,
+        Function = 5,
     }
     [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
@@ -197,6 +233,7 @@ namespace Valtuutus.Core.Engines.Check
     public interface ICheckEngine
     {
         System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken);
     }
     public enum RelationType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -173,7 +173,41 @@ namespace Valtuutus.Core.Engines.Check
     {
         public CheckEngine(Valtuutus.Core.Data.IDataReaderProvider reader, Valtuutus.Core.Schemas.Schema schema) { }
         public System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckExplainResult
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckExplainResult() { }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public bool Result { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckNode
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckNode() { }
+        public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
+        public string? Detail { get; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public string Name { get; init; }
+        public bool Result { get; }
+        public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
+    }
+    public enum CheckNodeType
+    {
+        Permission = 0,
+        Expression = 1,
+        Relation = 2,
+        TupleToUserSet = 3,
+        Attribute = 4,
+        Function = 5,
     }
     [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
@@ -199,6 +233,7 @@ namespace Valtuutus.Core.Engines.Check
     public interface ICheckEngine
     {
         System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken);
     }
     public enum RelationType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -173,7 +173,41 @@ namespace Valtuutus.Core.Engines.Check
     {
         public CheckEngine(Valtuutus.Core.Data.IDataReaderProvider reader, Valtuutus.Core.Schemas.Schema schema) { }
         public System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckExplainResult
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckExplainResult() { }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public bool Result { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckNode
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckNode() { }
+        public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
+        public string? Detail { get; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public string Name { get; init; }
+        public bool Result { get; }
+        public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
+    }
+    public enum CheckNodeType
+    {
+        Permission = 0,
+        Expression = 1,
+        Relation = 2,
+        TupleToUserSet = 3,
+        Attribute = 4,
+        Function = 5,
     }
     [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
@@ -199,6 +233,7 @@ namespace Valtuutus.Core.Engines.Check
     public interface ICheckEngine
     {
         System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken);
     }
     public enum RelationType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -173,7 +173,41 @@ namespace Valtuutus.Core.Engines.Check
     {
         public CheckEngine(Valtuutus.Core.Data.IDataReaderProvider reader, Valtuutus.Core.Schemas.Schema schema) { }
         public System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckExplainResult
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckExplainResult() { }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public bool Result { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class CheckNode
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        public CheckNode() { }
+        public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
+        public string? Detail { get; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public string Name { get; init; }
+        public bool Result { get; }
+        public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
+    }
+    public enum CheckNodeType
+    {
+        Permission = 0,
+        Expression = 1,
+        Relation = 2,
+        TupleToUserSet = 3,
+        Attribute = 4,
+        Function = 5,
     }
     [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
@@ -199,6 +233,7 @@ namespace Valtuutus.Core.Engines.Check
     public interface ICheckEngine
     {
         System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken);
     }
     public enum RelationType

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -195,9 +195,13 @@ namespace Valtuutus.Core.Engines.Check
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Name { get; init; }
         public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
         public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
     }
     public enum CheckNodeType

--- a/tests/Valtuutus.Data.InMemory.Tests/CheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/CheckEngineExplainSpecs.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.InMemory.Tests;
+
+[Collection("InMemorySpecs")]
+public sealed class CheckEngineExplainSpecs : BaseCheckEngineExplainSpecs
+{
+    public CheckEngineExplainSpecs(InMemoryFixture fixture) : base(fixture) { }
+
+    protected override IValtuutusDataBuilder AddSpecificProvider(IServiceCollection services)
+        => services.AddInMemory();
+}

--- a/tests/Valtuutus.Data.Postgres.Tests/CheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/CheckEngineExplainSpecs.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.Postgres.Tests;
+
+[Collection("PostgreSqlSpec")]
+public sealed class CheckEngineExplainSpecs : BaseCheckEngineExplainSpecs
+{
+    public CheckEngineExplainSpecs(PostgresFixture fixture) : base(fixture) { }
+
+    protected override IValtuutusDataBuilder AddSpecificProvider(IServiceCollection services)
+        => services.AddPostgres(_ => ((IWithDbConnectionFactory)Fixture).DbFactory);
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/CheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/CheckEngineExplainSpecs.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+[Collection("SqlServerSpec")]
+public sealed class CheckEngineExplainSpecs : BaseCheckEngineExplainSpecs
+{
+    public CheckEngineExplainSpecs(SqlServerFixture fixture) : base(fixture) { }
+
+    protected override IValtuutusDataBuilder AddSpecificProvider(IServiceCollection services)
+        => services.AddSqlServer(_ => ((IWithDbConnectionFactory)Fixture).DbFactory);
+}

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
@@ -1,0 +1,474 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data;
+
+namespace Valtuutus.Tests.Shared;
+
+public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
+{
+    protected BaseCheckEngineExplainSpecs(IDatabaseFixture fixture) { Fixture = fixture; }
+    protected IDatabaseFixture Fixture { get; }
+    protected abstract IValtuutusDataBuilder AddSpecificProvider(IServiceCollection services);
+
+    private async ValueTask<ICheckEngine> CreateEngine(RelationTuple[] tuples, AttributeTuple[] attributes,
+        string? schema = null)
+    {
+        var services = new ServiceCollection()
+            .AddValtuutusCore(schema ?? TestsConsts.DefaultSchema);
+        AddSpecificProvider(services).AddConcurrentQueryLimit(3);
+        var sp = services.BuildServiceProvider();
+        var scope = sp.CreateScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+        if (tuples.Length == 0 && attributes.Length == 0) return engine;
+        var writer = scope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+        await writer.Write(tuples, attributes, default);
+        return engine;
+    }
+
+    public async Task InitializeAsync() => await Fixture.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Explain_DirectRelation_ReturnsTrueWithRelationNode()
+    {
+        var engine = await CreateEngine(
+            [new RelationTuple("workspace", "expl-1", "owner", "user", "alice")],
+            []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-1",
+            Permission = "delete",     // delete := owner
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        result.Root.Type.Should().Be(CheckNodeType.Permission);
+        result.Root.Name.Should().Be("delete");
+        result.Root.Result.Should().BeTrue();
+        result.Root.Children.Should().HaveCount(1);
+        var ownerNode = result.Root.Children[0];
+        ownerNode.Type.Should().Be(CheckNodeType.Relation);
+        ownerNode.Name.Should().Be("owner");
+        ownerNode.Detail.Should().Be("direct tuple");
+        ownerNode.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Explain_DirectRelation_ReturnsFalseWithNoTupleDetail()
+    {
+        var engine = await CreateEngine([], []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-2",
+            Permission = "delete",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+        result.Root.Children.Should().HaveCount(1);
+        var ownerNode = result.Root.Children[0];
+        ownerNode.Type.Should().Be(CheckNodeType.Relation);
+        ownerNode.Name.Should().Be("owner");
+        ownerNode.Detail.Should().Be("no matching tuple");
+        ownerNode.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Explain_UnionExpression_ShortCircuitsAfterFirstTrue()
+    {
+        // view := public or owner or admin or member
+        // alice is owner; public=false
+        var engine = await CreateEngine(
+            [new RelationTuple("workspace", "expl-3", "owner", "user", "alice")],
+            [new AttributeTuple("workspace", "expl-3", "public", System.Text.Json.Nodes.JsonValue.Create(false))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-3",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        result.Root.Name.Should().Be("view");
+
+        // Grammar parses "a or b or c or d" as a left-associative binary tree.
+        // The owner node must appear somewhere in the tree.
+        // We don't assert owner.Result because with real async DB backends the owner
+        // branch may be cancelled before its query returns if another branch wins the race first.
+        var ownerNode = FindNode(result.Root, n => n.Name == "owner");
+        ownerNode.Should().NotBeNull("owner relation should be present in tree");
+
+        // Public attribute evaluated to false (alice is not public-access).
+        // We search by name only: if the branch was cancelled before CheckAttribute ran,
+        // the node type stays as Permission (set by GetNodeInfo) instead of Attribute.
+        var publicAttrNode = FindNode(result.Root, n => n.Name == "public");
+        publicAttrNode.Should().NotBeNull("public node should exist in tree");
+        publicAttrNode!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Explain_IntersectExpression_ReturnsFalseWhenFirstChildFalse()
+    {
+        // comment := member and public (binary intersect — exactly 2 children)
+        // alice is NOT a member; public=true
+        var engine = await CreateEngine(
+            [],
+            [new AttributeTuple("workspace", "expl-4", "public", System.Text.Json.Nodes.JsonValue.Create(true))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-4",
+            Permission = "comment",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+        result.Root.Name.Should().Be("comment");
+        // Binary parse: exactly 2 top-level children
+        result.Root.Children.Should().HaveCount(2);
+        // member resolves false (no tuple), public resolves true or short-circuited
+        result.Root.Children.Should().Contain(n => n.Name == "member" && !n.Result);
+    }
+
+    [Fact]
+    public async Task Explain_AttributeCheck_ReturnsAttributeNodeWithDetail()
+    {
+        var engine = await CreateEngine(
+            [],
+            [new AttributeTuple("workspace", "expl-5", "public", System.Text.Json.Nodes.JsonValue.Create(true))]);
+
+        // view := public or owner or admin or member — public is true
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-5",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        // The attribute node is nested inside the binary expression tree
+        var publicNode = FindNode(result.Root, n => n.Type == CheckNodeType.Attribute && n.Name == "public");
+        publicNode.Should().NotBeNull();
+        publicNode!.Detail.Should().Be("attribute=True");
+        publicNode.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Explain_FunctionCall_ReturnsFunctionNodeWithDetail()
+    {
+        // project.edit := (parent.admin or team.member) and isActiveStatus(status)
+        // Seed: alice is parent workspace admin AND status=1
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-6", "parent", "workspace", "expl-ws6"),
+                new RelationTuple("workspace", "expl-ws6", "admin", "user", "alice")
+            ],
+            [new AttributeTuple("project", "expl-6", "status", System.Text.Json.Nodes.JsonValue.Create(1))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-6",
+            Permission = "edit",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        var fnNode = FindNodeByType(result.Root, CheckNodeType.Function);
+        fnNode.Should().NotBeNull();
+        fnNode!.Name.Should().Be("isActiveStatus");
+        fnNode.Detail.Should().Be("fn result=True");
+        fnNode.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Explain_TupleToUserSet_ResolvesViaRelatedEntity()
+    {
+        // project.edit := (parent.admin or ...) and isActiveStatus(status)
+        // alice is admin of workspace ws1; project parent is ws1; status=1
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-7", "parent", "workspace", "expl-ws7"),
+                new RelationTuple("workspace", "expl-ws7", "admin", "user", "alice")
+            ],
+            [new AttributeTuple("project", "expl-7", "status", System.Text.Json.Nodes.JsonValue.Create(1))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-7",
+            Permission = "edit",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        var ttuNode = FindNodeByType(result.Root, CheckNodeType.TupleToUserSet);
+        ttuNode.Should().NotBeNull();
+        ttuNode!.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Explain_NoInfiniteRecursion_ReturnsFiniteTree()
+    {
+        var engine = await CreateEngine(
+            [new RelationTuple("project", "expl-8", "member", "user", "alice")],
+            []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-8",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        result.Root.Name.Should().Be("view");
+    }
+
+    [Fact]
+    public async Task Explain_NegateExpression_ReturnsNegatedResult()
+    {
+        // Custom schema: permission banned := not(member)
+        // alice is NOT a member → banned = true
+        const string negateSchema = """
+            entity user {}
+            entity doc {
+                relation member @user;
+                permission banned := not(member);
+            }
+            """;
+        var engine = await CreateEngine([], [], negateSchema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "doc", EntityId = "expl-n1",
+            Permission = "banned",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        result.Root.Children.Should().HaveCount(1);
+        var memberNode = result.Root.Children[0];
+        memberNode.Name.Should().Be("member");
+        memberNode.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Explain_MemoizedSubCheck_RecordsMemoizedDetail()
+    {
+        // edit := owner and view; view := owner
+        // The "owner" relation is evaluated twice in one Explain call —
+        // the second evaluation should hit the memo cache.
+        const string memoSchema = """
+            entity user {}
+            entity doc {
+                relation owner @user;
+                permission view := owner;
+                permission edit := owner and view;
+            }
+            """;
+        var engine = await CreateEngine(
+            [new RelationTuple("doc", "expl-m1", "owner", "user", "alice")],
+            [], memoSchema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "doc", EntityId = "expl-m1",
+            Permission = "edit",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        var memoizedNode = FindNode(result.Root, n => n.Detail == "memoized");
+        memoizedNode.Should().NotBeNull("a repeated sub-check should be recorded as memoized");
+    }
+
+    [Fact]
+    public async Task Explain_DepthLimitReached_ReturnsFalseWithDetail()
+    {
+        var engine = await CreateEngine(
+            [new RelationTuple("workspace", "expl-dl1", "owner", "user", "alice")],
+            []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-dl1",
+            Permission = "delete",
+            SubjectType = "user", SubjectId = "alice",
+            Depth = 0
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+        result.Root.Detail.Should().Be("depth limit reached");
+    }
+
+    [Fact]
+    public async Task Explain_IndirectRelationViaSubRelation_ResolvesAndRecordsChildNode()
+    {
+        // project.member @user @team#member — indirect path via team
+        // alice is a direct member of team expl-t9; team is project member via #member
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-9", "member", "team", "expl-t9", "member"),
+                new RelationTuple("team", "expl-t9", "member", "user", "alice"),
+            ],
+            []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-9",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        // The Relation node for "member" resolves via the indirect (sub-relation) path
+        var memberRelationNode = FindNode(result.Root, n => n.Type == CheckNodeType.Relation && n.Name == "member");
+        memberRelationNode.Should().NotBeNull("member relation node should appear in tree");
+        memberRelationNode!.Children.Should().NotBeEmpty("indirect path creates child nodes");
+    }
+
+    [Fact]
+    public async Task Explain_MissingAttribute_ReturnsAttributeFalseDetail()
+    {
+        // public attribute not seeded — CheckAttribute gets null from the reader
+        var engine = await CreateEngine([], []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-attr1",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+        var publicNode = FindNode(result.Root, n => n.Type == CheckNodeType.Attribute && n.Name == "public");
+        publicNode.Should().NotBeNull("public attribute node should appear in tree");
+        publicNode!.Detail.Should().Be("attribute=False");
+    }
+
+    [Fact]
+    public async Task Explain_TupleToUserSet_SlowPathSingleRelation_RecordsNode()
+    {
+        // project.edit := (parent.admin or team.member) and isActiveStatus(status)
+        // team.member has sub-relation paths (@group#member) → fast path skipped
+        // One team tuple → slow path single-relation branch
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-10", "team", "team", "expl-t10"),
+                new RelationTuple("team", "expl-t10", "member", "user", "alice"),
+            ],
+            [new AttributeTuple("project", "expl-10", "status", System.Text.Json.Nodes.JsonValue.Create(1))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-10",
+            Permission = "edit",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        // parent.admin (fast-path) is also a TTU node but returns false — find team.member specifically
+        var ttuNode = FindNode(result.Root, n => n.Type == CheckNodeType.TupleToUserSet && n.Name == "team.member");
+        ttuNode.Should().NotBeNull("TTU node for team.member should appear in tree");
+        ttuNode!.Result.Should().BeTrue();
+        ttuNode.Children.Should().NotBeEmpty("slow-path creates child nodes for the resolved relation");
+    }
+
+    [Fact]
+    public async Task Explain_SubjectTypeCannotReach_ReturnsFalseWithDetail()
+    {
+        // "organization" cannot reach workspace.delete (only users can via owner relation)
+        var engine = await CreateEngine([], []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "workspace", EntityId = "expl-sc1",
+            Permission = "delete",
+            SubjectType = "organization", SubjectId = "org-1"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+        result.Root.Detail.Should().Be("subject type cannot reach permission");
+    }
+
+    [Fact]
+    public async Task Explain_IndirectRelation_MultipleIndirectPaths_RecordsAllChildren()
+    {
+        // project.member has @user @team#member — two indirect team tuples, alice in one
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-11", "member", "team", "expl-t11a", "member"),
+                new RelationTuple("project", "expl-11", "member", "team", "expl-t11b", "member"),
+                new RelationTuple("team", "expl-t11a", "member", "user", "alice"),
+            ],
+            []);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-11",
+            Permission = "view",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        // The member Relation node resolves via multiple indirect paths
+        var memberNode = FindNode(result.Root, n => n.Type == CheckNodeType.Relation && n.Name == "member");
+        memberNode.Should().NotBeNull();
+        memberNode!.Children.Count.Should().BeGreaterThanOrEqualTo(2, "one child per indirect relation tuple");
+    }
+
+    [Fact]
+    public async Task Explain_TupleToUserSet_MultipleRelations_ParallelPath_RecordsNodes()
+    {
+        // project.edit with two team tuples — team.member has sub-relation paths so batch
+        // fast-path is skipped; falls through to parallel multi-relation path in CheckTupleToUserSet
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("project", "expl-12", "team", "team", "expl-t12a"),
+                new RelationTuple("project", "expl-12", "team", "team", "expl-t12b"),
+                new RelationTuple("team", "expl-t12a", "member", "user", "alice"),
+            ],
+            [new AttributeTuple("project", "expl-12", "status", System.Text.Json.Nodes.JsonValue.Create(1))]);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "project", EntityId = "expl-12",
+            Permission = "edit",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+        var ttuNode = FindNode(result.Root, n => n.Type == CheckNodeType.TupleToUserSet && n.Name == "team.member");
+        ttuNode.Should().NotBeNull();
+        ttuNode!.Result.Should().BeTrue();
+        ttuNode.Children.Count.Should().BeGreaterThanOrEqualTo(2, "one child per relation tuple in the parallel path");
+    }
+
+    private static CheckNode? FindNodeByType(CheckNode root, CheckNodeType type)
+    {
+        if (root.Type == type) return root;
+        foreach (var child in root.Children)
+        {
+            var found = FindNodeByType(child, type);
+            if (found is not null) return found;
+        }
+        return null;
+    }
+
+    private static CheckNode? FindNode(CheckNode root, Func<CheckNode, bool> predicate)
+    {
+        if (predicate(root)) return root;
+        foreach (var child in root.Children)
+        {
+            var found = FindNode(child, predicate);
+            if (found is not null) return found;
+        }
+        return null;
+    }
+}

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineExplainSpecs.cs
@@ -131,10 +131,12 @@ public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
 
         result.Result.Should().BeFalse();
         result.Root.Name.Should().Be("comment");
-        // Binary parse: exactly 2 top-level children
-        result.Root.Children.Should().HaveCount(2);
+        // Intersect wraps children under a single "and" expression node
+        result.Root.Children.Should().HaveCount(1);
+        result.Root.Children[0].Name.Should().Be("and");
+        result.Root.Children[0].Type.Should().Be(CheckNodeType.Expression);
         // member resolves false (no tuple), public resolves true or short-circuited
-        result.Root.Children.Should().Contain(n => n.Name == "member" && !n.Result);
+        result.Root.Children[0].Children.Should().Contain(n => n.Name == "member" && !n.Result);
     }
 
     [Fact]
@@ -448,6 +450,103 @@ public abstract class BaseCheckEngineExplainSpecs : IAsyncLifetime
         ttuNode.Should().NotBeNull();
         ttuNode!.Result.Should().BeTrue();
         ttuNode.Children.Count.Should().BeGreaterThanOrEqualTo(2, "one child per relation tuple in the parallel path");
+    }
+
+    [Fact]
+    public async Task Explain_UnionFailed_NoDuplicatedNodes()
+    {
+        // read := viewer or editor or admin — three-way union, none granted
+        const string schema = """
+            entity user {}
+            entity resource {
+                relation viewer @user;
+                relation editor @user;
+                relation admin @user;
+                permission read := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine([], [], schema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "res-1",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeFalse();
+
+        // Each relation should appear exactly once — no duplicate nodes with the same name.
+        var allNodes = CollectAllNodes(result.Root);
+        var nameGroups = allNodes.GroupBy(n => n.Name).Where(g => g.Count() > 1).ToList();
+        nameGroups.Should().BeEmpty("each relation name should appear at most once in the tree");
+
+        // All three leaf relations must be present and failed.
+        foreach (var rel in new[] { "viewer", "editor", "admin" })
+        {
+            var node = FindNode(result.Root, n => n.Name == rel);
+            node.Should().NotBeNull($"{rel} node should exist in tree");
+            node!.Result.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task Explain_RbacTupleToUserSet_ShowsRoleChildNodes()
+    {
+        // RBAC schema: admin/editor/viewer are @role#assignee (tuple-to-userset)
+        // alice is assignee of admin_role, which has admin on resource:api
+        const string rbacSchema = """
+            entity user {}
+            entity role {
+                relation assignee @user;
+            }
+            entity resource {
+                relation admin  @role#assignee;
+                relation editor @role#assignee;
+                relation viewer @role#assignee;
+                permission manage := admin;
+                permission write  := editor or admin;
+                permission read   := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("role", "admin_role", "assignee", "user", "alice"),
+                new RelationTuple("role", "editor_role", "assignee", "user", "bob"),
+                new RelationTuple("role", "viewer_role", "assignee", "user", "charlie"),
+                new RelationTuple("resource", "api", "admin", "role", "admin_role", "assignee"),
+                new RelationTuple("resource", "api", "editor", "role", "editor_role", "assignee"),
+                new RelationTuple("resource", "api", "viewer", "role", "viewer_role", "assignee"),
+            ],
+            [], rbacSchema);
+
+        var result = await engine.Explain(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "api",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, CancellationToken.None);
+
+        result.Result.Should().BeTrue();
+
+        // admin is a plain relation reference (not TTU notation), so its node type is Relation.
+        // It resolves via the indirect sub-relation path: admin @role#assignee → checks role:admin_role#assignee.
+        var adminNode = FindNode(result.Root, n => n.Name == "admin" && n.Type == CheckNodeType.Relation);
+        adminNode.Should().NotBeNull("admin Relation node should exist");
+        adminNode!.Children.Should().NotBeEmpty("admin should have a child showing role:admin_role was checked via sub-relation path");
+
+        var childOfAdmin = adminNode.Children[0];
+        childOfAdmin.EntityType.Should().Be("role");
+        childOfAdmin.EntityId.Should().Be("admin_role");
+        childOfAdmin.Result.Should().BeTrue();
+    }
+
+    private static List<CheckNode> CollectAllNodes(CheckNode root)
+    {
+        var result = new List<CheckNode> { root };
+        foreach (var child in root.Children)
+            result.AddRange(CollectAllNodes(child));
+        return result;
     }
 
     private static CheckNode? FindNodeByType(CheckNode root, CheckNodeType type)

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -765,6 +765,40 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
         result.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task Check_RbacViaSubRelation_ReturnsTrue()
+    {
+        // admin @role#assignee — "user" is not a direct entity, reaches via sub-relation path.
+        // Regression test: IsSubjectTypeAllowedInRelation was blocking this path early.
+        const string rbacSchema = """
+            entity user {}
+            entity role {
+                relation assignee @user;
+            }
+            entity resource {
+                relation admin  @role#assignee;
+                relation editor @role#assignee;
+                relation viewer @role#assignee;
+                permission read := viewer or editor or admin;
+            }
+            """;
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("role", "admin_role", "assignee", "user", "alice"),
+                new RelationTuple("resource", "api", "admin", "role", "admin_role", "assignee"),
+            ],
+            [], rbacSchema);
+
+        var result = await engine.Check(new CheckRequest
+        {
+            EntityType = "resource", EntityId = "api",
+            Permission = "read",
+            SubjectType = "user", SubjectId = "alice"
+        }, default);
+
+        result.Should().BeTrue();
+    }
+
     public static TheoryData<string, decimal?, bool> ContextAccessTheoryData = new()
     {
         {"withdraw_amount", 500.0m, true},


### PR DESCRIPTION
## Summary

- Bumps version to `0.9.0-beta`
- Adds release notes for new `Explain()` feature and TTU bug fix

## What's new in 0.9.0-beta

- **NEW:** `ICheckEngine.Explain()` — returns a full resolution tree showing why a permission check passed or failed
- **FIX:** TTU (tuple-to-userset) nodes now correctly terminate in ReBAC explain graphs

## Release process

After merging this PR to `main`, cut the GitHub release:

```bash
gh release create v0.9.0-beta --title "v0.9.0-beta" --notes "See PR for full changelog."
```

The publish workflow is triggered by the GitHub release event (not the merge itself).