### PR TITLE
fix: don't cancel memoized tasks via short-circuit CTS in CheckEngine

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -375,8 +375,8 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             var child = children[i];
             var childNode = childNodes?[i];
             rawTasks[i] = child.Type == PermissionNodeType.Expression
-                ? CheckExpression(req, child, memo, childNode, cancellationToken)
-                : CheckLeaf(req, child, memo, childNode, cancellationToken);
+                ? CheckExpression(req, child, memo, childNode, ct)
+                : CheckLeaf(req, child, memo, childNode, ct);
             tasks[i] = isUnion
                 ? rawTasks[i].ContinueWith(
                     static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
@@ -613,7 +613,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, computedUserSetRelation, memo, childNode, cancellationToken)
+            }, computedUserSetRelation, memo, childNode, ct)
             .ContinueWith(
                 static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                 innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
@@ -726,7 +726,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
-            }, memo, childNode, cancellationToken)
+            }, memo, childNode, ct)
             .ContinueWith(
                 static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
                 innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -1097,4 +1097,72 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
 
         result.Should().BeTrue();
     }
+
+    // Diamond pattern: both `owner` and `editor` are TTU pointing to the same group#member.
+    // A union short-circuit (view) must not cancel the memoized task that the intersection (admin) also awaits.
+    private const string DiamondSchema = """
+        entity user {}
+        entity group {
+            relation member @user;
+        }
+        entity folder {
+            relation owner @group#member;
+            relation editor @group#member;
+            permission view  := owner or editor;
+            permission admin := owner and editor;
+        }
+        """;
+
+    [Fact]
+    public async Task Check_Diamond_TTU_Intersection_ReturnsTrue_WhenSubjectIsGroupMember()
+    {
+        var engine = await CreateEngine([
+            new RelationTuple("group",  "g1", "member", "user", "alice"),
+            new RelationTuple("folder", "f1", "owner",  "group", "g1", "member"),
+            new RelationTuple("folder", "f1", "editor", "group", "g1", "member"),
+        ], [], DiamondSchema);
+
+        var result = await engine.Check(
+            new CheckRequest("folder", "f1", "admin", "user", "alice"), default);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Check_Diamond_TTU_Union_ReturnsTrue_WhenSubjectIsGroupMember()
+    {
+        var engine = await CreateEngine([
+            new RelationTuple("group",  "g1", "member", "user", "alice"),
+            new RelationTuple("folder", "f1", "owner",  "group", "g1", "member"),
+            new RelationTuple("folder", "f1", "editor", "group", "g1", "member"),
+        ], [], DiamondSchema);
+
+        var result = await engine.Check(
+            new CheckRequest("folder", "f1", "view", "user", "alice"), default);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SubjectPermission_Diamond_TTU_ReturnsBothTrue_WhenSubjectIsGroupMember()
+    {
+        // SubjectPermission checks view+admin concurrently with a shared CheckMemo.
+        // view (union) short-circuits as soon as `owner` is true, cancelling its pooled CTS.
+        // admin (intersection) must still resolve correctly from the same memoized group#member task.
+        var engine = await CreateEngine([
+            new RelationTuple("group",  "g1", "member", "user", "alice"),
+            new RelationTuple("folder", "f1", "owner",  "group", "g1", "member"),
+            new RelationTuple("folder", "f1", "editor", "group", "g1", "member"),
+        ], [], DiamondSchema);
+
+        var result = await engine.SubjectPermission(
+            new SubjectPermissionRequest
+            {
+                EntityType = "folder", EntityId = "f1",
+                SubjectType = "user", SubjectId = "alice"
+            }, default);
+
+        result.Should().ContainKey("view").WhoseValue.Should().BeTrue();
+        result.Should().ContainKey("admin").WhoseValue.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

- In `CheckExpressionChild`, `CheckRelation`, and `CheckTupleToUserSet`, parallel work tasks were started with the pooled short-circuit `cancellationToken`. When a union short-circuits (cancels the pooled CTS), any in-flight task stored in the shared `CheckMemo` was also canceled.
- Concurrent or subsequent checks hitting the same memo key would receive a canceled task and misinterpret it as a false/canceled result — most visible in diamond TTU patterns like `admin := owner and editor` checked alongside `view := owner or editor` via `SubjectPermission`.
- Fix: pass the outer `ct` to the actual work tasks; reserve the pooled `cancellationToken` for the `ContinueWith` short-circuit wrappers only. Memoized tasks are now unaffected by short-circuit cancellation.

## Test plan

- [x] `Check_Diamond_TTU_Intersection_ReturnsTrue_WhenSubjectIsGroupMember` — direct regression for the failing check
- [x] `Check_Diamond_TTU_Union_ReturnsTrue_WhenSubjectIsGroupMember` — union side of the diamond
- [x] `SubjectPermission_Diamond_TTU_ReturnsBothTrue_WhenSubjectIsGroupMember` — the concurrent shared-memo race condition
- [x] Full InMemory suite: 199/199 passing on net8/net9/net10