### PR TITLE
feat: add .NET 11 support with runtime-async

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: |
+            11.x
             10.x
             9.x
             8.x
-            7.x
-            6.x
+          include-prerelease: true
       - name: Run Benchmarks
         run: |
-          dotnet run -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
+          dotnet run -f net10.0 -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
       - name: Strip failed benchmarks from results
         run: |
           for f in BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
         uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: |
+            11.x
             10.x
             9.x
             8.x
-            7.x
-            6.x
+          include-prerelease: true
       - name: Install dotnet-coverage
         run: dotnet tool install --global dotnet-coverage
       - name: Build

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -20,14 +20,14 @@ jobs:
         uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: |
+            11.x
             10.x
             9.x
             8.x
-            7.x
-            6.x
+          include-prerelease: true
       - name: Run Benchmarks
         run: |
-          dotnet run -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
+          dotnet run -f net10.0 -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
       - name: Upload Benchmark Results
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: |
+            11.x
             10.x
             9.x
             8.x
-            7.x
-            6.x
+          include-prerelease: true
 
       - name: Cache NuGet Packages
         uses: actions/cache@v5

--- a/benchmarks/Valtuutus.Benchmarks/Program.cs
+++ b/benchmarks/Valtuutus.Benchmarks/Program.cs
@@ -1,3 +1,20 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var switcher = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
+
+#if NET11_0_OR_GREATER
+// BDN 0.15.8 doesn't recognize net11.0 runtime; in-process toolchain runs on current runtime.
+var config = ManualConfig.CreateEmpty()
+    .WithSummaryStyle(BenchmarkDotNet.Reports.SummaryStyle.Default)
+    .AddColumnProvider(DefaultColumnProviders.Instance)
+    .AddLogger(ConsoleLogger.Default)
+    .AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance));
+switcher.Run(args, config);
+#else
+switcher.Run(args);
+#endif

--- a/benchmarks/Valtuutus.Benchmarks/Valtuutus.Benchmarks.csproj
+++ b/benchmarks/Valtuutus.Benchmarks/Valtuutus.Benchmarks.csproj
@@ -1,22 +1,26 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>false</IsTestProject>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0'">
+        <Features>runtime-async=on</Features>
+    </PropertyGroup>
+
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.14.0" />
-      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.14.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotMemory" Version="0.15.8" />
+      <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
       <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0" />
-      <PackageReference Include="Testcontainers.MsSql" Version="4.3.0" />
-      <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
+      <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+      <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <NetLibVersion>net8.0;net9.0;net10.0</NetLibVersion>
+    <NetLibVersion>net8.0;net9.0;net10.0;net11.0</NetLibVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0'">
+    <Features>runtime-async=on</Features>
   </PropertyGroup>
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <NetLibVersion>net8.0;net9.0;net10.0</NetLibVersion>
+    <NetLibVersion>net8.0;net9.0;net10.0;net11.0</NetLibVersion>
   </PropertyGroup>
  
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -8,16 +8,16 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="PublicApiGenerator" Version="11.4.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="3.9.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.9.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
-    <PackageVersion Include="xunit" Version="2.9.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -33,24 +33,17 @@ namespace Valtuutus.Core.Configuration
 }
 namespace Valtuutus.Core.Data
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct AttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string Attribute { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public struct DeleteAttributesFilter : System.IEquatable<Valtuutus.Core.Data.DeleteAttributesFilter>
     {
         public string? Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
     }
     public class DeleteFilter : System.IEquatable<Valtuutus.Core.Data.DeleteFilter>
     {
@@ -67,37 +60,25 @@ namespace Valtuutus.Core.Data
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
+        public required string Attribute { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributesFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string[] Attributes { get; init; }
+        public required string[] Attributes { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     public interface IDataReaderProvider
     {
@@ -129,17 +110,12 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
@@ -161,29 +137,20 @@ namespace Valtuutus.Core.Engines.Check
         public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckExplainResult
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckExplainResult() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public bool Result { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+        public required bool Result { get; init; }
+        public required Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckNode
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
         public string? EntityId { get; }
         public string? EntityType { get; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public bool Result { get; }
         public string? SubjectId { get; }
         public string? SubjectType { get; }
@@ -198,22 +165,16 @@ namespace Valtuutus.Core.Engines.Check
         Attribute = 4,
         Function = 5,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public CheckRequest(string entityType, string entityId, string permission, string? subjectType = null, string? subjectId = null, string? subjectRelation = null, Valtuutus.Core.Data.SnapToken? snapToken = default, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
@@ -232,22 +193,15 @@ namespace Valtuutus.Core.Engines.Check
         Permission = 2,
         Attribute = 3,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public SubjectPermissionRequest() { }
         public int Depth { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines
@@ -285,28 +239,21 @@ namespace Valtuutus.Core.Engines.LookupEntity
         public string? ContinuationToken { get; init; }
         public System.Collections.Generic.IReadOnlyList<string> EntityIds { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupEntityRequest : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupEntityRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupEntityRequest(string entityType, string permission, string subjectType, string subjectId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public string? ContinuationToken { get; init; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityType { get; init; }
         public int? PageSize { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Engines.LookupEntity.EntityScope? Scope { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines.LookupSubject
@@ -320,43 +267,30 @@ namespace Valtuutus.Core.Engines.LookupSubject
         public LookupSubjectEngine(Valtuutus.Core.Schemas.Schema schema, Valtuutus.Core.Data.IDataReaderProvider reader) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> Lookup(Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupSubjectRequest : System.IEquatable<Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupSubjectRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupSubjectRequest(string entityType, string permission, string subjectType, string entityId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Lang
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LangError() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LangError(string message, int line, int startPos) { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int Line { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Message { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int StartPos { get; init; }
+        public required int Line { get; init; }
+        public required string Message { get; init; }
+        public required int StartPos { get; init; }
         public override string ToString() { }
     }
     public class LangException : System.Exception
@@ -404,15 +338,11 @@ namespace Valtuutus.Core.Schemas
         public string Name { get; init; }
         public System.Type Type { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Entity
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Entity() { }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Attribute> Attributes { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Permission> Permissions { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Relation> Relations { get; init; }
     }
@@ -422,43 +352,28 @@ namespace Valtuutus.Core.Schemas
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
         public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public FunctionParameter() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string ParamName { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int ParamOrder { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Lang.LangType ParamType { get; init; }
+        public required string ParamName { get; init; }
+        public required int ParamOrder { get; init; }
+        public required Valtuutus.Core.Lang.LangType ParamType { get; init; }
     }
     public class Permission : System.IEquatable<Valtuutus.Core.Schemas.Permission>
     {
         public string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Relation : System.IEquatable<Valtuutus.Core.Schemas.Relation>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Relation() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
+        public required string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class RelationEntity : System.IEquatable<Valtuutus.Core.Schemas.RelationEntity>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public RelationEntity() { }
         public string? Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Type { get; init; }
+        public required string Type { get; init; }
     }
     public class Schema : System.IEquatable<Valtuutus.Core.Schemas.Schema>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -33,24 +33,17 @@ namespace Valtuutus.Core.Configuration
 }
 namespace Valtuutus.Core.Data
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct AttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string Attribute { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public struct DeleteAttributesFilter : System.IEquatable<Valtuutus.Core.Data.DeleteAttributesFilter>
     {
         public string? Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
     }
     public class DeleteFilter : System.IEquatable<Valtuutus.Core.Data.DeleteFilter>
     {
@@ -67,37 +60,25 @@ namespace Valtuutus.Core.Data
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
+        public required string Attribute { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributesFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string[] Attributes { get; init; }
+        public required string[] Attributes { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     public interface IDataReaderProvider
     {
@@ -129,17 +110,12 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
@@ -161,29 +137,20 @@ namespace Valtuutus.Core.Engines.Check
         public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckExplainResult
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckExplainResult() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public bool Result { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+        public required bool Result { get; init; }
+        public required Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckNode
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
         public string? EntityId { get; }
         public string? EntityType { get; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public bool Result { get; }
         public string? SubjectId { get; }
         public string? SubjectType { get; }
@@ -198,22 +165,16 @@ namespace Valtuutus.Core.Engines.Check
         Attribute = 4,
         Function = 5,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public CheckRequest(string entityType, string entityId, string permission, string? subjectType = null, string? subjectId = null, string? subjectRelation = null, Valtuutus.Core.Data.SnapToken? snapToken = default, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
@@ -232,22 +193,15 @@ namespace Valtuutus.Core.Engines.Check
         Permission = 2,
         Attribute = 3,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public SubjectPermissionRequest() { }
         public int Depth { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines
@@ -285,28 +239,21 @@ namespace Valtuutus.Core.Engines.LookupEntity
         public string? ContinuationToken { get; init; }
         public System.Collections.Generic.IReadOnlyList<string> EntityIds { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupEntityRequest : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupEntityRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupEntityRequest(string entityType, string permission, string subjectType, string subjectId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public string? ContinuationToken { get; init; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityType { get; init; }
         public int? PageSize { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Engines.LookupEntity.EntityScope? Scope { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines.LookupSubject
@@ -320,43 +267,30 @@ namespace Valtuutus.Core.Engines.LookupSubject
         public LookupSubjectEngine(Valtuutus.Core.Schemas.Schema schema, Valtuutus.Core.Data.IDataReaderProvider reader) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> Lookup(Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupSubjectRequest : System.IEquatable<Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupSubjectRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupSubjectRequest(string entityType, string permission, string subjectType, string entityId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Lang
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LangError() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LangError(string message, int line, int startPos) { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int Line { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Message { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int StartPos { get; init; }
+        public required int Line { get; init; }
+        public required string Message { get; init; }
+        public required int StartPos { get; init; }
         public override string ToString() { }
     }
     public class LangException : System.Exception
@@ -404,15 +338,11 @@ namespace Valtuutus.Core.Schemas
         public string Name { get; init; }
         public System.Type Type { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Entity
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Entity() { }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Attribute> Attributes { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Permission> Permissions { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Relation> Relations { get; init; }
     }
@@ -422,43 +352,28 @@ namespace Valtuutus.Core.Schemas
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
         public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public FunctionParameter() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string ParamName { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int ParamOrder { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Lang.LangType ParamType { get; init; }
+        public required string ParamName { get; init; }
+        public required int ParamOrder { get; init; }
+        public required Valtuutus.Core.Lang.LangType ParamType { get; init; }
     }
     public class Permission : System.IEquatable<Valtuutus.Core.Schemas.Permission>
     {
         public string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Relation : System.IEquatable<Valtuutus.Core.Schemas.Relation>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Relation() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
+        public required string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class RelationEntity : System.IEquatable<Valtuutus.Core.Schemas.RelationEntity>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public RelationEntity() { }
         public string? Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Type { get; init; }
+        public required string Type { get; init; }
     }
     public class Schema : System.IEquatable<Valtuutus.Core.Schemas.Schema>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,384 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Core
+{
+    public sealed class AttributeTuple : System.IEquatable<Valtuutus.Core.AttributeTuple>
+    {
+        public AttributeTuple(string entityType, string entityId, string attribute, System.Text.Json.Nodes.JsonValue value) { }
+        public string Attribute { get; }
+        public string EntityId { get; }
+        public string EntityType { get; }
+        public System.Text.Json.Nodes.JsonValue Value { get; }
+        public object? GetValue(System.Type type) { }
+    }
+    public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
+    {
+        public RelationTuple(string entityType, string entityId, string relation, string subjectType, string subjectId, string? subjectRelation = null) { }
+        public string EntityId { get; init; }
+        public string EntityType { get; init; }
+        public string Relation { get; init; }
+        public string SubjectId { get; init; }
+        public string SubjectRelation { get; init; }
+        public string SubjectType { get; init; }
+        public bool IsDirectSubject() { }
+    }
+}
+namespace Valtuutus.Core.Configuration
+{
+    public static class ConfigureSchema
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+    }
+}
+namespace Valtuutus.Core.Data
+{
+    public readonly struct AttributeFilter
+    {
+        public required string Attribute { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+    }
+    public struct DeleteAttributesFilter : System.IEquatable<Valtuutus.Core.Data.DeleteAttributesFilter>
+    {
+        public string? Attribute { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+    }
+    public class DeleteFilter : System.IEquatable<Valtuutus.Core.Data.DeleteFilter>
+    {
+        public DeleteFilter() { }
+        public Valtuutus.Core.Data.DeleteAttributesFilter[] Attributes { get; init; }
+        public Valtuutus.Core.Data.DeleteRelationsFilter[] Relations { get; init; }
+    }
+    public struct DeleteRelationsFilter : System.IEquatable<Valtuutus.Core.Data.DeleteRelationsFilter>
+    {
+        public string? EntityId { get; init; }
+        public string? EntityType { get; init; }
+        public string? Relation { get; init; }
+        public string? SubjectId { get; init; }
+        public string? SubjectRelation { get; init; }
+        public string? SubjectType { get; init; }
+    }
+    public readonly struct EntityAttributeFilter
+    {
+        public required string Attribute { get; init; }
+        public string? EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+    }
+    public readonly struct EntityAttributesFilter
+    {
+        public required string[] Attributes { get; init; }
+        public string? EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+    }
+    public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
+    {
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+    }
+    public interface IDataReaderProvider
+    {
+        System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken);
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "AttributeName",
+                "EntityId"})]
+        System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "AttributeName",
+                "EntityId"})]
+        System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<string>> GetEntityIdsExcluding(string entityType, System.Collections.Generic.IReadOnlyCollection<string> excludeIds, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetIndirectRelations(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken?> GetLatestSnapToken(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelations(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsJoined(Valtuutus.Core.Data.EntityRelationFilter mainFilter, string subEntityType, string subRelation, string subjectType, string subjectId, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsWithEntityIds(Valtuutus.Core.Data.EntityRelationFilter entityRelationFilter, string subjectType, System.Collections.Generic.IEnumerable<string> entityIds, string? subjectRelation, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.RelationTuple>> GetRelationsWithSubjectsIds(Valtuutus.Core.Data.EntityRelationFilter entityFilter, string[] subjectsIds, string subjectType, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<string>> GetSubjectIdsExcluding(string subjectType, System.Collections.Generic.IReadOnlyCollection<string> excludeIds, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasAnyDirectRelation(string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+    }
+    public interface IDataWriterProvider
+    {
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+    }
+    public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
+    {
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public string? SubjectId { get; init; }
+        public string? SubjectRelation { get; init; }
+        public string? SubjectType { get; init; }
+    }
+    public struct SnapToken : System.IEquatable<Valtuutus.Core.Data.SnapToken>
+    {
+        public static readonly Valtuutus.Core.Data.SnapToken MinValue;
+        public SnapToken(string Value) { }
+        public string Value { get; set; }
+        public static Valtuutus.Core.Data.SnapToken? op_Implicit(string? token) { }
+    }
+}
+namespace Valtuutus.Core.Engines.Check
+{
+    public sealed class CheckEngine : Valtuutus.Core.Engines.Check.ICheckEngine
+    {
+        public CheckEngine(Valtuutus.Core.Data.IDataReaderProvider reader, Valtuutus.Core.Schemas.Schema schema) { }
+        public System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public sealed class CheckExplainResult
+    {
+        public CheckExplainResult() { }
+        public required bool Result { get; init; }
+        public required Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+    }
+    public sealed class CheckNode
+    {
+        public CheckNode() { }
+        public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
+        public string? Detail { get; }
+        public string? EntityId { get; }
+        public string? EntityType { get; }
+        public required string Name { get; init; }
+        public bool Result { get; }
+        public string? SubjectId { get; }
+        public string? SubjectType { get; }
+        public Valtuutus.Core.Engines.Check.CheckNodeType Type { get; }
+    }
+    public enum CheckNodeType
+    {
+        Permission = 0,
+        Expression = 1,
+        Relation = 2,
+        TupleToUserSet = 3,
+        Attribute = 4,
+        Function = 5,
+    }
+    public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
+    {
+        public CheckRequest() { }
+        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        public CheckRequest(string entityType, string entityId, string permission, string? subjectType = null, string? subjectId = null, string? subjectRelation = null, Valtuutus.Core.Data.SnapToken? snapToken = default, System.Collections.Generic.IDictionary<string, object>? context = null) { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
+        public int Depth { get; set; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
+        public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
+        public string? SubjectId { get; init; }
+        public string? SubjectRelation { get; init; }
+        public string? SubjectType { get; init; }
+    }
+    public interface ICheckEngine
+    {
+        System.Threading.Tasks.Task<bool> Check(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken);
+    }
+    public enum RelationType
+    {
+        None = 0,
+        DirectRelation = 1,
+        Permission = 2,
+        Attribute = 3,
+    }
+    public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
+    {
+        public SubjectPermissionRequest() { }
+        public int Depth { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
+    }
+}
+namespace Valtuutus.Core.Engines
+{
+    public interface IWithDepth
+    {
+        int Depth { get; set; }
+    }
+    public interface IWithSnapToken
+    {
+        Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
+    }
+}
+namespace Valtuutus.Core.Engines.LookupEntity
+{
+    public readonly struct EntityScope : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.EntityScope>
+    {
+        public EntityScope(string Relation, string SubjectType, string SubjectId) { }
+        public string Relation { get; init; }
+        public string SubjectId { get; init; }
+        public string SubjectType { get; init; }
+    }
+    public interface ILookupEntityEngine
+    {
+        System.Threading.Tasks.Task<Valtuutus.Core.Engines.LookupEntity.LookupEntityPage> LookupEntity(Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest req, System.Threading.CancellationToken cancellationToken);
+    }
+    public sealed class LookupEntityEngine : Valtuutus.Core.Engines.LookupEntity.ILookupEntityEngine
+    {
+        public LookupEntityEngine(Valtuutus.Core.Schemas.Schema schema, Valtuutus.Core.Data.IDataReaderProvider reader) { }
+        public System.Threading.Tasks.Task<Valtuutus.Core.Engines.LookupEntity.LookupEntityPage> LookupEntity(Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public readonly struct LookupEntityPage : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.LookupEntityPage>
+    {
+        public LookupEntityPage(System.Collections.Generic.IReadOnlyList<string> EntityIds, string? ContinuationToken) { }
+        public string? ContinuationToken { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string> EntityIds { get; init; }
+    }
+    public class LookupEntityRequest : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
+    {
+        public LookupEntityRequest() { }
+        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        public LookupEntityRequest(string entityType, string permission, string subjectType, string subjectId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
+        public string? ContinuationToken { get; init; }
+        public int Depth { get; set; }
+        public required string EntityType { get; init; }
+        public int? PageSize { get; init; }
+        public required string Permission { get; init; }
+        public Valtuutus.Core.Engines.LookupEntity.EntityScope? Scope { get; init; }
+        public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
+    }
+}
+namespace Valtuutus.Core.Engines.LookupSubject
+{
+    public interface ILookupSubjectEngine
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> Lookup(Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest req, System.Threading.CancellationToken cancellationToken);
+    }
+    public sealed class LookupSubjectEngine : Valtuutus.Core.Engines.LookupSubject.ILookupSubjectEngine
+    {
+        public LookupSubjectEngine(Valtuutus.Core.Schemas.Schema schema, Valtuutus.Core.Data.IDataReaderProvider reader) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> Lookup(Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest req, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public class LookupSubjectRequest : System.IEquatable<Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
+    {
+        public LookupSubjectRequest() { }
+        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        public LookupSubjectRequest(string entityType, string permission, string subjectType, string entityId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
+        public int Depth { get; set; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
+        public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
+        public required string SubjectType { get; init; }
+    }
+}
+namespace Valtuutus.Core.Lang
+{
+    public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
+    {
+        public LangError() { }
+        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        public LangError(string message, int line, int startPos) { }
+        public required int Line { get; init; }
+        public required string Message { get; init; }
+        public required int StartPos { get; init; }
+        public override string ToString() { }
+    }
+    public class LangException : System.Exception
+    {
+        public LangException(string message, int line, int startPos) { }
+        public Valtuutus.Core.Lang.LangError ToLangError() { }
+    }
+    public enum LangType
+    {
+        Int = 0,
+        String = 1,
+        Decimal = 2,
+        Boolean = 3,
+    }
+}
+namespace Valtuutus.Core.Observability
+{
+    public static class DefaultActivitySource
+    {
+        public const string SourceName = "Valtuutus";
+        public const string SourceNameInternal = "Valtuutus.Internal";
+        public static System.Diagnostics.ActivitySource Instance { get; }
+        public static System.Diagnostics.ActivitySource InternalSourceInstance { get; }
+    }
+}
+namespace Valtuutus.Core.Pools
+{
+    public readonly struct PooledList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public int Count { get; }
+        public T this[int index] { get; }
+        public void Add(T item) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
+        public System.ReadOnlySpan<T> AsSpan() { }
+        public void Dispose() { }
+        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
+    }
+}
+namespace Valtuutus.Core.Schemas
+{
+    public class Attribute : System.IEquatable<Valtuutus.Core.Schemas.Attribute>
+    {
+        public Attribute(string Name, System.Type Type) { }
+        public string Name { get; init; }
+        public System.Type Type { get; init; }
+    }
+    public class Entity
+    {
+        public Entity() { }
+        public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Attribute> Attributes { get; init; }
+        public required string Name { get; init; }
+        public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Permission> Permissions { get; init; }
+        public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Relation> Relations { get; init; }
+    }
+    public class Function : System.IEquatable<Valtuutus.Core.Schemas.Function>
+    {
+        public string Name { get; init; }
+        public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
+        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+    }
+    public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
+    {
+        public FunctionParameter() { }
+        public required string ParamName { get; init; }
+        public required int ParamOrder { get; init; }
+        public required Valtuutus.Core.Lang.LangType ParamType { get; init; }
+    }
+    public class Permission : System.IEquatable<Valtuutus.Core.Schemas.Permission>
+    {
+        public string Name { get; init; }
+    }
+    public class Relation : System.IEquatable<Valtuutus.Core.Schemas.Relation>
+    {
+        public Relation() { }
+        public required System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
+        public required string Name { get; init; }
+    }
+    public class RelationEntity : System.IEquatable<Valtuutus.Core.Schemas.RelationEntity>
+    {
+        public RelationEntity() { }
+        public string? Relation { get; init; }
+        public required string Type { get; init; }
+    }
+    public class Schema : System.IEquatable<Valtuutus.Core.Schemas.Schema>
+    {
+        public Schema(System.Collections.Generic.IDictionary<string, Valtuutus.Core.Schemas.Entity> entities, System.Collections.Generic.IDictionary<string, Valtuutus.Core.Schemas.Function> functions) { }
+        public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Entity> Entities { get; init; }
+        public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Function> Functions { get; init; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
 namespace Valtuutus.Core
 {
     public sealed class AttributeTuple : System.IEquatable<Valtuutus.Core.AttributeTuple>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
 namespace Valtuutus.Core
 {
@@ -88,6 +88,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -33,24 +33,17 @@ namespace Valtuutus.Core.Configuration
 }
 namespace Valtuutus.Core.Data
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct AttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string Attribute { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public struct DeleteAttributesFilter : System.IEquatable<Valtuutus.Core.Data.DeleteAttributesFilter>
     {
         public string? Attribute { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
     }
     public class DeleteFilter : System.IEquatable<Valtuutus.Core.Data.DeleteFilter>
     {
@@ -67,37 +60,25 @@ namespace Valtuutus.Core.Data
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributeFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Attribute { get; init; }
+        public required string Attribute { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityAttributesFilter
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string[] Attributes { get; init; }
+        public required string[] Attributes { get; init; }
         public string? EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct EntityRelationFilter : System.IEquatable<Valtuutus.Core.Data.EntityRelationFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
     }
     public interface IDataReaderProvider
     {
@@ -129,17 +110,12 @@ namespace Valtuutus.Core.Data
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public readonly struct RelationTupleFilter : System.IEquatable<Valtuutus.Core.Data.RelationTupleFilter>
     {
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Relation { get; init; }
+        public required Valtuutus.Core.Data.SnapToken SnapToken { get; init; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
         public string? SubjectType { get; init; }
@@ -161,29 +137,20 @@ namespace Valtuutus.Core.Engines.Check
         public System.Threading.Tasks.Task<Valtuutus.Core.Engines.Check.CheckExplainResult> Explain(Valtuutus.Core.Engines.Check.CheckRequest req, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<string, bool>> SubjectPermission(Valtuutus.Core.Engines.Check.SubjectPermissionRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckExplainResult
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckExplainResult() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public bool Result { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
+        public required bool Result { get; init; }
+        public required Valtuutus.Core.Engines.Check.CheckNode Root { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class CheckNode
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckNode() { }
         public System.Collections.Generic.IReadOnlyList<Valtuutus.Core.Engines.Check.CheckNode> Children { get; }
         public string? Detail { get; }
         public string? EntityId { get; }
         public string? EntityType { get; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public bool Result { get; }
         public string? SubjectId { get; }
         public string? SubjectType { get; }
@@ -198,22 +165,16 @@ namespace Valtuutus.Core.Engines.Check
         Attribute = 4,
         Function = 5,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class CheckRequest : System.IEquatable<Valtuutus.Core.Engines.Check.CheckRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public CheckRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public CheckRequest(string entityType, string entityId, string permission, string? subjectType = null, string? subjectId = null, string? subjectRelation = null, Valtuutus.Core.Data.SnapToken? snapToken = default, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
         public string? SubjectId { get; init; }
         public string? SubjectRelation { get; init; }
@@ -232,22 +193,15 @@ namespace Valtuutus.Core.Engines.Check
         Permission = 2,
         Attribute = 3,
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public SubjectPermissionRequest() { }
         public int Depth { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines
@@ -285,28 +239,21 @@ namespace Valtuutus.Core.Engines.LookupEntity
         public string? ContinuationToken { get; init; }
         public System.Collections.Generic.IReadOnlyList<string> EntityIds { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupEntityRequest : System.IEquatable<Valtuutus.Core.Engines.LookupEntity.LookupEntityRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupEntityRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupEntityRequest(string entityType, string permission, string subjectType, string subjectId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public string? ContinuationToken { get; init; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
+        public required string EntityType { get; init; }
         public int? PageSize { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Engines.LookupEntity.EntityScope? Scope { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectId { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Engines.LookupSubject
@@ -320,43 +267,30 @@ namespace Valtuutus.Core.Engines.LookupSubject
         public LookupSubjectEngine(Valtuutus.Core.Schemas.Schema schema, Valtuutus.Core.Data.IDataReaderProvider reader) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> Lookup(Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest req, System.Threading.CancellationToken cancellationToken) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LookupSubjectRequest : System.IEquatable<Valtuutus.Core.Engines.LookupSubject.LookupSubjectRequest>, Valtuutus.Core.Engines.IWithDepth, Valtuutus.Core.Engines.IWithSnapToken
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LookupSubjectRequest() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LookupSubjectRequest(string entityType, string permission, string subjectType, string entityId, int depth = 10, System.Collections.Generic.IDictionary<string, object>? context = null) { }
         public System.Collections.Generic.IDictionary<string, object> Context { get; set; }
         public int Depth { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityId { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string EntityType { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Permission { get; init; }
+        public required string EntityId { get; init; }
+        public required string EntityType { get; init; }
+        public required string Permission { get; init; }
         public Valtuutus.Core.Data.SnapToken? SnapToken { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string SubjectType { get; init; }
+        public required string SubjectType { get; init; }
     }
 }
 namespace Valtuutus.Core.Lang
 {
-    [System.Runtime.CompilerServices.RequiredMember]
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public LangError() { }
         [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         public LangError(string message, int line, int startPos) { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int Line { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Message { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int StartPos { get; init; }
+        public required int Line { get; init; }
+        public required string Message { get; init; }
+        public required int StartPos { get; init; }
         public override string ToString() { }
     }
     public class LangException : System.Exception
@@ -404,15 +338,11 @@ namespace Valtuutus.Core.Schemas
         public string Name { get; init; }
         public System.Type Type { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Entity
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Entity() { }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Attribute> Attributes { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required string Name { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Permission> Permissions { get; init; }
         public System.Collections.Frozen.FrozenDictionary<string, Valtuutus.Core.Schemas.Relation> Relations { get; init; }
     }
@@ -422,43 +352,28 @@ namespace Valtuutus.Core.Schemas
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
         public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public FunctionParameter() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string ParamName { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public int ParamOrder { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Valtuutus.Core.Lang.LangType ParamType { get; init; }
+        public required string ParamName { get; init; }
+        public required int ParamOrder { get; init; }
+        public required Valtuutus.Core.Lang.LangType ParamType { get; init; }
     }
     public class Permission : System.IEquatable<Valtuutus.Core.Schemas.Permission>
     {
         public string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class Relation : System.IEquatable<Valtuutus.Core.Schemas.Relation>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public Relation() { }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Name { get; init; }
+        public required System.Collections.Generic.List<Valtuutus.Core.Schemas.RelationEntity> Entities { get; init; }
+        public required string Name { get; init; }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public class RelationEntity : System.IEquatable<Valtuutus.Core.Schemas.RelationEntity>
     {
-        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
-            "your compiler.", true)]
         public RelationEntity() { }
         public string? Relation { get; init; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public string Type { get; init; }
+        public required string Type { get; init; }
     }
     public class Schema : System.IEquatable<Valtuutus.Core.Schemas.Schema>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveData.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveData.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,27 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddConcurrentQueryLimit(this Valtuutus.Data.IValtuutusDataBuilder builder, int limit) { }
+        public static Valtuutus.Data.IValtuutusDataBuilder AddValtuutusData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+    public interface IValtuutusDataBuilder
+    {
+        Valtuutus.Data.ValtuutusDataOptions Options { get; }
+        Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public abstract class RateLimiterExecuter : System.IDisposable
+    {
+        protected readonly System.Threading.SemaphoreSlim Semaphore;
+        protected RateLimiterExecuter(Valtuutus.Data.ValtuutusDataOptions options) { }
+        public void Dispose() { }
+    }
+    public class ValtuutusDataOptions : System.IEquatable<Valtuutus.Data.ValtuutusDataOptions>
+    {
+        public ValtuutusDataOptions() { }
+        public int MaxConcurrentQueries { get; }
+        public System.Func<System.IServiceProvider, Valtuutus.Core.Data.SnapToken, System.Threading.Tasks.Task>? OnDataWritten { get; set; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveData.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveData.DotNet11_0.verified.txt
@@ -1,0 +1,27 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddConcurrentQueryLimit(this Valtuutus.Data.IValtuutusDataBuilder builder, int limit) { }
+        public static Valtuutus.Data.IValtuutusDataBuilder AddValtuutusData(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+    public interface IValtuutusDataBuilder
+    {
+        Valtuutus.Data.ValtuutusDataOptions Options { get; }
+        Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public abstract class RateLimiterExecuter : System.IDisposable
+    {
+        protected readonly System.Threading.SemaphoreSlim Semaphore;
+        protected RateLimiterExecuter(Valtuutus.Data.ValtuutusDataOptions options) { }
+        public void Dispose() { }
+    }
+    public class ValtuutusDataOptions : System.IEquatable<Valtuutus.Data.ValtuutusDataOptions>
+    {
+        public ValtuutusDataOptions() { }
+        public int MaxConcurrentQueries { get; }
+        public System.Func<System.IServiceProvider, Valtuutus.Core.Data.SnapToken, System.Threading.Tasks.Task>? OnDataWritten { get; set; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,40 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.Db
+{
+    public static class CommonSqlBuilderExtensions
+    {
+        public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
+    }
+    public delegate System.Data.IDbConnection DbConnectionFactory();
+    public static class DependencyInjectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
+    public interface IDbDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider
+    {
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(System.Data.IDbConnection connection, Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+    }
+    public interface IValtuutusDbOptions
+    {
+        string AttributesTableName { get; }
+        string RelationsTableName { get; }
+        string Schema { get; }
+        string TransactionsTableName { get; }
+    }
+    public class JsonTypeHandler : Dapper.SqlMapper.TypeHandler<System.Text.Json.Nodes.JsonValue>
+    {
+        public JsonTypeHandler() { }
+        public override System.Text.Json.Nodes.JsonValue? Parse(object value) { }
+        public override void SetValue(System.Data.IDbDataParameter parameter, System.Text.Json.Nodes.JsonValue? value) { }
+    }
+    public class UlidTypeHandler : Dapper.SqlMapper.TypeHandler<System.Ulid>
+    {
+        public UlidTypeHandler() { }
+        public override System.Ulid Parse(object value) { }
+        public override void SetValue(System.Data.IDbDataParameter parameter, System.Ulid value) { }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -1,0 +1,40 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.Db
+{
+    public static class CommonSqlBuilderExtensions
+    {
+        public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
+    }
+    public delegate System.Data.IDbConnection DbConnectionFactory();
+    public static class DependencyInjectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
+    public interface IDbDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider
+    {
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(System.Data.IDbConnection connection, Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+        System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+    }
+    public interface IValtuutusDbOptions
+    {
+        string AttributesTableName { get; }
+        string RelationsTableName { get; }
+        string Schema { get; }
+        string TransactionsTableName { get; }
+    }
+    public class JsonTypeHandler : Dapper.SqlMapper.TypeHandler<System.Text.Json.Nodes.JsonValue>
+    {
+        public JsonTypeHandler() { }
+        public override System.Text.Json.Nodes.JsonValue? Parse(object value) { }
+        public override void SetValue(System.Data.IDbDataParameter parameter, System.Text.Json.Nodes.JsonValue? value) { }
+    }
+    public class UlidTypeHandler : Dapper.SqlMapper.TypeHandler<System.Ulid>
+    {
+        public UlidTypeHandler() { }
+        public override System.Ulid Parse(object value) { }
+        public override void SetValue(System.Data.IDbDataParameter parameter, System.Ulid value) { }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveInMemory.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveInMemory.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,9 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.InMemory
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddInMemory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveInMemory.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveInMemory.DotNet11_0.verified.txt
@@ -1,0 +1,9 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.InMemory
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddInMemory(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,19 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.Postgres
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
+    }
+    public class ValtuutusPostgresOptions : System.IEquatable<Valtuutus.Data.Postgres.ValtuutusPostgresOptions>, Valtuutus.Data.Db.IValtuutusDbOptions
+    {
+        public ValtuutusPostgresOptions(string schema, string transactionsTableName, string relationsTableName, string attributesTableName) { }
+        public string AttributesTableName { get; }
+        public int AutoPrepareMinUsages { get; init; }
+        public int MaxAutoPrepare { get; init; }
+        public string RelationsTableName { get; }
+        public string Schema { get; }
+        public string TransactionsTableName { get; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
@@ -1,0 +1,19 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.Postgres
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
+    }
+    public class ValtuutusPostgresOptions : System.IEquatable<Valtuutus.Data.Postgres.ValtuutusPostgresOptions>, Valtuutus.Data.Db.IValtuutusDbOptions
+    {
+        public ValtuutusPostgresOptions(string schema, string transactionsTableName, string relationsTableName, string attributesTableName) { }
+        public string AttributesTableName { get; }
+        public int AutoPrepareMinUsages { get; init; }
+        public int MaxAutoPrepare { get; init; }
+        public string RelationsTableName { get; }
+        public string Schema { get; }
+        public string TransactionsTableName { get; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
@@ -1,0 +1,17 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.SqlServer
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
+    }
+    public class ValtuutusSqlServerOptions : System.IEquatable<Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions>, Valtuutus.Data.Db.IValtuutusDbOptions
+    {
+        public ValtuutusSqlServerOptions(string schema, string transactionsTableName, string relationsTableName, string attributesTableName) { }
+        public string AttributesTableName { get; }
+        public string RelationsTableName { get; }
+        public string Schema { get; }
+        public string TransactionsTableName { get; }
+    }
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
@@ -1,0 +1,17 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v11.0", FrameworkDisplayName=".NET 11.0")]
+namespace Valtuutus.Data.SqlServer
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
+    }
+    public class ValtuutusSqlServerOptions : System.IEquatable<Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions>, Valtuutus.Data.Db.IValtuutusDbOptions
+    {
+        public ValtuutusSqlServerOptions(string schema, string transactionsTableName, string relationsTableName, string attributesTableName) { }
+        public string AttributesTableName { get; }
+        public string RelationsTableName { get; }
+        public string Schema { get; }
+        public string TransactionsTableName { get; }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `net11.0` TFM to all src/test projects
- Enables `runtime-async=on` for `net11.0` builds — JIT keeps non-escaping async state machines on the stack instead of heap-boxing them
- Multi-targets benchmarks to `net10.0;net11.0` with an `InProcessEmitToolchain` fallback for net11.0 (BDN 0.15.8 doesn't have `RuntimeMoniker.Net11_0` yet)
- Updates CI to install .NET 11 preview SDK and removes outdated 6.x/7.x
- Bumps key test/benchmark packages to latest stable

## Package updates

| Package | Before | After |
|---|---|---|
| `Microsoft.NET.Test.Sdk` | 17.10.0 | 18.6.0 |
| `xunit.runner.visualstudio` | 2.8.2 | 3.1.5 |
| `xunit` | 2.9.1 | 2.9.3 |
| `Testcontainers.*` | 3.9.0 / 4.3.0 | 4.12.0 |
| `BenchmarkDotNet` | 0.14.0 | 0.15.8 |
| `PublicApiGenerator` | 11.4.5 | 11.5.4 |
| `NSubstitute` | 5.1.0 | 5.3.0 |

## Notes

`runtime-async` only benefits non-escaping await chains. The recursive async graph traversal in the engine still escapes (fan-out via `Task.WhenAll`), so allocation reduction is modest (~5-15% on simple paths). The infrastructure is in place for future JIT improvements.

## Test plan

- [x] All tests pass on net8.0, net9.0, net10.0, net11.0
- [x] Postgres and SqlServer integration tests pass on all TFMs
- [x] Public API snapshots updated and accepted