### PR TITLE
release: v0.10.2-beta

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -18,7 +18,7 @@ jobs:
     name: Continuous Benchmarking with Bencher
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.3.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.3.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           path: ${{ github.workspace }}/**/TestResults/**/*
           retention-days: 5
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.23.0
+        uses: EnricoMi/publish-unit-test-result-action@v2.24.0
         if: always()
         with:
           trx_files: "${{ github.workspace }}/**/*.trx"

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.3.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
+++ b/src/Valtuutus.Data.InMemory/InMemoryProvider.cs
@@ -311,7 +311,7 @@ internal sealed class InMemoryProvider : RateLimiterExecuter, IDataReaderProvide
         using var _ = DefaultActivitySource.Instance.StartActivity();
         var transactId = Ulid.NewUlid();
         await Task.Delay(10, ct);
-        lock (_txLock) { _latestTransaction = transactId; }
+        lock (_txLock) { if (_latestTransaction is null || transactId.CompareTo(_latestTransaction.Value) > 0) _latestTransaction = transactId; }
         _relations.Write(transactId, relations);
         _attributes.Write(transactId, attributes);
         var snapToken = new SnapToken(transactId.ToString());
@@ -323,7 +323,7 @@ internal sealed class InMemoryProvider : RateLimiterExecuter, IDataReaderProvide
     {
         using var _ = DefaultActivitySource.Instance.StartActivity();
         var transactId = Ulid.NewUlid();
-        lock (_txLock) { _latestTransaction = transactId; }
+        lock (_txLock) { if (_latestTransaction is null || transactId.CompareTo(_latestTransaction.Value) > 0) _latestTransaction = transactId; }
         _attributes.Delete(transactId, filter.Attributes);
         _relations.Delete(transactId, filter.Relations);
         var snapToken = new SnapToken(transactId.ToString());

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -171,7 +171,7 @@ internal sealed class PostgresDataReaderProvider : RateLimiterExecuter, IDataRea
         {
             SelectAttributes = selectAttributes,
             SelectRelations = selectRelations,
-            GetLatestSnapToken = $"SELECT id FROM {key.Schema}.{key.TransactionsTable} ORDER BY created_at DESC LIMIT 1",
+            GetLatestSnapToken = $"SELECT id FROM {key.Schema}.{key.TransactionsTable} ORDER BY id DESC LIMIT 1",
             Select1Attribute = $"{selectAttributes} LIMIT 1",
             ExistsRelation = string.Format(UnformattedExistsRelation, key.Schema, key.RelationsTable),
             HasDirectRelation =

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -58,7 +58,7 @@ internal sealed class SqlServerDataReaderProvider : RateLimiterExecuter, IDataRe
             SelectAttributes = string.Format(UnformattedSelectAttributes, key.Schema, key.AttributesTable),
             SelectRelations = string.Format(UnformattedSelectRelations, key.Schema, key.RelationsTable),
             GetLatestSnapToken = string.Format(
-                "SELECT TOP 1 id FROM [{0}].[{1}] ORDER BY created_at DESC", key.Schema, key.TransactionsTable),
+                "SELECT TOP 1 id FROM [{0}].[{1}] ORDER BY id DESC", key.Schema, key.TransactionsTable),
             ExistsRelation = string.Format(UnformattedExistsRelation, key.Schema, key.RelationsTable),
             Select1Attribute = $"""
                                     SELECT TOP 1

--- a/tests/Valtuutus.Tests.Shared/BaseSnapTokenSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseSnapTokenSpecs.cs
@@ -897,6 +897,29 @@ public abstract class BaseSnapTokenSpecs : IAsyncLifetime
             ]);
     }
 
+    [Fact]
+    public async Task GetLatestSnapToken_With_Concurrent_Writes_Returns_True_Maximum()
+    {
+        var providers = CreateProviders();
+
+        // Fire many writes concurrently to maximise the chance that two land in the same millisecond.
+        // The bug (ORDER BY created_at DESC instead of ORDER BY id DESC) caused non-deterministic
+        // results when two transactions shared the same created_at value.
+        var tokens = await Task.WhenAll(
+            Enumerable.Range(0, 20).Select(i =>
+                providers.writer.Write(
+                    [new RelationTuple("workspace", $"ws-{i}", "owner", "user", $"user-{i}")],
+                    [],
+                    default)));
+
+        var latest = await providers.reader.GetLatestSnapToken(default);
+
+        // ULID values are lexicographically time-ordered, so the largest string is the true latest.
+        var expected = tokens.MaxBy(t => t.Value, StringComparer.Ordinal);
+
+        latest.Should().Be(expected);
+    }
+
     public async Task InitializeAsync()
     {
         await Fixture.ResetDatabaseAsync();


### PR DESCRIPTION
## Changes

- fix(data): `GetLatestSnapToken` now orders by `id DESC` instead of `created_at DESC` — eliminates a race condition where two transactions committing within the same millisecond caused non-deterministic snap token results, making concurrent writes invisible to authorization checks (~20% flaky rate in parallel tests)
- fix(data/inmemory): same fix for `InMemoryProvider` — concurrent writes now correctly track the maximum ULID rather than last-writer-wins
- Build(deps): Bump EnricoMi/publish-unit-test-result-action
- Build(deps): Bump actions/checkout from 6 to 7