### PR TITLE
fix: exclude external libraries from coverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: dotnet build Valtuutus.sln --no-incremental
       - name: Test with coverage
-        run: dotnet-coverage collect 'dotnet test Valtuutus.sln -c Release --logger:"trx;LogFilePrefix=testResults"' -f cobertura -o 'coverage.xml'
+        run: dotnet-coverage collect 'dotnet test Valtuutus.sln -c Release --logger:"trx;LogFilePrefix=testResults"' -f cobertura -o 'coverage.xml' -s coverage.runsettings
       - name: Coverage summary
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*Valtuutus\..*\.dll$</ModulePath>
+              </Include>
+              <Exclude>
+                <ModulePath>.*Tests.*\.dll$</ModulePath>
+                <ModulePath>.*testhost.*</ModulePath>
+              </Exclude>
+            </ModulePaths>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -5,15 +5,11 @@
       <DataCollector friendlyName="Code Coverage">
         <Configuration>
           <CodeCoverage>
-            <ModulePaths>
+            <Sources>
               <Include>
-                <ModulePath>.*Valtuutus\..*\.dll$</ModulePath>
+                <Source>.*[/\\]src[/\\]Valtuutus.*</Source>
               </Include>
-              <Exclude>
-                <ModulePath>.*Tests.*\.dll$</ModulePath>
-                <ModulePath>.*testhost.*</ModulePath>
-              </Exclude>
-            </ModulePaths>
+            </Sources>
           </CodeCoverage>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
## Summary

- Adds `coverage.runsettings` with `ModulePaths` include/exclude rules
- `dotnet-coverage` now instruments only `Valtuutus.*.dll` assemblies, excluding test projects and `testhost`
- Passes the settings file to the collect command via `-s coverage.runsettings`