### PR TITLE
ci: fix base_benchmarks — remove --err, add name/concurrency/permissions

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Run Benchmarks
         run: |
           dotnet run -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
+      - name: Strip failed benchmarks from results
+        run: |
+          for f in BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do
+            jq '.Benchmarks |= map(select(.Statistics != null))' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          done
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher
         env:
@@ -38,17 +43,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for f in BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do
-            bencher run \
-            --project valtuutus \
-            --token "$BENCHER_API_TOKEN" \
-            --branch "${{ github.ref_name }}" \
-            --testbed ubuntu-latest \
-            --threshold-measure latency \
-            --threshold-test t_test \
-            --threshold-max-sample-size 64 \
-            --threshold-upper-boundary 0.99 \
-            --thresholds-reset \
-            --adapter c_sharp_dot_net \
-            --file "$f" \
-            --github-actions "$GITHUB_TOKEN"
+            count=$(jq '.Benchmarks | length' "$f")
+            if [ "$count" -gt 0 ]; then
+              bencher run \
+              --project valtuutus \
+              --token "$BENCHER_API_TOKEN" \
+              --branch "${{ github.ref_name }}" \
+              --testbed ubuntu-latest \
+              --threshold-measure latency \
+              --threshold-test t_test \
+              --threshold-max-sample-size 64 \
+              --threshold-upper-boundary 0.99 \
+              --thresholds-reset \
+              --adapter c_sharp_dot_net \
+              --file "$f" \
+              --github-actions "$GITHUB_TOKEN"
+            else
+              echo "Skipping $f — no successful benchmark results"
+            fi
           done

--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -1,8 +1,17 @@
+name: Track Base Branch Benchmarks
+
 on:
   push:
     branches:
       - main
       - dev
+
+concurrency:
+  group: base-benchmarks-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  checks: write
 
 jobs:
   benchmark_base_branch:
@@ -39,7 +48,6 @@ jobs:
             --threshold-max-sample-size 64 \
             --threshold-upper-boundary 0.99 \
             --thresholds-reset \
-            --err \
             --adapter c_sharp_dot_net \
             --file "$f" \
             --github-actions "$GITHUB_TOKEN"


### PR DESCRIPTION
## Summary

Two commits fixing \`base_benchmarks.yml\`, which was running on main/dev but never received the updates applied to the other benchmark workflows.

**Commit 1** — mirrors the \`post_pr_benchmarks.yml\` fixes from #170:
- Remove \`--err\` so a regression alert doesn't fail the workflow
- Add \`name:\` (was showing as filename in GitHub UI)
- Add \`concurrency:\` group to cancel queued runs on newer pushes
- Add \`permissions: checks: write\` explicitly

**Commit 2** — fixes the actual 400 Bad Request from Bencher:

When a benchmark crashes during BenchmarkDotNet's pilot phase (e.g. \`Check_Diamond\` throws \`TaskCanceledException\`), the result JSON contains entries with \`null\` Statistics. Bencher's \`c_sharp_dot_net\` adapter rejects the **entire file** with 400 Bad Request and \`"Are you sure c_sharp_dot_net is the right adapter?"\` — not a regression, not a missing file, a parse failure on the null entry.

Fix: a \`jq\` pre-pass strips \`null\`-Statistics entries from each result file before bencher sees it. Files left with zero benchmarks are skipped with a log message instead of passed to bencher.