### PR TITLE
ci: collect coverage on push to dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - '**.md'
     branches:
       - main
+      - dev
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:


### PR DESCRIPTION
## Summary
- Add `dev` to push trigger branches in `build.yml` so coverage is collected on pushes to `dev` in addition to `main`