### PR TITLE
refactor: replace FastMember.ObjectReader with hand-written DbDataReader impls (SqlServer bulk copy)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageVersion Include="Antlr4BuildTasks" Version="12.10.0" />
-    <PackageVersion Include="FastMember" Version="1.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="[8.0.0,)" />

--- a/src/Valtuutus.Data.SqlServer/AttributeTupleDataReader.cs
+++ b/src/Valtuutus.Data.SqlServer/AttributeTupleDataReader.cs
@@ -1,0 +1,90 @@
+using System.Collections;
+using System.Data.Common;
+using Valtuutus.Core;
+
+namespace Valtuutus.Data.SqlServer;
+
+internal sealed class AttributeTupleDataReader : DbDataReader
+{
+    private static readonly string[] ColumnNames =
+    [
+        "EntityType", "EntityId", "Attribute", "Value", "TransactionId"
+    ];
+
+    private readonly IEnumerator<AttributeTuple> _enumerator;
+    private readonly string _transactionId;
+    private bool _isClosed;
+
+    public AttributeTupleDataReader(IEnumerable<AttributeTuple> attributes, string transactionId)
+    {
+        _enumerator = attributes.GetEnumerator();
+        _transactionId = transactionId;
+    }
+
+    public override int FieldCount => ColumnNames.Length;
+
+    public override bool HasRows => true;
+
+    public override bool IsClosed => _isClosed;
+
+    public override int Depth => 0;
+
+    public override int RecordsAffected => -1;
+
+    public override string GetName(int ordinal) => ColumnNames[ordinal];
+
+    public override int GetOrdinal(string name)
+    {
+        for (var i = 0; i < ColumnNames.Length; i++)
+        {
+            if (string.Equals(ColumnNames[i], name, StringComparison.OrdinalIgnoreCase))
+                return i;
+        }
+
+        throw new IndexOutOfRangeException(name);
+    }
+
+    public override Type GetFieldType(int ordinal) => typeof(string);
+
+    public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();
+
+    public override bool Read() => _enumerator.MoveNext();
+
+    public override bool IsDBNull(int ordinal) => false;
+
+    public override object GetValue(int ordinal)
+    {
+        var current = _enumerator.Current;
+        return ordinal switch
+        {
+            0 => current.EntityType,
+            1 => current.EntityId,
+            2 => current.Attribute,
+            3 => current.Value.ToJsonString(),
+            4 => _transactionId,
+            _ => throw new IndexOutOfRangeException(ordinal.ToString())
+        };
+    }
+
+    public override void Close() => _isClosed = true;
+
+    public override bool NextResult() => throw new NotSupportedException();
+    public override int GetValues(object[] values) => throw new NotSupportedException();
+    public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+    public override bool GetBoolean(int ordinal) => throw new NotSupportedException();
+    public override byte GetByte(int ordinal) => throw new NotSupportedException();
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override char GetChar(int ordinal) => throw new NotSupportedException();
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override DateTime GetDateTime(int ordinal) => throw new NotSupportedException();
+    public override decimal GetDecimal(int ordinal) => throw new NotSupportedException();
+    public override double GetDouble(int ordinal) => throw new NotSupportedException();
+    public override float GetFloat(int ordinal) => throw new NotSupportedException();
+    public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+    public override short GetInt16(int ordinal) => throw new NotSupportedException();
+    public override int GetInt32(int ordinal) => throw new NotSupportedException();
+    public override long GetInt64(int ordinal) => throw new NotSupportedException();
+    public override string GetString(int ordinal) => throw new NotSupportedException();
+    public override object this[int ordinal] => throw new NotSupportedException();
+    public override object this[string name] => throw new NotSupportedException();
+}

--- a/src/Valtuutus.Data.SqlServer/RelationTupleDataReader.cs
+++ b/src/Valtuutus.Data.SqlServer/RelationTupleDataReader.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using System.Data.Common;
+using Valtuutus.Core;
+
+namespace Valtuutus.Data.SqlServer;
+
+internal sealed class RelationTupleDataReader : DbDataReader
+{
+    private static readonly string[] ColumnNames =
+    [
+        "EntityType", "EntityId", "SubjectType", "SubjectId", "Relation", "SubjectRelation", "TransactionId"
+    ];
+
+    private readonly IEnumerator<RelationTuple> _enumerator;
+    private readonly string _transactionId;
+    private bool _isClosed;
+
+    public RelationTupleDataReader(IEnumerable<RelationTuple> relations, string transactionId)
+    {
+        _enumerator = relations.GetEnumerator();
+        _transactionId = transactionId;
+    }
+
+    public override int FieldCount => ColumnNames.Length;
+
+    public override bool HasRows => true;
+
+    public override bool IsClosed => _isClosed;
+
+    public override int Depth => 0;
+
+    public override int RecordsAffected => -1;
+
+    public override string GetName(int ordinal) => ColumnNames[ordinal];
+
+    public override int GetOrdinal(string name)
+    {
+        for (var i = 0; i < ColumnNames.Length; i++)
+        {
+            if (string.Equals(ColumnNames[i], name, StringComparison.OrdinalIgnoreCase))
+                return i;
+        }
+
+        throw new IndexOutOfRangeException(name);
+    }
+
+    public override Type GetFieldType(int ordinal) => typeof(string);
+
+    public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();
+
+    public override bool Read() => _enumerator.MoveNext();
+
+    public override bool IsDBNull(int ordinal) => false;
+
+    public override object GetValue(int ordinal)
+    {
+        var current = _enumerator.Current;
+        return ordinal switch
+        {
+            0 => current.EntityType,
+            1 => current.EntityId,
+            2 => current.SubjectType,
+            3 => current.SubjectId,
+            4 => current.Relation,
+            5 => current.SubjectRelation,
+            6 => _transactionId,
+            _ => throw new IndexOutOfRangeException(ordinal.ToString())
+        };
+    }
+
+    public override void Close() => _isClosed = true;
+
+    public override bool NextResult() => throw new NotSupportedException();
+    public override int GetValues(object[] values) => throw new NotSupportedException();
+    public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+    public override bool GetBoolean(int ordinal) => throw new NotSupportedException();
+    public override byte GetByte(int ordinal) => throw new NotSupportedException();
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override char GetChar(int ordinal) => throw new NotSupportedException();
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override DateTime GetDateTime(int ordinal) => throw new NotSupportedException();
+    public override decimal GetDecimal(int ordinal) => throw new NotSupportedException();
+    public override double GetDouble(int ordinal) => throw new NotSupportedException();
+    public override float GetFloat(int ordinal) => throw new NotSupportedException();
+    public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+    public override short GetInt16(int ordinal) => throw new NotSupportedException();
+    public override int GetInt32(int ordinal) => throw new NotSupportedException();
+    public override long GetInt64(int ordinal) => throw new NotSupportedException();
+    public override string GetString(int ordinal) => throw new NotSupportedException();
+    public override object this[int ordinal] => throw new NotSupportedException();
+    public override object this[string name] => throw new NotSupportedException();
+}

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using Valtuutus.Core;
 using Valtuutus.Core.Data;
-using FastMember;
 using Microsoft.Data.SqlClient;
 using Valtuutus.Data.Db;
 using System.Data;
@@ -149,16 +148,7 @@ public class SqlServerDataWriterProvider : IDbDataWriterProvider
         using var relationsBulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.Default, transaction);
         relationsBulkCopy.DestinationTableName = _c.RelationsDestinationTableName;
 
-        await using var relationsReader = ObjectReader.Create(relations.Select(x => new
-        {
-            x.EntityType,
-            x.EntityId,
-            x.SubjectType,
-            x.SubjectId,
-            x.Relation,
-            x.SubjectRelation,
-            TransactionId = transactId.ToString()
-        }));
+        await using var relationsReader = new RelationTupleDataReader(relations, transactId.ToString());
         relationsBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("EntityType", "entity_type"));
         relationsBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("EntityId", "entity_id"));
         relationsBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("Relation", "relation"));
@@ -183,14 +173,7 @@ public class SqlServerDataWriterProvider : IDbDataWriterProvider
         using var attributesBulkCopy = new SqlBulkCopy(connection, SqlBulkCopyOptions.Default, transaction);
         attributesBulkCopy.DestinationTableName = "#temp_attributes";
 
-        await using var attributesReader = ObjectReader.Create(attributes.Select(t => new
-        {
-            t.EntityType,
-            t.EntityId,
-            t.Attribute,
-            Value = t.Value.ToJsonString(),
-            TransactionId = transactId.ToString()
-        }));
+        await using var attributesReader = new AttributeTupleDataReader(attributes, transactId.ToString());
         attributesBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("EntityType", "entity_type"));
         attributesBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("EntityId", "entity_id"));
         attributesBulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping("Attribute", "attribute"));

--- a/src/Valtuutus.Data.SqlServer/Valtuutus.Data.SqlServer.csproj
+++ b/src/Valtuutus.Data.SqlServer/Valtuutus.Data.SqlServer.csproj
@@ -9,13 +9,15 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="FastMember" />
       <PackageReference Include="Microsoft.Data.SqlClient" />
     </ItemGroup>
 
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Valtuutus.Api.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Valtuutus.Data.SqlServer.Tests</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
     

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,7 +4,6 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="FastMember" Version="1.5.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />

--- a/tests/Valtuutus.Data.SqlServer.Tests/AttributeTupleDataReaderSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/AttributeTupleDataReaderSpecs.cs
@@ -1,0 +1,127 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Valtuutus.Core;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+public sealed class AttributeTupleDataReaderSpecs
+{
+    private static readonly string[] ExpectedColumns =
+    [
+        "EntityType", "EntityId", "Attribute", "Value", "TransactionId"
+    ];
+
+    private static AttributeTupleDataReader CreateSut(params AttributeTuple[] attributes)
+        => new(attributes, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+
+    [Fact]
+    public void FieldCount_ShouldBe5()
+    {
+        using var sut = CreateSut();
+
+        sut.FieldCount.Should().Be(5);
+    }
+
+    [Fact]
+    public void GetName_ShouldReturnColumnNamesInFixedOrder()
+    {
+        using var sut = CreateSut();
+
+        for (var i = 0; i < ExpectedColumns.Length; i++)
+        {
+            sut.GetName(i).Should().Be(ExpectedColumns[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData("EntityType", 0)]
+    [InlineData("entitytype", 0)]
+    [InlineData("EntityId", 1)]
+    [InlineData("Attribute", 2)]
+    [InlineData("Value", 3)]
+    [InlineData("TransactionId", 4)]
+    [InlineData("TRANSACTIONID", 4)]
+    public void GetOrdinal_ShouldResolveNamesCaseInsensitively(string name, int expectedOrdinal)
+    {
+        using var sut = CreateSut();
+
+        sut.GetOrdinal(name).Should().Be(expectedOrdinal);
+    }
+
+    [Fact]
+    public void GetOrdinal_ShouldThrowIndexOutOfRangeException_ForUnknownColumn()
+    {
+        using var sut = CreateSut();
+
+        var act = () => sut.GetOrdinal("not_a_column");
+
+        act.Should().Throw<IndexOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Read_ShouldExposeEachTupleValueByOrdinal_AndComputeValueLazily()
+    {
+        var attributes = new[]
+        {
+            new AttributeTuple("project", "1", "name", JsonValue.Create("foo")!),
+            new AttributeTuple("project", "2", "public", JsonValue.Create(true)!)
+        };
+        using var sut = CreateSut(attributes);
+
+        foreach (var expected in attributes)
+        {
+            sut.Read().Should().BeTrue();
+            sut.GetValue(0).Should().Be(expected.EntityType);
+            sut.GetValue(1).Should().Be(expected.EntityId);
+            sut.GetValue(2).Should().Be(expected.Attribute);
+            sut.GetValue(3).Should().Be(expected.Value.ToJsonString());
+            sut.GetValue(4).Should().Be("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        }
+
+        sut.Read().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDBNull_ShouldAlwaysReturnFalse()
+    {
+        using var sut = CreateSut(new AttributeTuple("project", "1", "name", JsonValue.Create("foo")!));
+        sut.Read();
+
+        for (var i = 0; i < sut.FieldCount; i++)
+        {
+            sut.IsDBNull(i).Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void GetFieldType_ShouldReturnStringForAllColumns()
+    {
+        using var sut = CreateSut();
+
+        for (var i = 0; i < ExpectedColumns.Length; i++)
+        {
+            sut.GetFieldType(i).Should().Be(typeof(string));
+        }
+    }
+
+    [Fact]
+    public void GetInt32_ShouldThrowNotSupportedException()
+    {
+        using var sut = CreateSut(new AttributeTuple("project", "1", "name", JsonValue.Create("foo")!));
+        sut.Read();
+
+        var act = () => sut.GetInt32(0);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void Close_ShouldSetIsClosed()
+    {
+        using var sut = CreateSut();
+
+        sut.IsClosed.Should().BeFalse();
+        sut.Close();
+        sut.IsClosed.Should().BeTrue();
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/RelationTupleDataReaderSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/RelationTupleDataReaderSpecs.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Valtuutus.Core;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+public sealed class RelationTupleDataReaderSpecs
+{
+    private static readonly string[] ExpectedColumns =
+    [
+        "EntityType", "EntityId", "SubjectType", "SubjectId", "Relation", "SubjectRelation", "TransactionId"
+    ];
+
+    private static RelationTupleDataReader CreateSut(params RelationTuple[] relations)
+        => new(relations, "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+
+    [Fact]
+    public void FieldCount_ShouldBe7()
+    {
+        using var sut = CreateSut();
+
+        sut.FieldCount.Should().Be(7);
+    }
+
+    [Fact]
+    public void GetName_ShouldReturnColumnNamesInFixedOrder()
+    {
+        using var sut = CreateSut();
+
+        for (var i = 0; i < ExpectedColumns.Length; i++)
+        {
+            sut.GetName(i).Should().Be(ExpectedColumns[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData("EntityType", 0)]
+    [InlineData("entitytype", 0)]
+    [InlineData("EntityId", 1)]
+    [InlineData("SubjectType", 2)]
+    [InlineData("SubjectId", 3)]
+    [InlineData("Relation", 4)]
+    [InlineData("SubjectRelation", 5)]
+    [InlineData("TransactionId", 6)]
+    [InlineData("TRANSACTIONID", 6)]
+    public void GetOrdinal_ShouldResolveNamesCaseInsensitively(string name, int expectedOrdinal)
+    {
+        using var sut = CreateSut();
+
+        sut.GetOrdinal(name).Should().Be(expectedOrdinal);
+    }
+
+    [Fact]
+    public void GetOrdinal_ShouldThrowIndexOutOfRangeException_ForUnknownColumn()
+    {
+        using var sut = CreateSut();
+
+        var act = () => sut.GetOrdinal("not_a_column");
+
+        act.Should().Throw<IndexOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Read_ShouldExposeEachTupleValueByOrdinal()
+    {
+        var relations = new[]
+        {
+            new RelationTuple("project", "1", "member", "user", "1"),
+            new RelationTuple("project", "2", "owner", "user", "2", "admin")
+        };
+        using var sut = CreateSut(relations);
+
+        foreach (var expected in relations)
+        {
+            sut.Read().Should().BeTrue();
+            sut.GetValue(0).Should().Be(expected.EntityType);
+            sut.GetValue(1).Should().Be(expected.EntityId);
+            sut.GetValue(2).Should().Be(expected.SubjectType);
+            sut.GetValue(3).Should().Be(expected.SubjectId);
+            sut.GetValue(4).Should().Be(expected.Relation);
+            sut.GetValue(5).Should().Be(expected.SubjectRelation);
+            sut.GetValue(6).Should().Be("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        }
+
+        sut.Read().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDBNull_ShouldAlwaysReturnFalse()
+    {
+        using var sut = CreateSut(new RelationTuple("project", "1", "member", "user", "1"));
+        sut.Read();
+
+        for (var i = 0; i < sut.FieldCount; i++)
+        {
+            sut.IsDBNull(i).Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public void GetFieldType_ShouldReturnStringForAllColumns()
+    {
+        using var sut = CreateSut();
+
+        for (var i = 0; i < ExpectedColumns.Length; i++)
+        {
+            sut.GetFieldType(i).Should().Be(typeof(string));
+        }
+    }
+
+    [Fact]
+    public void GetBoolean_ShouldThrowNotSupportedException()
+    {
+        using var sut = CreateSut(new RelationTuple("project", "1", "member", "user", "1"));
+        sut.Read();
+
+        var act = () => sut.GetBoolean(0);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void Close_ShouldSetIsClosed()
+    {
+        using var sut = CreateSut();
+
+        sut.IsClosed.Should().BeFalse();
+        sut.Close();
+        sut.IsClosed.Should().BeTrue();
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/Valtuutus.Data.SqlServer.Tests.csproj
+++ b/tests/Valtuutus.Data.SqlServer.Tests/Valtuutus.Data.SqlServer.Tests.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FastMember" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Respawn" />


### PR DESCRIPTION
## Summary
- `RelationTupleDataReader` and `AttributeTupleDataReader` replace `FastMember.ObjectReader` in `SqlServerDataWriterProvider` — fixed-schema `System.Data.Common.DbDataReader` subclasses driven by `SqlBulkCopy.WriteToServerAsync` via `GetName`/`GetOrdinal`/`GetValue` only.
- `FastMember` builds its accessor via `Reflection.Emit`, not NativeAOT-compatible — this was a blocker for #215.
- Removed `FastMember` package reference from src/test csproj and both `Directory.Packages.props`.

Closes #219

## Test plan
- [x] New unit tests (TDD, RED confirmed before impl) for both readers: `FieldCount`, `GetName`/`GetOrdinal` (case-insensitive + throw), row-by-row `Read`/`GetValue`, `IsDBNull` always false, `GetFieldType`, unsupported-getter `NotSupportedException`, `Close`/`IsClosed`.
- [x] Full solution build: 0 errors.
- [x] Full test suite (all projects, all TFMs) passing: 823/823, including `Valtuutus.Data.SqlServer.Tests` Testcontainers integration tests (real bulk-copy round trip) and `Valtuutus.Api.Tests` public-API snapshot tests (unaffected — new readers are `internal`).