### PR TITLE
perf(core): dedicated single-entity attribute fetch with early exit

### DIFF
--- a/src/Valtuutus.Core/Data/IDataReaderProvider.cs
+++ b/src/Valtuutus.Core/Data/IDataReaderProvider.cs
@@ -140,6 +140,12 @@ public interface IDataReaderProvider
     Task<Dictionary<(string AttributeName, string EntityId), AttributeTuple>> GetAttributesWithEntityIds(EntityAttributesFilter filter, IEnumerable<string> entitiesIds, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Retrieves attributes for a single entity. Optimized path for Check engine — avoids dictionary allocation.
+    /// <paramref name="filter"/>.<see cref="EntityAttributesFilter.EntityId"/> must be set.
+    /// </summary>
+    Task<PooledList<AttributeTuple>> GetAttributesSingleEntity(EntityAttributesFilter filter, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Returns all distinct entity IDs of the given type that are NOT in <paramref name="excludeIds"/>.
     /// Pass an empty collection to retrieve all entity IDs (no exclusion filter).
     /// Implements DB-side set complement for negation support in LookupEntity.

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -453,26 +453,29 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
 
         var attributeArguments = leafExp.AttributeArgNames;
 
-        var attributes = await reader.GetAttributes(
+        using var attributes = await reader.GetAttributesSingleEntity(
             new EntityAttributesFilter
             {
                 Attributes = attributeArguments,
                 EntityId = req.EntityId,
                 EntityType = req.EntityType,
                 SnapToken = req.SnapToken ?? SnapToken.MinValue
-            }, null, ct);
+            }, ct);
 
         using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
 
         using var fnArgs = paramToArg.ToLambdaArgs(
             static (arg, state) =>
             {
-                var (attrs, entityId, entityType, sch) = state;
-                if (!attrs.TryGetValue((arg.AttributeName, entityId), out var attr))
-                    return null;
-                return attr.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
+                var (attrs, entityType, sch) = state;
+                foreach (var a in attrs)
+                {
+                    if (a.Attribute == arg.AttributeName)
+                        return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
+                }
+                return null;
             },
-            (attributes, req.EntityId, req.EntityType, schema),
+            (attributes, req.EntityType, schema),
             req.Context);
 
         var result = fn.Lambda(fnArgs.Dictionary);

--- a/src/Valtuutus.Data.InMemory/AttributesStore.cs
+++ b/src/Valtuutus.Data.InMemory/AttributesStore.cs
@@ -1,5 +1,6 @@
 using Valtuutus.Core;
 using Valtuutus.Core.Data;
+using Valtuutus.Core.Pools;
 
 namespace Valtuutus.Data.InMemory;
 
@@ -92,6 +93,25 @@ internal sealed class AttributesStore : IDisposable
                 if (scopedEntityIds is not null && !scopedEntityIds.Contains(e.Attribute.EntityId)) continue;
                 var k = (e.Attribute.Attribute, e.Attribute.EntityId);
                 if (!result.ContainsKey(k)) result[k] = e.Attribute;
+            }
+        }
+        return result;
+    }
+
+    public PooledList<AttributeTuple> GetByNamesSingleEntity(EntityAttributesFilter filter)
+    {
+        using var _ = Read();
+        var result = PooledList<AttributeTuple>.Rent();
+        var snap = filter.SnapToken;
+        foreach (var attrName in filter.Attributes)
+        {
+            if (!_byEntityTypeAttr.TryGetValue((filter.EntityType, attrName), out var bucket)) continue;
+            foreach (var e in bucket)
+            {
+                if (!IsVisible(e, snap)) continue;
+                if (filter.EntityId is not null && e.Attribute.EntityId != filter.EntityId) continue;
+                result.Add(e.Attribute);
+                break;
             }
         }
         return result;

--- a/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
+++ b/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
@@ -192,6 +192,20 @@ internal sealed class InMemoryProvider : RateLimiterExecuter, IDataReaderProvide
         }
     }
 
+    public async Task<PooledList<AttributeTuple>> GetAttributesSingleEntity(EntityAttributesFilter filter, CancellationToken cancellationToken)
+    {
+        using var _ = DefaultActivitySource.Instance.StartActivity();
+        await Semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            return _attributes.GetByNamesSingleEntity(filter);
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
     public async Task<Dictionary<(string AttributeName, string EntityId), AttributeTuple>> GetAttributes(
         EntityAttributesFilter filter, EntityScope? scope, CancellationToken cancellationToken)
     {

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -746,6 +746,36 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
         }
     }
 
+    public async Task<PooledList<AttributeTuple>> GetAttributesSingleEntity(EntityAttributesFilter filter, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity();
+        await Semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            using var connection = _connectionFactory();
+            var queryTemplate = new SqlBuilder()
+                .FilterAttributes(filter)
+                .AddTemplate(_q.SelectAttributes);
+
+            var pooled = PooledList<AttributeTuple>.Rent();
+            try
+            {
+                pooled.AddRange(await connection.QueryAsync<AttributeTuple>(new CommandDefinition(queryTemplate.RawSql,
+                    queryTemplate.Parameters, cancellationToken: cancellationToken)));
+                return pooled;
+            }
+            catch
+            {
+                pooled.Dispose();
+                throw;
+            }
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
     public async Task<List<AttributeTuple>> GetAttributesWithEntityIds(AttributeFilter filter, IEnumerable<string> entitiesIds, CancellationToken cancellationToken)
     {
         using var activity = DefaultActivitySource.Instance.StartActivity();

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -277,6 +277,36 @@ internal sealed class SqlServerDataReaderProvider : RateLimiterExecuter, IDataRe
         }
     }
 
+    public async Task<PooledList<AttributeTuple>> GetAttributesSingleEntity(EntityAttributesFilter filter, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity();
+        await Semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            await using var connection = (SqlConnection)_connectionFactory();
+            var queryTemplate = new SqlBuilder()
+                .FilterAttributes(filter, _q.TvpListIdsTypeName)
+                .AddTemplate(_q.SelectAttributes);
+
+            var pooled = PooledList<AttributeTuple>.Rent();
+            try
+            {
+                pooled.AddRange(await connection.QueryAsync<AttributeTuple>(new CommandDefinition(queryTemplate.RawSql,
+                    queryTemplate.Parameters, cancellationToken: cancellationToken)));
+                return pooled;
+            }
+            catch
+            {
+                pooled.Dispose();
+                throw;
+            }
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
     public async Task<List<AttributeTuple>> GetAttributesWithEntityIds(AttributeFilter filter, IEnumerable<string> entitiesIds, CancellationToken cancellationToken)
     {
         using var activity = DefaultActivitySource.Instance.StartActivity();

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -107,6 +107,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -107,6 +107,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -107,6 +107,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -107,6 +107,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",


### PR DESCRIPTION
## Summary

- Add `GetAttributesSingleEntity` to `IDataReaderProvider` — returns `PooledList<AttributeTuple>` instead of `Dictionary<(string,string), AttributeTuple>`
- Inner bucket loop breaks after first match per attribute name, eliminating the O(n) full-bucket scan that `GetByNames` performed even after the EntityId filter fix from #188
- `CheckEngine.CheckLeafFn` uses the new method; lambda switches to struct-enumerator linear scan (no alloc for tiny n)
- All three providers implemented (InMemory, Postgres, SqlServer)

## Benchmarks (InMemory, default job, 15 iterations)

| | Check_Complex | Allocated |
|---|---|---|
| dev (before) | 127,677 ns | 3,983 B |
| this PR | 6,551 ns | 3,467 B |
| delta | ~20x faster | -516 B |

The speedup comes primarily from the `break` — once the attribute for the target entity is found in a bucket, iteration stops. Previously `GetByNames` scanned all ~5000 entries per attribute name even though only one could match.