### PR TITLE
perf(core): reduce GC pressure in function check hot path

### DIFF
--- a/src/Valtuutus.Core/Data/EntityAttributeFilter.cs
+++ b/src/Valtuutus.Core/Data/EntityAttributeFilter.cs
@@ -1,6 +1,6 @@
 namespace Valtuutus.Core.Data;
 
-public class EntityAttributeFilter
+public readonly struct EntityAttributeFilter
 {
     public required string EntityType { get; init; }
     public string? EntityId { get; init; }
@@ -8,7 +8,7 @@ public class EntityAttributeFilter
     public required SnapToken SnapToken { get; init; }
 }
 
-public class EntityAttributesFilter
+public readonly struct EntityAttributesFilter
 {
     public required string EntityType { get; init; }
     public string? EntityId { get; init; }
@@ -16,7 +16,7 @@ public class EntityAttributesFilter
     public required SnapToken SnapToken { get; init; }
 }
 
-public class AttributeFilter
+public readonly struct AttributeFilter
 {
     public required string EntityType { get; init; }
     public required string Attribute { get; init; }

--- a/src/Valtuutus.Core/Data/RelationTupleFilter.cs
+++ b/src/Valtuutus.Core/Data/RelationTupleFilter.cs
@@ -1,6 +1,6 @@
 namespace Valtuutus.Core.Data;
 
-public record RelationTupleFilter
+public readonly record struct RelationTupleFilter
 {
     public required string EntityType { get; init; }
     public required string EntityId { get; init; }
@@ -11,7 +11,7 @@ public record RelationTupleFilter
     public required SnapToken SnapToken { get; init; }
 }
 
-public record EntityRelationFilter
+public readonly record struct EntityRelationFilter
 {
     public required string EntityType { get; init; }
     public required string Relation { get; init; }

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -368,51 +368,59 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         var cancellationToken = pooledCts.Token;
         var innerCts = pooledCts.InnerSource;
 
-        var rawTasks = new Task<bool>[count];
-        var tasks = new Task<bool>[count];
-        for (var i = 0; i < count; i++)
-        {
-            var child = children[i];
-            var childNode = childNodes?[i];
-            rawTasks[i] = child.Type == PermissionNodeType.Expression
-                ? CheckExpression(req, child, memo, childNode, ct)
-                : CheckLeaf(req, child, memo, childNode, ct);
-            tasks[i] = isUnion
-                ? rawTasks[i].ContinueWith(
-                    static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
-                    innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current)
-                : rawTasks[i].ContinueWith(
-                    static (t, s) => { if (!t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
-                    innerCts, cancellationToken, TaskContinuationOptions.NotOnFaulted, TaskScheduler.Current);
-        }
-
+        var rawTasks = ArrayPool<Task<bool>>.Shared.Rent(count);
+        var tasks = ArrayPool<Task<bool>>.Shared.Rent(count);
         try
         {
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-            if (childNodes is not null)
-                for (var i = 0; i < count; i++)
-                {
-                    childNodes[i].Result = results[i];
-                    node!._children.Add(childNodes[i]);
-                }
-            return isUnion ? results.AsSpan().Contains(true) : !results.AsSpan().Contains(false);
-        }
-        catch (OperationCanceledException)
-        {
-            if (childNodes is not null)
+            for (var i = 0; i < count; i++)
             {
-                for (var i = 0; i < count; i++)
-                {
-                    if (rawTasks[i].IsCompletedSuccessfully)
-                        childNodes[i].Result = rawTasks[i].Result;
-                    else
-                        childNodes[i].Detail = isUnion
-                            ? "skipped (evaluation stopped after a success)"
-                            : "skipped (evaluation stopped after a failure)";
-                    node!._children.Add(childNodes[i]);
-                }
+                var child = children[i];
+                var childNode = childNodes?[i];
+                rawTasks[i] = child.Type == PermissionNodeType.Expression
+                    ? CheckExpression(req, child, memo, childNode, ct)
+                    : CheckLeaf(req, child, memo, childNode, ct);
+                tasks[i] = isUnion
+                    ? rawTasks[i].ContinueWith(
+                        static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
+                        innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current)
+                    : rawTasks[i].ContinueWith(
+                        static (t, s) => { if (!t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
+                        innerCts, cancellationToken, TaskContinuationOptions.NotOnFaulted, TaskScheduler.Current);
             }
-            return isUnion;
+
+            try
+            {
+                var results = await Task.WhenAll(new ArraySegment<Task<bool>>(tasks, 0, count)).ConfigureAwait(false);
+                if (childNodes is not null)
+                    for (var i = 0; i < count; i++)
+                    {
+                        childNodes[i].Result = results[i];
+                        node!._children.Add(childNodes[i]);
+                    }
+                return isUnion ? results.AsSpan().Contains(true) : !results.AsSpan().Contains(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (childNodes is not null)
+                {
+                    for (var i = 0; i < count; i++)
+                    {
+                        if (rawTasks[i].IsCompletedSuccessfully)
+                            childNodes[i].Result = rawTasks[i].Result;
+                        else
+                            childNodes[i].Detail = isUnion
+                                ? "skipped (evaluation stopped after a success)"
+                                : "skipped (evaluation stopped after a failure)";
+                        node!._children.Add(childNodes[i]);
+                    }
+                }
+                return isUnion;
+            }
+        }
+        finally
+        {
+            ArrayPool<Task<bool>>.Shared.Return(rawTasks, clearArray: true);
+            ArrayPool<Task<bool>>.Shared.Return(tasks, clearArray: true);
         }
     }
 
@@ -443,7 +451,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             return false;
         }
 
-        var attributeArguments = leafExp.GetArgsAttributesNames();
+        var attributeArguments = leafExp.AttributeArgNames;
 
         var attributes = await reader.GetAttributes(
             new EntityAttributesFilter
@@ -600,46 +608,54 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             for (var i = 0; i < relations.Count; i++)
                 childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = computedUserSetRelation, EntityType = relations[i].SubjectType, EntityId = relations[i].SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
 
-        var tasks = new Task<bool>[relations.Count];
-        for (var i = 0; i < relations.Count; i++)
-        {
-            var relation = relations[i];
-            var childNode = childNodes?[i];
-            tasks[i] = CheckComputedUserSet(new CheckRequest
-            {
-                EntityType = relation.SubjectType,
-                EntityId = relation.SubjectId,
-                Permission = relation.SubjectRelation,
-                SubjectId = req.SubjectId,
-                SnapToken = req.SnapToken,
-                Depth = req.Depth
-            }, computedUserSetRelation, memo, childNode, ct)
-            .ContinueWith(
-                static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
-                innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
-        }
-
+        var taskCount = relations.Count;
+        var tasks = ArrayPool<Task<bool>>.Shared.Rent(taskCount);
         try
         {
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-            if (childNodes is not null)
-                for (var i = 0; i < childNodes.Length; i++)
+            for (var i = 0; i < taskCount; i++)
+            {
+                var relation = relations[i];
+                var childNode = childNodes?[i];
+                tasks[i] = CheckComputedUserSet(new CheckRequest
                 {
-                    childNodes[i].Result = results[i];
-                    node!._children.Add(childNodes[i]);
-                }
-            return results.AsSpan().Contains(true);
+                    EntityType = relation.SubjectType,
+                    EntityId = relation.SubjectId,
+                    Permission = relation.SubjectRelation,
+                    SubjectId = req.SubjectId,
+                    SnapToken = req.SnapToken,
+                    Depth = req.Depth
+                }, computedUserSetRelation, memo, childNode, ct)
+                .ContinueWith(
+                    static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
+                    innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
+            }
+
+            try
+            {
+                var results = await Task.WhenAll(new ArraySegment<Task<bool>>(tasks, 0, taskCount)).ConfigureAwait(false);
+                if (childNodes is not null)
+                    for (var i = 0; i < childNodes.Length; i++)
+                    {
+                        childNodes[i].Result = results[i];
+                        node!._children.Add(childNodes[i]);
+                    }
+                return results.AsSpan().Contains(true);
+            }
+            catch (OperationCanceledException)
+            {
+                if (childNodes is not null)
+                    for (var i = 0; i < childNodes.Length; i++)
+                    {
+                        if (tasks[i].IsCompletedSuccessfully)
+                            childNodes[i].Result = tasks[i].Result;
+                        node!._children.Add(childNodes[i]);
+                    }
+                return true;
+            }
         }
-        catch (OperationCanceledException)
+        finally
         {
-            if (childNodes is not null)
-                for (var i = 0; i < childNodes.Length; i++)
-                {
-                    if (tasks[i].IsCompletedSuccessfully)
-                        childNodes[i].Result = tasks[i].Result;
-                    node!._children.Add(childNodes[i]);
-                }
-            return true;
+            ArrayPool<Task<bool>>.Shared.Return(tasks, clearArray: true);
         }
     }
 
@@ -713,47 +729,55 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 childNodes[i] = new CheckNode { Type = CheckNodeType.Permission, Name = r.SubjectRelation ?? r.SubjectType, EntityType = r.SubjectType, EntityId = r.SubjectId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
 
-        var tasks = new Task<bool>[indirectRelations.Count];
-        var count = 0;
-        foreach (ref readonly var relation in indirectRelations.AsSpan())
-        {
-            var childNode = childNodes?[count];
-            tasks[count] = CheckInternal(new CheckRequest
-            {
-                EntityType = relation.SubjectType,
-                EntityId = relation.SubjectId,
-                Permission = relation.SubjectRelation,
-                SubjectId = req.SubjectId,
-                SnapToken = req.SnapToken,
-                Depth = req.Depth
-            }, memo, childNode, ct)
-            .ContinueWith(
-                static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
-                innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
-            count++;
-        }
-
+        var taskCount = indirectRelations.Count;
+        var tasks = ArrayPool<Task<bool>>.Shared.Rent(taskCount);
         try
         {
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-            if (childNodes is not null)
-                for (var i = 0; i < childNodes.Length; i++)
+            var count = 0;
+            foreach (ref readonly var relation in indirectRelations.AsSpan())
+            {
+                var childNode = childNodes?[count];
+                tasks[count] = CheckInternal(new CheckRequest
                 {
-                    childNodes[i].Result = results[i];
-                    node!._children.Add(childNodes[i]);
-                }
-            return results.AsSpan().Contains(true);
+                    EntityType = relation.SubjectType,
+                    EntityId = relation.SubjectId,
+                    Permission = relation.SubjectRelation,
+                    SubjectId = req.SubjectId,
+                    SnapToken = req.SnapToken,
+                    Depth = req.Depth
+                }, memo, childNode, ct)
+                .ContinueWith(
+                    static (t, s) => { if (t.Result) ((CancellationTokenSource)s!).Cancel(); return t.Result; },
+                    innerCts, cancellationToken, TaskContinuationOptions.NotOnCanceled, TaskScheduler.Current);
+                count++;
+            }
+
+            try
+            {
+                var results = await Task.WhenAll(new ArraySegment<Task<bool>>(tasks, 0, taskCount)).ConfigureAwait(false);
+                if (childNodes is not null)
+                    for (var i = 0; i < childNodes.Length; i++)
+                    {
+                        childNodes[i].Result = results[i];
+                        node!._children.Add(childNodes[i]);
+                    }
+                return results.AsSpan().Contains(true);
+            }
+            catch (OperationCanceledException)
+            {
+                if (childNodes is not null)
+                    for (var i = 0; i < childNodes.Length; i++)
+                    {
+                        if (tasks[i].IsCompletedSuccessfully)
+                            childNodes[i].Result = tasks[i].Result;
+                        node!._children.Add(childNodes[i]);
+                    }
+                return true;
+            }
         }
-        catch (OperationCanceledException)
+        finally
         {
-            if (childNodes is not null)
-                for (var i = 0; i < childNodes.Length; i++)
-                {
-                    if (tasks[i].IsCompletedSuccessfully)
-                        childNodes[i].Result = tasks[i].Result;
-                    node!._children.Add(childNodes[i]);
-                }
-            return true;
+            ArrayPool<Task<bool>>.Shared.Return(tasks, clearArray: true);
         }
     }
 

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -295,7 +295,7 @@ public sealed class LookupEntityEngine(
         if (fn is null) throw new InvalidOperationException();
         if (!node.IsContextValid(req.Context)) return ListPool<LookupEntityResult>.Rent();
 
-        var attributeArguments = node.GetArgsAttributesNames();
+        var attributeArguments = node.AttributeArgNames;
         var attributes = await reader.GetAttributesWithEntityIds(
             new EntityAttributesFilter
             {
@@ -344,7 +344,7 @@ public sealed class LookupEntityEngine(
             return ListPool<LookupEntityResult>.Rent();
         }
 
-        var attributeArguments = node.GetArgsAttributesNames();
+        var attributeArguments = node.AttributeArgNames;
 
         var cacheKey = req.EntityType + "\x00" + string.Join(",", attributeArguments) + "\x00" + req.Scope?.Relation + "\x00" + req.Scope?.SubjectType + "\x00" + req.Scope?.SubjectId;
         var attributesTask = req.AttributeCache.GetOrAdd(cacheKey,

--- a/src/Valtuutus.Core/Engines/LookupSubject/LookupSubjectEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupSubject/LookupSubjectEngine.cs
@@ -204,7 +204,7 @@ public sealed class LookupSubjectEngine(
             return new RelationOrAttributeTuples(new List<RelationTuple>());
         }
 
-        var attributeArguments = node.GetArgsAttributesNames();
+        var attributeArguments = node.AttributeArgNames;
 
         var attributes = await reader.GetAttributesWithEntityIds(
             new EntityAttributesFilter

--- a/src/Valtuutus.Core/Lang/ExpressionNode.cs
+++ b/src/Valtuutus.Core/Lang/ExpressionNode.cs
@@ -61,7 +61,7 @@ internal static class LangTypeExtensions
     }
 }
 
-internal record LiteralValueUnion : IComparable<LiteralValueUnion>
+internal record struct LiteralValueUnion : IComparable<LiteralValueUnion>
 {
     public LangType LiteralType { get; set; }
     public int? IntValue { get; set; }
@@ -69,34 +69,18 @@ internal record LiteralValueUnion : IComparable<LiteralValueUnion>
     public decimal? DecimalValue { get; set; }
     public bool? BooleanValue { get; set; }
 
-    public int CompareTo(LiteralValueUnion? other)
+    public int CompareTo(LiteralValueUnion other)
     {
-        if (ReferenceEquals(this, other))
-        {
-            return 0;
-        }
-
-        if (other is null)
-        {
-            return 1;
-        }
-
         if (LiteralType != other.LiteralType)
-        {
             throw new ArgumentException("Incompatible literal type comparison");
-        }
 
         var intValueComparison = Nullable.Compare(IntValue, other.IntValue);
         if (intValueComparison != 0)
-        {
             return intValueComparison;
-        }
 
         var stringValueComparison = string.Compare(StringValue, other.StringValue, StringComparison.Ordinal);
         if (stringValueComparison != 0)
-        {
             return stringValueComparison;
-        }
 
         return Nullable.Compare(DecimalValue, other.DecimalValue);
     }

--- a/src/Valtuutus.Core/Schemas/Function.cs
+++ b/src/Valtuutus.Core/Schemas/Function.cs
@@ -27,13 +27,8 @@ public record Function
     internal PooledDictionary<FunctionParameter, PermissionNodeExpArgument> CreateParamToArgMap(IList<PermissionNodeExpArgument> args)
     {
         var pooled = PooledDictionary<FunctionParameter, PermissionNodeExpArgument>.Rent();
-
-        var argsByOrder = new Dictionary<int, PermissionNodeExpArgument>(args.Count);
-        foreach (var arg in args) argsByOrder[arg.ArgOrder] = arg;
-
         foreach (var parameter in Parameters)
-            pooled.Dictionary[parameter] = argsByOrder[parameter.ParamOrder];
-
+            pooled.Dictionary[parameter] = args[parameter.ParamOrder];
         return pooled;
     }
 

--- a/src/Valtuutus.Core/Schemas/Permission.cs
+++ b/src/Valtuutus.Core/Schemas/Permission.cs
@@ -104,7 +104,7 @@ internal record PermissionNodeExpArgumentBooleanLiteral : PermissionNodeExpArgum
 
 internal record PermissionNodeLeafExp(string FunctionName, PermissionNodeExpArgument[] Args)
 {
-    internal string[] GetArgsAttributesNames() => Args
+    internal string[] AttributeArgNames { get; } = Args
         .Where(a => a.Type == PermissionNodeExpArgumentType.Attribute)
         .Cast<PermissionNodeExpArgumentAttribute>()
         .Select(x => x.AttributeName)

--- a/src/Valtuutus.Data.InMemory/AttributesStore.cs
+++ b/src/Valtuutus.Data.InMemory/AttributesStore.cs
@@ -88,6 +88,7 @@ internal sealed class AttributesStore : IDisposable
             foreach (var e in bucket)
             {
                 if (!IsVisible(e, snap)) continue;
+                if (filter.EntityId is not null && e.Attribute.EntityId != filter.EntityId) continue;
                 if (scopedEntityIds is not null && !scopedEntityIds.Contains(e.Attribute.EntityId)) continue;
                 var k = (e.Attribute.Attribute, e.Attribute.EntityId);
                 if (!result.ContainsKey(k)) result[k] = e.Attribute;

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -34,11 +34,8 @@ namespace Valtuutus.Core.Configuration
 namespace Valtuutus.Core.Data
 {
     [System.Runtime.CompilerServices.RequiredMember]
-    public class AttributeFilter
+    public readonly struct AttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public AttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -71,11 +68,8 @@ namespace Valtuutus.Core.Data
         public string? SubjectType { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributeFilter
+    public readonly struct EntityAttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         public string? EntityId { get; init; }
@@ -85,11 +79,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributesFilter
+    public readonly struct EntityAttributesFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributesFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string[] Attributes { get; init; }
         public string? EntityId { get; init; }
@@ -99,11 +90,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
+    public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityRelationFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityType { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -142,11 +130,8 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
+    public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public RelationTupleFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityId { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -34,11 +34,8 @@ namespace Valtuutus.Core.Configuration
 namespace Valtuutus.Core.Data
 {
     [System.Runtime.CompilerServices.RequiredMember]
-    public class AttributeFilter
+    public readonly struct AttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public AttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -71,11 +68,8 @@ namespace Valtuutus.Core.Data
         public string? SubjectType { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributeFilter
+    public readonly struct EntityAttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         public string? EntityId { get; init; }
@@ -85,11 +79,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributesFilter
+    public readonly struct EntityAttributesFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributesFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string[] Attributes { get; init; }
         public string? EntityId { get; init; }
@@ -99,11 +90,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
+    public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityRelationFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityType { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -142,11 +130,8 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
+    public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public RelationTupleFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityId { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -34,11 +34,8 @@ namespace Valtuutus.Core.Configuration
 namespace Valtuutus.Core.Data
 {
     [System.Runtime.CompilerServices.RequiredMember]
-    public class AttributeFilter
+    public readonly struct AttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public AttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -71,11 +68,8 @@ namespace Valtuutus.Core.Data
         public string? SubjectType { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributeFilter
+    public readonly struct EntityAttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         public string? EntityId { get; init; }
@@ -85,11 +79,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributesFilter
+    public readonly struct EntityAttributesFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributesFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string[] Attributes { get; init; }
         public string? EntityId { get; init; }
@@ -99,11 +90,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
+    public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityRelationFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityType { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -142,11 +130,8 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
+    public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public RelationTupleFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityId { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -34,11 +34,8 @@ namespace Valtuutus.Core.Configuration
 namespace Valtuutus.Core.Data
 {
     [System.Runtime.CompilerServices.RequiredMember]
-    public class AttributeFilter
+    public readonly struct AttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public AttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -71,11 +68,8 @@ namespace Valtuutus.Core.Data
         public string? SubjectType { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributeFilter
+    public readonly struct EntityAttributeFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributeFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string Attribute { get; init; }
         public string? EntityId { get; init; }
@@ -85,11 +79,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityAttributesFilter
+    public readonly struct EntityAttributesFilter
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityAttributesFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string[] Attributes { get; init; }
         public string? EntityId { get; init; }
@@ -99,11 +90,8 @@ namespace Valtuutus.Core.Data
         public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
+    public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public EntityRelationFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityType { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
@@ -142,11 +130,8 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
     [System.Runtime.CompilerServices.RequiredMember]
-    public class RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
+    public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
-        public RelationTupleFilter() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public string EntityId { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]


### PR DESCRIPTION
## Summary

**Commit 1 — `LiteralValueUnion` struct + `CreateParamToArgMap` direct index**
- Change `LiteralValueUnion` from `record` (heap-allocated class) to `record struct` — eliminates one managed allocation per lambda invocation in compiled permission functions
- Remove intermediate `Dictionary<int, PermissionNodeExpArgument>` in `CreateParamToArgMap` — direct index into args array (safe: parser always emits args in `ArgOrder`-sequential order)

**Commit 2 — Pre-compute attribute arg names + pool task arrays**
- Pre-compute `GetArgsAttributesNames()` result as a field on `PermissionNodeLeafExp` at construction time — eliminates LINQ chain allocation on every function leaf evaluation (applies to Check, LookupEntity, LookupSubject engines)
- Replace `new Task<bool>[n]` in `CheckExpressionChild`, `CheckTupleToUserSet`, and `CheckRelation` with `ArrayPool<Task<bool>>.Shared`

**Commit 3 — Filter types → readonly structs**
- `RelationTupleFilter`, `EntityRelationFilter`, `EntityAttributeFilter`, `EntityAttributesFilter`, `AttributeFilter` changed from `class`/`record` to `readonly struct` — eliminates one heap alloc per reader call on the check hot path

**Commit 4 — fix: respect EntityId in GetByNames (InMemory provider)**
- `GetByNames` in `AttributesStore` ignored `EntityAttributesFilter.EntityId`, iterating and materializing attributes for **all entities** of the given type. With 5000 projects, this allocated a ~170 KB Dictionary per `CheckLeafFn` call instead of a 1-entry dict.
- Fix: add early-continue guard when `EntityId` is set.

## Benchmark results (InMemory)

| Benchmark | Before (dev) | After | Delta |
|---|---|---|---|
| `Check_Complex` alloc | 584,741 B | **4,264 B** | **-99.3%** |
| `Check_Complex` latency | ~460 µs | **~142 µs** | **-69%** |
| `SubjectPermission` alloc | 596,831 B | **~15 KB** | **-97.5%** |

The dominant gain was the `GetByNames` bug fix — it was the source of ~570 KB of wasted allocation per operation.

## Test plan

- [x] All InMemory tests pass (net8/net9/net10)
- [x] All Lang tests pass (net8/net9/net10)