### PR TITLE
fix: bump OpenTelemetry.Exporter.OpenTelemetryProtocol to 1.15.3

### DIFF
--- a/samples/Valtuutus.Playground/Valtuutus.Playground.csproj
+++ b/samples/Valtuutus.Playground/Valtuutus.Playground.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.7" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />


### PR DESCRIPTION
Bumps the OTLP exporter from 1.9.0 → 1.15.3 to patch CVE-2026-42191 (moderate). The disk retry feature in affected versions silently falls back to `Path.GetTempPath()`, enabling local blob injection, telemetry disclosure, and resource exhaustion on multi-user systems.

This project doesn't enable disk retry, so it's not actively exploitable — this is a proactive hardening measure.

See: GHSA-4625-4j76-fww9