### PR TITLE
feat(data): add YugabyteDB provider reusing the Postgres reader

### DIFF
--- a/src/Valtuutus.Data.Postgres/DependencyInjectionExtensions.cs
+++ b/src/Valtuutus.Data.Postgres/DependencyInjectionExtensions.cs
@@ -26,4 +26,26 @@ public static class DependencyInjectionExtensions
         builder.Services.AddScoped<IDbDataWriterProvider, PostgresDataWriterProvider>();
         return builder;
     }
+
+    /// <summary>
+    /// Adds a YugabyteDB data reader and writer to the service collection. YugabyteDB is PostgreSQL-wire
+    /// compatible, so this reuses the Postgres reader verbatim and swaps in a writer that avoids the binary
+    /// <c>COPY</c> and <c>MERGE</c> statements YugabyteDB does not support (SQLSTATE 0A000).
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="factory">This is a scoped connection factory. Can be used to set multitenant access to the database.</param>
+    /// <param name="options">Options to configure schema and table names.</param>
+    public static IValtuutusDataBuilder AddYugabyte(this IServiceCollection services,
+        Func<IServiceProvider, DbConnectionFactory> factory,
+        ValtuutusPostgresOptions? options = null)
+    {
+        var postgresOptions = options ?? new ValtuutusPostgresOptions();
+        var builder = services.AddValtuutusData();
+        builder.Services.AddDbSetup(factory, postgresOptions);
+        builder.Services.AddSingleton(postgresOptions);
+        builder.Services.AddScoped<IDataReaderProvider, PostgresDataReaderProvider>();
+        builder.Services.AddScoped<IDataWriterProvider, YugabyteDataWriterProvider>();
+        builder.Services.AddScoped<IDbDataWriterProvider, YugabyteDataWriterProvider>();
+        return builder;
+    }
 }

--- a/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
@@ -10,7 +10,7 @@ using System.Collections.Concurrent;
 
 namespace Valtuutus.Data.Postgres;
 
-internal sealed class PostgresDataWriterProvider : IDbDataWriterProvider
+internal class PostgresDataWriterProvider : IDbDataWriterProvider
 {
     private readonly DbConnectionFactory _factory;
     private readonly IServiceProvider _provider;
@@ -103,9 +103,28 @@ internal sealed class PostgresDataWriterProvider : IDbDataWriterProvider
 
         await InsertTransaction((NpgsqlConnection)connection, transactId, (NpgsqlTransaction)transaction, ct);
 
-        await using var relationsWriter = await ((NpgsqlConnection)connection).BeginBinaryImportAsync(
-            _c.CopyRelations,
-            ct);
+        await WriteRelationsAsync(
+            (NpgsqlConnection)connection, (NpgsqlTransaction)transaction, relations, transactId, ct);
+        await WriteAttributesAsync(
+            (NpgsqlConnection)connection, (NpgsqlTransaction)transaction, attributes, transactId, ct);
+
+        var snapToken = new SnapToken(transactId.ToString());
+        await (_options.OnDataWritten?.Invoke(_provider, snapToken) ?? Task.CompletedTask);
+        return snapToken;
+    }
+
+    /// <summary>
+    /// Persists the relation tuples for <paramref name="transactId"/>. Default uses a binary COPY for bulk
+    /// throughput; a PostgreSQL-wire engine that does not support binary COPY overrides this.
+    /// </summary>
+    protected virtual async Task WriteRelationsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        IEnumerable<RelationTuple> relations,
+        Ulid transactId,
+        CancellationToken ct)
+    {
+        await using var relationsWriter = await connection.BeginBinaryImportAsync(_c.CopyRelations, ct);
         foreach (var record in relations)
         {
             await relationsWriter.StartRowAsync(ct);
@@ -120,12 +139,24 @@ internal sealed class PostgresDataWriterProvider : IDbDataWriterProvider
 
         await relationsWriter.CompleteAsync(ct);
         await relationsWriter.CloseAsync(ct);
+    }
 
+    /// <summary>
+    /// Upserts the attribute tuples for <paramref name="transactId"/> (latest-value-wins). Default stages into
+    /// a temp table via binary COPY and applies a MERGE; an engine without binary COPY / MERGE overrides this.
+    /// </summary>
+    protected virtual async Task WriteAttributesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        IEnumerable<AttributeTuple> attributes,
+        Ulid transactId,
+        CancellationToken ct)
+    {
         await connection.ExecuteAsync(new CommandDefinition(
             "CREATE TEMPORARY TABLE temp_attributes (entity_type VARCHAR(256), entity_id VARCHAR(64), attribute VARCHAR(64), value JSONB, created_tx_id CHAR(26))",
             transaction, cancellationToken: ct));
 
-        await using var attributesWriter = await ((NpgsqlConnection)connection).BeginBinaryImportAsync(
+        await using var attributesWriter = await connection.BeginBinaryImportAsync(
             "copy temp_attributes (entity_type, entity_id, attribute, value, created_tx_id) from STDIN (FORMAT BINARY)",
             ct);
 
@@ -144,10 +175,6 @@ internal sealed class PostgresDataWriterProvider : IDbDataWriterProvider
 
         await connection.ExecuteAsync(new CommandDefinition(
             _c.MergeAttributes, transaction, cancellationToken: ct));
-
-        var snapToken = new SnapToken(transactId.ToString());
-        await (_options.OnDataWritten?.Invoke(_provider, snapToken) ?? Task.CompletedTask);
-        return snapToken;
     }
 
     private async Task InsertTransaction(NpgsqlConnection db, Ulid transactId,

--- a/src/Valtuutus.Data.Postgres/YugabyteDataWriterProvider.cs
+++ b/src/Valtuutus.Data.Postgres/YugabyteDataWriterProvider.cs
@@ -1,0 +1,96 @@
+using System.Data;
+using Dapper;
+using Npgsql;
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Postgres;
+
+/// <summary>
+/// YugabyteDB speaks the PostgreSQL wire protocol, so it reuses the entire Postgres reader and most of the
+/// writer. It does NOT, however, support binary <c>COPY ... (FORMAT BINARY)</c> or <c>MERGE</c> — both raise
+/// SQLSTATE <c>0A000 "This statement not supported yet"</c>. This provider overrides only those two write
+/// steps with plain <c>INSERT</c>/<c>UPDATE</c>; everything else (transaction handling, the snap-token model,
+/// soft-deletes, and all reads) is inherited unchanged, so the stored rows stay byte-identical and the
+/// Postgres reader works as-is.
+/// </summary>
+internal sealed class YugabyteDataWriterProvider : PostgresDataWriterProvider
+{
+    private readonly string _insertRelation;
+    private readonly string _softDeleteAttribute;
+    private readonly string _insertAttribute;
+
+    public YugabyteDataWriterProvider(
+        DbConnectionFactory factory,
+        IServiceProvider provider,
+        ValtuutusDataOptions options,
+        IValtuutusDbOptions dbOptions)
+        : base(factory, provider, options, dbOptions)
+    {
+        var key = DbQueryCacheKey.From(dbOptions);
+        _insertRelation =
+            $"INSERT INTO {key.Schema}.{key.RelationsTable} (entity_type, entity_id, relation, subject_type, subject_id, subject_relation, created_tx_id) " +
+            "VALUES (@EntityType, @EntityId, @Relation, @SubjectType, @SubjectId, @SubjectRelation, @CreatedTxId)";
+        // Latest-value-wins upsert without MERGE: retire the current live row (the `unique_attributes` partial
+        // index permits one live row per key), then insert the new value under this transaction id.
+        _softDeleteAttribute =
+            $"UPDATE {key.Schema}.{key.AttributesTable} SET deleted_tx_id = @CreatedTxId " +
+            "WHERE entity_type = @EntityType AND entity_id = @EntityId AND attribute = @Attribute AND deleted_tx_id IS NULL";
+        _insertAttribute =
+            $"INSERT INTO {key.Schema}.{key.AttributesTable} (entity_type, entity_id, attribute, value, created_tx_id) " +
+            "VALUES (@EntityType, @EntityId, @Attribute, CAST(@Value AS jsonb), @CreatedTxId)";
+    }
+
+    protected override async Task WriteRelationsAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        IEnumerable<RelationTuple> relations,
+        Ulid transactId,
+        CancellationToken ct)
+    {
+        // Fixed-length CHAR(26) so it matches the column and the reader's lexical snap-token comparisons.
+        var createdTxId = new DbString { Length = 26, Value = transactId.ToString(), IsFixedLength = true };
+        var rows = relations.Select(record => new
+        {
+            record.EntityType,
+            record.EntityId,
+            record.Relation,
+            record.SubjectType,
+            record.SubjectId,
+            record.SubjectRelation,
+            CreatedTxId = createdTxId,
+        }).ToList();
+        if (rows.Count == 0)
+            return;
+
+        // Dapper runs the parameterized command once per element of the list.
+        await connection.ExecuteAsync(new CommandDefinition(
+            _insertRelation, rows, transaction, cancellationToken: ct));
+    }
+
+    protected override async Task WriteAttributesAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        IEnumerable<AttributeTuple> attributes,
+        Ulid transactId,
+        CancellationToken ct)
+    {
+        var createdTxId = new DbString { Length = 26, Value = transactId.ToString(), IsFixedLength = true };
+        var rows = attributes.Select(record => new
+        {
+            record.EntityType,
+            record.EntityId,
+            record.Attribute,
+            Value = record.Value.ToJsonString(),
+            CreatedTxId = createdTxId,
+        }).ToList();
+        if (rows.Count == 0)
+            return;
+
+        await connection.ExecuteAsync(new CommandDefinition(
+            _softDeleteAttribute, rows, transaction, cancellationToken: ct));
+        await connection.ExecuteAsync(new CommandDefinition(
+            _insertAttribute, rows, transaction, cancellationToken: ct));
+    }
+}

--- a/src/Valtuutus.Data.Postgres/YugabyteDataWriterProvider.cs
+++ b/src/Valtuutus.Data.Postgres/YugabyteDataWriterProvider.cs
@@ -77,14 +77,21 @@ internal sealed class YugabyteDataWriterProvider : PostgresDataWriterProvider
         CancellationToken ct)
     {
         var createdTxId = new DbString { Length = 26, Value = transactId.ToString(), IsFixedLength = true };
-        var rows = attributes.Select(record => new
-        {
-            record.EntityType,
-            record.EntityId,
-            record.Attribute,
-            Value = record.Value.ToJsonString(),
-            CreatedTxId = createdTxId,
-        }).ToList();
+        // Collapse a same-batch duplicate key to last-wins. The two-phase soft-delete-then-insert below would
+        // otherwise insert two live rows for one (entity_type, entity_id, attribute) and trip the
+        // `unique_attributes` partial index. (The Postgres MERGE this overrides instead errors on a duplicate
+        // source row; last-wins is the natural upsert semantics — the latest value for a key wins.)
+        var rows = attributes
+            .GroupBy(a => (a.EntityType, a.EntityId, a.Attribute))
+            .Select(g => g.Last())
+            .Select(record => new
+            {
+                record.EntityType,
+                record.EntityId,
+                record.Attribute,
+                Value = record.Value.ToJsonString(),
+                CreatedTxId = createdTxId,
+            }).ToList();
         if (rows.Count == 0)
             return;
 

--- a/tests/Valtuutus.Data.Postgres.Tests/YugabyteDataEngineSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/YugabyteDataEngineSpecs.cs
@@ -1,0 +1,35 @@
+using Dapper;
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.Postgres.Tests;
+
+// Drives the shared data-engine suite (relation/attribute write, upsert, delete, snap-token) against a real
+// YugabyteDB node via AddYugabyte — proving the INSERT/UPDATE writer round-trips through the Postgres reader
+// where the base COPY/MERGE writer cannot run at all (SQLSTATE 0A000).
+[Collection("YugabyteSpec")]
+public class YugabyteDataEngineSpecs : BaseDataEngineSpecs
+{
+    protected override IValtuutusDataBuilder AddSpecificProvider(IServiceCollection services)
+    {
+        return services.AddYugabyte(_ => ((IWithDbConnectionFactory)Fixture).DbFactory);
+    }
+
+    protected override async Task<(RelationTuple[] relations, AttributeTuple[] attributes)> GetCurrentTuples()
+    {
+        using var db = ((IWithDbConnectionFactory)Fixture).DbFactory();
+        var relations = (await db.QueryAsync<RelationTuple>(
+            """
+            SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation
+            FROM public.relation_tuples WHERE deleted_tx_id IS NULL
+            """)).ToArray();
+        var attributes = (await db.QueryAsync<AttributeTuple>(
+            "SELECT entity_type, entity_id, attribute, value FROM public.attributes WHERE deleted_tx_id IS NULL")).ToArray();
+
+        return (relations, attributes);
+    }
+
+    public YugabyteDataEngineSpecs(YugabyteFixture fixture) : base(fixture) { }
+}

--- a/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
@@ -72,15 +72,21 @@ public class YugabyteFixture : IAsyncLifetime, IDatabaseFixture, IWithDbConnecti
         }
     }
 
-    // Tables plus the partial unique index that makes the attribute upsert (soft-delete-then-insert) provable;
-    // the optional INCLUDE covering indexes are omitted so the schema applies on YugabyteDB unchanged.
+    // The full production schema (matches Valtuutus' Postgres migration / the CCA authz migration), including
+    // the INCLUDE covering and partial indexes — so this fixture also proves YugabyteDB accepts those DDLs,
+    // not just that the writer round-trips against a minimal schema.
     private const string DbMigration =
         """
         CREATE TABLE "public"."attributes" ("id" bigint NOT NULL GENERATED ALWAYS AS IDENTITY, "entity_type" character varying(256) NOT NULL, "entity_id" character varying(64) NOT NULL, "attribute" character varying(64) NOT NULL, "value" jsonb NOT NULL, created_tx_id char(26) NOT NULL, deleted_tx_id char(26), PRIMARY KEY ("id"));
+        CREATE INDEX "idx_attributes" ON "public"."attributes" ("entity_type", "entity_id", "attribute") INCLUDE ("value");
         CREATE TABLE "public"."relation_tuples" ("id" bigint NOT NULL GENERATED ALWAYS AS IDENTITY, "entity_type" character varying(256) NOT NULL, "entity_id" character varying(64) NOT NULL, "relation" character varying(64) NOT NULL, "subject_type" character varying(256) NOT NULL, "subject_id" character varying(64) NOT NULL, "subject_relation" character varying(64) NOT NULL, created_tx_id char(26) NOT NULL, deleted_tx_id char(26), PRIMARY KEY ("id"));
         CREATE INDEX "idx_tuples_entity_relation" ON "public"."relation_tuples" ("entity_type", "relation");
+        CREATE INDEX "idx_tuples_subject_entities" ON "public"."relation_tuples" ("entity_type", "relation", "subject_type", "subject_id") INCLUDE ("entity_id", "subject_relation");
         CREATE INDEX "idx_tuples_user" ON "public"."relation_tuples" ("entity_type", "entity_id", "relation", "subject_id");
+        CREATE INDEX "idx_tuples_userset" ON "public"."relation_tuples" ("entity_type", "entity_id", "relation", "subject_type", "subject_relation");
         CREATE TABLE "public"."transactions" ("id" char(26) NOT NULL, "created_at" timestamptz NOT NULL, PRIMARY KEY ("id"));
         CREATE UNIQUE INDEX "unique_attributes" on public.attributes (entity_type, entity_id, attribute) where deleted_tx_id is null;
+        CREATE INDEX "idx_tuples_direct" ON "public"."relation_tuples" ("entity_type", "entity_id", "relation", "subject_id") INCLUDE ("subject_type", "created_tx_id", "deleted_tx_id") WHERE subject_relation = '';
+        CREATE INDEX "idx_tuples_indirect" ON "public"."relation_tuples" ("entity_type", "entity_id", "relation") INCLUDE ("subject_type", "subject_id", "subject_relation", "created_tx_id", "deleted_tx_id") WHERE subject_relation <> '';
         """;
 }

--- a/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
@@ -72,9 +72,9 @@ public class YugabyteFixture : IAsyncLifetime, IDatabaseFixture, IWithDbConnecti
         }
     }
 
-    // The full production schema (matches Valtuutus' Postgres migration / the CCA authz migration), including
-    // the INCLUDE covering and partial indexes — so this fixture also proves YugabyteDB accepts those DDLs,
-    // not just that the writer round-trips against a minimal schema.
+    // The full schema from Valtuutus' Postgres migration, including the INCLUDE covering and partial indexes —
+    // so this fixture also proves YugabyteDB accepts those DDLs, not just that the writer round-trips against a
+    // minimal schema.
     private const string DbMigration =
         """
         CREATE TABLE "public"."attributes" ("id" bigint NOT NULL GENERATED ALWAYS AS IDENTITY, "entity_type" character varying(256) NOT NULL, "entity_id" character varying(64) NOT NULL, "attribute" character varying(64) NOT NULL, "value" jsonb NOT NULL, created_tx_id char(26) NOT NULL, deleted_tx_id char(26), PRIMARY KEY ("id"));

--- a/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/YugabyteFixture.cs
@@ -1,0 +1,86 @@
+using Dapper;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Npgsql;
+using Valtuutus.Data.Db;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.Postgres.Tests;
+
+[CollectionDefinition("YugabyteSpec")]
+public sealed class YugabyteSpecsFixture : ICollectionFixture<YugabyteFixture>
+{
+}
+
+/// <summary>
+/// Runs the shared data-engine specs against a real YugabyteDB node. YugabyteDB is PostgreSQL-wire
+/// compatible but rejects binary <c>COPY</c> and <c>MERGE</c> (SQLSTATE 0A000), so this proves the
+/// <see cref="DependencyInjectionExtensions.AddYugabyte"/> provider — which swaps those for INSERT/UPDATE —
+/// round-trips correctly through the (unchanged) Postgres reader.
+/// </summary>
+public class YugabyteFixture : IAsyncLifetime, IDatabaseFixture, IWithDbConnectionFactory
+{
+    public DbConnectionFactory DbFactory { get; private set; } = default!;
+
+    private readonly IContainer _dbContainer = new ContainerBuilder()
+        .WithImage("yugabytedb/yugabyte:latest")
+        .WithName($"yb-integration-tests-{Guid.NewGuid()}")
+        .WithCommand("bin/yugabyted", "start", "--daemon=false", "--ui=false")
+        .WithPortBinding(5433, true)
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _dbContainer.StartAsync();
+        var connectionString =
+            $"Host={_dbContainer.Hostname};Port={_dbContainer.GetMappedPublicPort(5433)};" +
+            "Username=yugabyte;Password=yugabyte;Database=yugabyte;Include Error Detail=true";
+        DbFactory = () => new NpgsqlConnection(connectionString);
+
+        // The mapped port opens before YSQL accepts queries; retry the schema apply until the node is ready.
+        await RunWithRetryAsync(async () =>
+        {
+            await using var conn = (NpgsqlConnection)DbFactory();
+            await conn.OpenAsync();
+            await conn.ExecuteAsync(DbMigration);
+        });
+    }
+
+    public async Task ResetDatabaseAsync()
+    {
+        await using var conn = (NpgsqlConnection)DbFactory();
+        await conn.OpenAsync();
+        await conn.ExecuteAsync(
+            "DELETE FROM public.relation_tuples; DELETE FROM public.attributes; DELETE FROM public.transactions;");
+    }
+
+    public async Task DisposeAsync() => await _dbContainer.DisposeAsync();
+
+    private static async Task RunWithRetryAsync(Func<Task> action)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (Exception) when (attempt < 40)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+            }
+        }
+    }
+
+    // Tables plus the partial unique index that makes the attribute upsert (soft-delete-then-insert) provable;
+    // the optional INCLUDE covering indexes are omitted so the schema applies on YugabyteDB unchanged.
+    private const string DbMigration =
+        """
+        CREATE TABLE "public"."attributes" ("id" bigint NOT NULL GENERATED ALWAYS AS IDENTITY, "entity_type" character varying(256) NOT NULL, "entity_id" character varying(64) NOT NULL, "attribute" character varying(64) NOT NULL, "value" jsonb NOT NULL, created_tx_id char(26) NOT NULL, deleted_tx_id char(26), PRIMARY KEY ("id"));
+        CREATE TABLE "public"."relation_tuples" ("id" bigint NOT NULL GENERATED ALWAYS AS IDENTITY, "entity_type" character varying(256) NOT NULL, "entity_id" character varying(64) NOT NULL, "relation" character varying(64) NOT NULL, "subject_type" character varying(256) NOT NULL, "subject_id" character varying(64) NOT NULL, "subject_relation" character varying(64) NOT NULL, created_tx_id char(26) NOT NULL, deleted_tx_id char(26), PRIMARY KEY ("id"));
+        CREATE INDEX "idx_tuples_entity_relation" ON "public"."relation_tuples" ("entity_type", "relation");
+        CREATE INDEX "idx_tuples_user" ON "public"."relation_tuples" ("entity_type", "entity_id", "relation", "subject_id");
+        CREATE TABLE "public"."transactions" ("id" char(26) NOT NULL, "created_at" timestamptz NOT NULL, PRIMARY KEY ("id"));
+        CREATE UNIQUE INDEX "unique_attributes" on public.attributes (entity_type, entity_id, attribute) where deleted_tx_id is null;
+        """;
+}


### PR DESCRIPTION
YugabyteDB speaks the PostgreSQL wire protocol, so the Postgres reader and
most of the writer work against it unchanged — but it rejects binary
`COPY ... (FORMAT BINARY)` and `MERGE` with SQLSTATE 0A000
("This statement not supported yet"), which the Postgres writer uses for
bulk relation and attribute writes. Against Yugabyte the writer therefore
fails on every Write, so the engine cannot persist any tuple.

Add an `AddYugabyte` provider that reuses the Postgres reader verbatim and
overrides only the two unsupported write steps:

- PostgresDataWriterProvider: extract the relation COPY and the
  attribute temp-table/COPY/MERGE into `protected virtual` WriteRelationsAsync
  / WriteAttributesAsync (behaviour-preserving; un-sealed) so a wire-compatible
  engine can override just those.
- YugabyteDataWriterProvider: override both with plain INSERT (relations) and
  soft-delete-then-INSERT (attributes, latest-value-wins — preserves the
  `unique_attributes` partial index and the created_tx_id/deleted_tx_id snap
  -token model the reader relies on). Stored rows are byte-identical, so the
  Postgres reader resolves them unchanged.

Validated by running the shared data-engine suite against a real YugabyteDB
container via `AddYugabyte` (YugabyteFixture + YugabyteDataEngineSpecs); the
full Postgres suite still passes, confirming the extraction is behaviour
-preserving.