### PR TITLE
refactor: source-gen JsonSerializerContext for delete-filter serialization

### DIFF
--- a/src/Valtuutus.Data.Db/DeleteFilterJsonContext.cs
+++ b/src/Valtuutus.Data.Db/DeleteFilterJsonContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+using Valtuutus.Core.Data;
+
+namespace Valtuutus.Data.Db;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(DeleteRelationsFilter[]))]
+[JsonSerializable(typeof(DeleteAttributesFilter[]))]
+public partial class DeleteFilterJsonContext : JsonSerializerContext
+{
+}

--- a/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
+++ b/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
@@ -12,5 +12,4 @@
       <ProjectReference Include="..\Valtuutus.Data\Valtuutus.Data.csproj" />
     </ItemGroup>
 
-
 </Project>

--- a/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataWriterProvider.cs
@@ -27,11 +27,6 @@ public class PostgresDataWriterProvider : IDbDataWriterProvider
     private static readonly ConcurrentDictionary<DbQueryCacheKey, WriterCommands> CommandCache = new();
     private readonly WriterCommands _c;
 
-    private static readonly JsonSerializerOptions DeleteFilterJsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-    };
-
     public PostgresDataWriterProvider(DbConnectionFactory factory,
         IServiceProvider provider,
         ValtuutusDataOptions options,
@@ -237,13 +232,13 @@ public class PostgresDataWriterProvider : IDbDataWriterProvider
 
         if (filter.Relations.Length > 0)
         {
-            var filtersJson = JsonSerializer.Serialize(filter.Relations, DeleteFilterJsonOptions);
+            var filtersJson = JsonSerializer.Serialize(filter.Relations, DeleteFilterJsonContext.Default.DeleteRelationsFilterArray);
             await ExecuteDeleteBatch(npgsqlConnection, npgsqlTransaction, _c.DeleteRelations, snapTokenValue, filtersJson, ct);
         }
 
         if (filter.Attributes.Length > 0)
         {
-            var filtersJson = JsonSerializer.Serialize(filter.Attributes, DeleteFilterJsonOptions);
+            var filtersJson = JsonSerializer.Serialize(filter.Attributes, DeleteFilterJsonContext.Default.DeleteAttributesFilterArray);
             await ExecuteDeleteBatch(npgsqlConnection, npgsqlTransaction, _c.DeleteAttributes, snapTokenValue, filtersJson, ct);
         }
 

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataWriterProvider.cs
@@ -18,11 +18,6 @@ public class SqlServerDataWriterProvider : IDbDataWriterProvider
     private static readonly ConcurrentDictionary<DbQueryCacheKey, WriterCommands> CommandCache = new();
     private readonly WriterCommands _c;
 
-    private static readonly JsonSerializerOptions DeleteFilterJsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-    };
-
     public SqlServerDataWriterProvider(DbConnectionFactory factory,
         ValtuutusDataOptions options,
         IServiceProvider provider,
@@ -233,13 +228,13 @@ public class SqlServerDataWriterProvider : IDbDataWriterProvider
 
         if (filter.Relations.Length > 0)
         {
-            var filtersJson = JsonSerializer.Serialize(filter.Relations, DeleteFilterJsonOptions);
+            var filtersJson = JsonSerializer.Serialize(filter.Relations, DeleteFilterJsonContext.Default.DeleteRelationsFilterArray);
             await ExecuteDeleteBatch(sqlConnection, sqlTransaction, _c.DeleteRelations, snapTokenValue, filtersJson, ct);
         }
 
         if (filter.Attributes.Length > 0)
         {
-            var filtersJson = JsonSerializer.Serialize(filter.Attributes, DeleteFilterJsonOptions);
+            var filtersJson = JsonSerializer.Serialize(filter.Attributes, DeleteFilterJsonContext.Default.DeleteAttributesFilterArray);
             await ExecuteDeleteBatch(sqlConnection, sqlTransaction, _c.DeleteAttributes, snapTokenValue, filtersJson, ct);
         }
 

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
@@ -12,6 +12,22 @@ namespace Valtuutus.Data.Db
         public string TransactionsTable { get; init; }
         public static Valtuutus.Data.Db.DbQueryCacheKey From(Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteAttributesFilter[]))]
+    [System.Text.Json.Serialization.JsonSerializable(typeof(Valtuutus.Core.Data.DeleteRelationsFilter[]))]
+    [System.Text.Json.Serialization.JsonSourceGenerationOptions(PropertyNamingPolicy=System.Text.Json.Serialization.JsonKnownNamingPolicy.SnakeCaseLower)]
+    public class DeleteFilterJsonContext : System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public DeleteFilterJsonContext() { }
+        public DeleteFilterJsonContext(System.Text.Json.JsonSerializerOptions options) { }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter> DeleteAttributesFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteAttributesFilter[]> DeleteAttributesFilterArray { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter> DeleteRelationsFilter { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<Valtuutus.Core.Data.DeleteRelationsFilter[]> DeleteRelationsFilterArray { get; }
+        protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions { get; }
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo<string> String { get; }
+        public static Valtuutus.Data.Db.DeleteFilterJsonContext Default { get; }
+        public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
+    }
     public static class DependencyInjectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }


### PR DESCRIPTION
## Summary
- Adds shared `DeleteFilterJsonContext` (`Valtuutus.Data.Db`) covering `DeleteRelationsFilter[]`/`DeleteAttributesFilter[]`, matching the `SnakeCaseLower` naming policy both providers already used.
- `PostgresDataWriterProvider` and `SqlServerDataWriterProvider` now serialize delete filters via the generated `JsonTypeInfo<T>` overload instead of the reflection-based `JsonSerializerOptions` overload, removing IL2026/IL3050 trim/AOT warnings.
- Updated `ApproveDataDb` API-approval snapshots to include the new public type.

Closes #217

## Test plan
- [x] `dotnet build` (Postgres, SqlServer, full solution) — 0 errors
- [x] `dotnet test` (full solution incl. Postgres/SqlServer testcontainer specs, Api.Tests approval specs) — all green, net8/9/10/11