### PR TITLE
ci: post coverage for changed files only, fix fork PR support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,18 @@ jobs:
           badge: true
           format: markdown
           output: both
-      - name: Add coverage PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Upload coverage artifact
         if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
         with:
-          recreate: true
-          path: code-coverage-results.md
+          name: coverage_results
+          path: coverage.xml
+      - name: Upload PR event
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr_event
+          path: ${{ github.event_path }}
       - name: Upload Test Result Files
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/post_coverage.yml
+++ b/.github/workflows/post_coverage.yml
@@ -1,0 +1,131 @@
+name: Post Coverage Results
+
+on:
+  workflow_run:
+    workflows: [Build and test]
+    types: [completed]
+
+concurrency:
+  group: post-coverage-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  post_coverage:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      COVERAGE_ARTIFACT: coverage_results
+      PR_EVENT: pr_event
+    steps:
+      - name: Download coverage results
+        uses: dawidd6/action-download-artifact@v20
+        with:
+          name: ${{ env.COVERAGE_ARTIFACT }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Download PR event
+        uses: dawidd6/action-download-artifact@v20
+        with:
+          name: ${{ env.PR_EVENT }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR info
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const event = JSON.parse(fs.readFileSync('event.json', {encoding: 'utf8'}));
+            core.exportVariable('PR_NUMBER', event.number);
+
+      - name: Get changed source files
+        uses: actions/github-script@v9
+        id: changed
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const changed = files
+              .filter(f => f.filename.startsWith('src/') && f.filename.endsWith('.cs'))
+              .map(f => f.filename);
+            require('fs').writeFileSync('changed_files.txt', changed.join('\n'));
+            core.setOutput('count', changed.length);
+
+      - name: Filter coverage to changed files
+        run: |
+          if [ "${{ steps.changed.outputs.count }}" = "0" ]; then
+            echo "No changed source files — using full project coverage"
+            cp coverage.xml coverage-pr.xml
+            exit 0
+          fi
+          python3 << 'PYEOF'
+          import xml.etree.ElementTree as ET, shutil
+
+          with open('changed_files.txt') as f:
+              changed = {line.strip().replace('\\', '/') for line in f if line.strip()}
+
+          def matches(filename):
+              fn = filename.replace('\\', '/').lstrip('./')
+              return any(fn.endswith(cf) or cf.endswith(fn) for cf in changed)
+
+          tree = ET.parse('coverage.xml')
+          root = tree.getroot()
+
+          total_valid = total_covered = branches_valid = branches_covered = 0
+
+          for packages in root.findall('.//packages'):
+              for pkg in list(packages.findall('package')):
+                  for classes in pkg.findall('classes'):
+                      for cls in list(classes.findall('class')):
+                          if not matches(cls.get('filename', '')):
+                              classes.remove(cls)
+                              continue
+                          for line in cls.findall('.//line'):
+                              total_valid += 1
+                              if int(line.get('hits', '0')) > 0:
+                                  total_covered += 1
+                              if line.get('branch') == 'true':
+                                  try:
+                                      nums = line.get('condition-coverage', '0% (0/0)').split('(')[1].rstrip(')').split('/')
+                                      branches_covered += int(nums[0])
+                                      branches_valid += int(nums[1])
+                                  except (IndexError, ValueError):
+                                      pass
+                  if not pkg.find('.//class'):
+                      packages.remove(pkg)
+
+          if total_valid == 0:
+              print('No coverage data for changed files — using full project coverage')
+              shutil.copy('coverage.xml', 'coverage-pr.xml')
+          else:
+              line_rate = total_covered / total_valid
+              branch_rate = branches_covered / branches_valid if branches_valid else 0
+              root.set('lines-valid', str(total_valid))
+              root.set('lines-covered', str(total_covered))
+              root.set('line-rate', f'{line_rate:.4f}')
+              root.set('branches-valid', str(branches_valid))
+              root.set('branches-covered', str(branches_covered))
+              root.set('branch-rate', f'{branch_rate:.4f}')
+              tree.write('coverage-pr.xml', encoding='utf-8', xml_declaration=True)
+          PYEOF
+
+      - name: Coverage summary (changed files)
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage-pr.xml
+          badge: true
+          format: markdown
+          output: both
+
+      - name: Post coverage PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ env.PR_NUMBER }}
+          recreate: true
+          path: code-coverage-results.md


### PR DESCRIPTION
## Summary

- **Changed-files coverage**: PR comments now show coverage only for `.cs` files modified in the PR (via GitHub API diff), not the entire project — fallback to full coverage if no source files changed or coverage data is empty
- **Fork PR support**: splits into the same two-workflow pattern used for benchmarks
  - `build.yml` uploads `coverage.xml` + `event.json` as artifacts (PR builds only); keeps the irongut summary in the job log for all builds
  - `post_coverage.yml` triggers on `workflow_run` — always runs in the base-repo context so `GITHUB_TOKEN` has full write access, works for fork PRs

## How the filter works

1. GitHub API (`pulls.listFiles`) fetches the exact set of changed `.cs` files under `src/`
2. Python script walks the Cobertura XML, removes `<class>` elements whose `filename` doesn't match, recalculates `lines-valid`/`lines-covered`/`branches-*` on the root element
3. `irongut/CodeCoverageSummary` reads the filtered XML; `marocchino/sticky-pull-request-comment` posts it with the PR number from `event.json`