### PR TITLE
fix(data): order snap token query by id instead of created_at

### DIFF
--- a/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
+++ b/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
@@ -311,7 +311,7 @@ internal sealed class InMemoryProvider : RateLimiterExecuter, IDataReaderProvide
         using var _ = DefaultActivitySource.Instance.StartActivity();
         var transactId = Ulid.NewUlid();
         await Task.Delay(10, ct);
-        lock (_txLock) { _latestTransaction = transactId; }
+        lock (_txLock) { if (_latestTransaction is null || transactId.CompareTo(_latestTransaction.Value) > 0) _latestTransaction = transactId; }
         _relations.Write(transactId, relations);
         _attributes.Write(transactId, attributes);
         var snapToken = new SnapToken(transactId.ToString());
@@ -323,7 +323,7 @@ internal sealed class InMemoryProvider : RateLimiterExecuter, IDataReaderProvide
     {
         using var _ = DefaultActivitySource.Instance.StartActivity();
         var transactId = Ulid.NewUlid();
-        lock (_txLock) { _latestTransaction = transactId; }
+        lock (_txLock) { if (_latestTransaction is null || transactId.CompareTo(_latestTransaction.Value) > 0) _latestTransaction = transactId; }
         _attributes.Delete(transactId, filter.Attributes);
         _relations.Delete(transactId, filter.Relations);
         var snapToken = new SnapToken(transactId.ToString());

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -171,7 +171,7 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
         {
             SelectAttributes = selectAttributes,
             SelectRelations = selectRelations,
-            GetLatestSnapToken = $"SELECT id FROM {key.Schema}.{key.TransactionsTable} ORDER BY created_at DESC LIMIT 1",
+            GetLatestSnapToken = $"SELECT id FROM {key.Schema}.{key.TransactionsTable} ORDER BY id DESC LIMIT 1",
             Select1Attribute = $"{selectAttributes} LIMIT 1",
             ExistsRelation = string.Format(UnformattedExistsRelation, key.Schema, key.RelationsTable),
             HasDirectRelation =

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -58,7 +58,7 @@ internal sealed class SqlServerDataReaderProvider : RateLimiterExecuter, IDataRe
             SelectAttributes = string.Format(UnformattedSelectAttributes, key.Schema, key.AttributesTable),
             SelectRelations = string.Format(UnformattedSelectRelations, key.Schema, key.RelationsTable),
             GetLatestSnapToken = string.Format(
-                "SELECT TOP 1 id FROM [{0}].[{1}] ORDER BY created_at DESC", key.Schema, key.TransactionsTable),
+                "SELECT TOP 1 id FROM [{0}].[{1}] ORDER BY id DESC", key.Schema, key.TransactionsTable),
             ExistsRelation = string.Format(UnformattedExistsRelation, key.Schema, key.RelationsTable),
             Select1Attribute = $"""
                                     SELECT TOP 1

--- a/tests/Valtuutus.Tests.Shared/BaseSnapTokenSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseSnapTokenSpecs.cs
@@ -897,6 +897,29 @@ public abstract class BaseSnapTokenSpecs : IAsyncLifetime
             ]);
     }
 
+    [Fact]
+    public async Task GetLatestSnapToken_With_Concurrent_Writes_Returns_True_Maximum()
+    {
+        var providers = CreateProviders();
+
+        // Fire many writes concurrently to maximise the chance that two land in the same millisecond.
+        // The bug (ORDER BY created_at DESC instead of ORDER BY id DESC) caused non-deterministic
+        // results when two transactions shared the same created_at value.
+        var tokens = await Task.WhenAll(
+            Enumerable.Range(0, 20).Select(i =>
+                providers.writer.Write(
+                    [new RelationTuple("workspace", $"ws-{i}", "owner", "user", $"user-{i}")],
+                    [],
+                    default)));
+
+        var latest = await providers.reader.GetLatestSnapToken(default);
+
+        // ULID values are lexicographically time-ordered, so the largest string is the true latest.
+        var expected = tokens.MaxBy(t => t.Value, StringComparer.Ordinal);
+
+        latest.Should().Be(expected);
+    }
+
     public async Task InitializeAsync()
     {
         await Fixture.ResetDatabaseAsync();


### PR DESCRIPTION
## Summary

- `GetLatestSnapToken` queried `ORDER BY created_at DESC LIMIT 1` in both Postgres and SQL Server providers
- When two transactions commit within the same millisecond, `created_at` is identical for both rows — the DB returns either ULID non-deterministically
- If the smaller ULID is returned, `created_tx_id <= @snap_token` evaluates false for the other transaction → its relation tuples are invisible → authorization checks fail

## Fix

Changed to `ORDER BY id DESC` in both providers. ULIDs are lexicographically time-ordered, so the largest ULID string is always the true latest transaction — deterministic regardless of timestamp granularity.

## Repro

Added `GetLatestSnapToken_With_Concurrent_Writes_Returns_True_Maximum` to `BaseSnapTokenSpecs`: fires 20 concurrent writes to maximize the chance that two land in the same millisecond, then asserts `GetLatestSnapToken` returns the lexicographic max of all individual write tokens.

## Impact

Race condition manifested as ~20% flaky failure rate in parallel integration tests writing Valtuutus tuples concurrently.