### PR TITLE
chore: make DbQueryCacheKey public, remove InternalsVisibleTo

### DIFF
--- a/src/Valtuutus.Data.Db/DbQueryCacheKey.cs
+++ b/src/Valtuutus.Data.Db/DbQueryCacheKey.cs
@@ -1,6 +1,6 @@
 namespace Valtuutus.Data.Db;
 
-internal readonly record struct DbQueryCacheKey(
+public readonly record struct DbQueryCacheKey(
     string Schema,
     string TransactionsTable,
     string RelationsTable,

--- a/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
+++ b/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
@@ -17,13 +17,5 @@
       <ProjectReference Include="..\Valtuutus.Data\Valtuutus.Data.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Valtuutus.Data.Postgres</_Parameter1>
-        </AssemblyAttribute>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Valtuutus.Data.SqlServer</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
 
 </Project>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
@@ -7,6 +7,15 @@ namespace Valtuutus.Data.Db
         public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
     }
     public delegate System.Data.IDbConnection DbConnectionFactory();
+    public readonly struct DbQueryCacheKey : System.IEquatable<Valtuutus.Data.Db.DbQueryCacheKey>
+    {
+        public DbQueryCacheKey(string Schema, string TransactionsTable, string RelationsTable, string AttributesTable) { }
+        public string AttributesTable { get; init; }
+        public string RelationsTable { get; init; }
+        public string Schema { get; init; }
+        public string TransactionsTable { get; init; }
+        public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -7,6 +7,15 @@ namespace Valtuutus.Data.Db
         public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
     }
     public delegate System.Data.IDbConnection DbConnectionFactory();
+    public readonly struct DbQueryCacheKey : System.IEquatable<Valtuutus.Data.Db.DbQueryCacheKey>
+    {
+        public DbQueryCacheKey(string Schema, string TransactionsTable, string RelationsTable, string AttributesTable) { }
+        public string AttributesTable { get; init; }
+        public string RelationsTable { get; init; }
+        public string Schema { get; init; }
+        public string TransactionsTable { get; init; }
+        public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
@@ -7,6 +7,15 @@ namespace Valtuutus.Data.Db
         public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
     }
     public delegate System.Data.IDbConnection DbConnectionFactory();
+    public readonly struct DbQueryCacheKey : System.IEquatable<Valtuutus.Data.Db.DbQueryCacheKey>
+    {
+        public DbQueryCacheKey(string Schema, string TransactionsTable, string RelationsTable, string AttributesTable) { }
+        public string AttributesTable { get; init; }
+        public string RelationsTable { get; init; }
+        public string Schema { get; init; }
+        public string TransactionsTable { get; init; }
+        public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
@@ -7,6 +7,15 @@ namespace Valtuutus.Data.Db
         public static Dapper.SqlBuilder ApplySnapTokenFilter(Dapper.SqlBuilder builder, Valtuutus.Core.Data.SnapToken snapToken) { }
     }
     public delegate System.Data.IDbConnection DbConnectionFactory();
+    public readonly struct DbQueryCacheKey : System.IEquatable<Valtuutus.Data.Db.DbQueryCacheKey>
+    {
+        public DbQueryCacheKey(string Schema, string TransactionsTable, string RelationsTable, string AttributesTable) { }
+        public string AttributesTable { get; init; }
+        public string RelationsTable { get; init; }
+        public string Schema { get; init; }
+        public string TransactionsTable { get; init; }
+        public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }


### PR DESCRIPTION
## Summary

- `DbQueryCacheKey` in `Valtuutus.Data.Db` changed from `internal` to `public`
- Removed `InternalsVisibleTo` entries for `Valtuutus.Data.Postgres` and `Valtuutus.Data.SqlServer` from `Valtuutus.Data.Db.csproj`
- Updated public API snapshots in `Valtuutus.Api.Tests`

## Test plan

- [x] All tests pass locally