### PR TITLE
fix: drop temp_attributes table after merge

### DIFF
--- a/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
@@ -61,6 +61,8 @@ public class PostgresDataWriterProvider : IDbDataWriterProvider
                            INSERT INTO {key.Schema}.{key.AttributesTable} (entity_type, entity_id, attribute, value, created_tx_id)
                            SELECT entity_type, entity_id, attribute, value, created_tx_id
                            FROM temp_attributes;
+
+                           DROP TABLE temp_attributes;
                            """"
     };
 

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
@@ -49,6 +49,8 @@ public class SqlServerDataWriterProvider : IDbDataWriterProvider
                                INSERT INTO [{key.Schema}].[{key.AttributesTable}] (entity_type, entity_id, attribute, value, created_tx_id)
                                SELECT source.entity_type, source.entity_id, source.attribute, source.value, source.created_tx_id
                                FROM #temp_attributes AS source;
+
+                               DROP TABLE #temp_attributes;
                                """,
             DeleteRelations =
                 $"UPDATE [{key.Schema}].[{key.RelationsTable}] set deleted_tx_id = @SnapToken /**where**/",

--- a/tests/Valtuutus.Data.Postgres.Tests/DataEngineSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/DataEngineSpecs.cs
@@ -3,6 +3,7 @@ using Valtuutus.Core.Data;
 using Dapper;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Data.Db;
 using Valtuutus.Tests.Shared;
 
 namespace Valtuutus.Data.Postgres.Tests;
@@ -38,6 +39,40 @@ public class DataEngineSpecs : BaseDataEngineSpecs
         exists.Should().BeTrue();
     }
     
+    [Fact]
+    public async Task WritingData_TwiceOnSameConnection_ShouldNotThrow()
+    {
+        // arrange
+        var provider = Provider.GetRequiredService<IDbDataWriterProvider>();
+        await using var db = (Npgsql.NpgsqlConnection)((IWithDbConnectionFactory)Fixture).DbFactory();
+        await db.OpenAsync();
+
+        // act
+        await provider.Write(db, [], [new AttributeTuple("project", "1", "name", System.Text.Json.Nodes.JsonValue.Create("foo")!)], default);
+        var act = () => provider.Write(db, [], [new AttributeTuple("project", "2", "name", System.Text.Json.Nodes.JsonValue.Create("bar")!)], default);
+
+        // assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task WritingData_TwiceInSameTransaction_ShouldNotThrow()
+    {
+        // arrange
+        var provider = Provider.GetRequiredService<IDbDataWriterProvider>();
+        await using var db = (Npgsql.NpgsqlConnection)((IWithDbConnectionFactory)Fixture).DbFactory();
+        await db.OpenAsync();
+        await using var transaction = await db.BeginTransactionAsync();
+
+        // act
+        await provider.Write(db, transaction, [], [new AttributeTuple("project", "1", "name", System.Text.Json.Nodes.JsonValue.Create("foo")!)], default);
+        var act = () => provider.Write(db, transaction, [], [new AttributeTuple("project", "2", "name", System.Text.Json.Nodes.JsonValue.Create("bar")!)], default);
+
+        // assert
+        await act.Should().NotThrowAsync();
+        await transaction.CommitAsync();
+    }
+
     [Fact]
     public async Task DeletingData_ShouldReturnTransactionId()
     {

--- a/tests/Valtuutus.Data.SqlServer.Tests/DataEngineSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/DataEngineSpecs.cs
@@ -3,6 +3,7 @@ using Valtuutus.Core.Data;
 using Dapper;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Data.Db;
 using Valtuutus.Tests.Shared;
 
 namespace Valtuutus.Data.SqlServer.Tests;
@@ -47,6 +48,40 @@ public sealed class DataEngineSpecs : BaseDataEngineSpecs
         exists.Should().BeTrue();
     }
     
+    [Fact]
+    public async Task WritingData_TwiceOnSameConnection_ShouldNotThrow()
+    {
+        // arrange
+        var provider = Provider.GetRequiredService<IDbDataWriterProvider>();
+        await using var db = (Microsoft.Data.SqlClient.SqlConnection)((IWithDbConnectionFactory)Fixture).DbFactory();
+        await db.OpenAsync();
+
+        // act
+        await provider.Write(db, [], [new AttributeTuple("project", "1", "name", System.Text.Json.Nodes.JsonValue.Create("foo")!)], default);
+        var act = () => provider.Write(db, [], [new AttributeTuple("project", "2", "name", System.Text.Json.Nodes.JsonValue.Create("bar")!)], default);
+
+        // assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task WritingData_TwiceInSameTransaction_ShouldNotThrow()
+    {
+        // arrange
+        var provider = Provider.GetRequiredService<IDbDataWriterProvider>();
+        await using var db = (Microsoft.Data.SqlClient.SqlConnection)((IWithDbConnectionFactory)Fixture).DbFactory();
+        await db.OpenAsync();
+        var transaction = (Microsoft.Data.SqlClient.SqlTransaction)await db.BeginTransactionAsync();
+
+        // act
+        await provider.Write(db, transaction, [], [new AttributeTuple("project", "1", "name", System.Text.Json.Nodes.JsonValue.Create("foo")!)], default);
+        var act = () => provider.Write(db, transaction, [], [new AttributeTuple("project", "2", "name", System.Text.Json.Nodes.JsonValue.Create("bar")!)], default);
+
+        // assert
+        await act.Should().NotThrowAsync();
+        await transaction.CommitAsync();
+    }
+
     [Fact]
     public async Task DeletingData_ShouldReturnTransactionId()
     {


### PR DESCRIPTION
## Summary
- Postgres and SqlServer `IDbDataWriterProvider` created a `temp_attributes` staging table for the attribute MERGE but never dropped it, so a second `Write()` call sharing the same connection (or same transaction) failed with an "already exists" error.
- Both providers now drop the temp table as part of the same MERGE batch (no extra roundtrip), instead of relying on `ON COMMIT DROP` (Postgres) which doesn't help when `Write()` is called twice within the same uncommitted transaction.

## Test plan
- [x] `WritingData_TwiceOnSameConnection_ShouldNotThrow` (Postgres + SqlServer) — repros original issue, passes
- [x] `WritingData_TwiceInSameTransaction_ShouldNotThrow` (Postgres + SqlServer) — repros same-transaction edge case, passes
- [x] Full `DataEngineSpecs` suites pass on both providers
- [x] `dotnet build` clean across solution

Fixes #107