### PR TITLE
feat: compile schema DSL functions at build time via source generator

### DIFF
--- a/src/Valtuutus.Core/Configuration/ConfigureSchema.cs
+++ b/src/Valtuutus.Core/Configuration/ConfigureSchema.cs
@@ -13,10 +13,21 @@ public static class ConfigureSchema
     /// </summary>
     /// <param name="services">Service colletion</param>
     /// <param name="schemaText">Text representation of the schema</param>
+    /// <param name="compiledFunctions">
+    /// Optional map of schema function name to a build-time-compiled delegate (e.g. the source-generated
+    /// <c>SchemaFunctionsGen.All</c>). When a function name is present here, its delegate is used directly
+    /// instead of building and compiling a System.Linq.Expressions tree at schema-load time — avoids the
+    /// per-call interpreter cost under NativeAOT. Functions not present in the map still fall back to the
+    /// existing Expression-tree path, so this also covers schemas loaded from a source not known at compile
+    /// time (DB, admin API, etc).
+    /// </param>
     /// <returns></returns>
-    public static IServiceCollection AddValtuutusCore(this IServiceCollection services, string schemaText)
+    public static IServiceCollection AddValtuutusCore(
+        this IServiceCollection services,
+        string schemaText,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
     {
-        var builder = new SchemaReader();
+        var builder = new SchemaReader(compiledFunctions);
         var result = builder.Parse(schemaText);
         if (result.IsT1)
         {
@@ -30,16 +41,23 @@ public static class ConfigureSchema
 
         return services;
     }
-    
+
     /// <summary>
     /// Add Core Valtuutus services
     /// </summary>
     /// <param name="services">Service colletion</param>
     /// <param name="stream">Stream of the representation of the schema</param>
+    /// <param name="compiledFunctions">
+    /// Optional map of schema function name to a build-time-compiled delegate. See the <c>string schemaText</c>
+    /// overload for details.
+    /// </param>
     /// <returns></returns>
-    public static IServiceCollection AddValtuutusCore(this IServiceCollection services, Stream stream)
+    public static IServiceCollection AddValtuutusCore(
+        this IServiceCollection services,
+        Stream stream,
+        IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
     {
-        var builder = new SchemaReader();
+        var builder = new SchemaReader(compiledFunctions);
         var result = builder.Parse(stream);
         if (result.IsT1)
         {
@@ -53,5 +71,5 @@ public static class ConfigureSchema
 
         return services;
     }
-    
+
 }

--- a/src/Valtuutus.Core/Lang/SchemaReaders/SchemaFunctionReader.cs
+++ b/src/Valtuutus.Core/Lang/SchemaReaders/SchemaFunctionReader.cs
@@ -5,7 +5,9 @@ using Valtuutus.Lang;
 
 namespace Valtuutus.Core.Lang.SchemaReaders;
 
-internal class SchemaFunctionReader(SchemaReader schemaReader)
+internal class SchemaFunctionReader(
+    SchemaReader schemaReader,
+    IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
 {
     public Function Parse(ValtuutusParser.FunctionDefinitionContext funcCtx)
     {
@@ -30,6 +32,12 @@ internal class SchemaFunctionReader(SchemaReader schemaReader)
             var paramName = param.GetText();
             var paramType = funcCtx.parameterList().type()[i].ToLangType();
             parameters.Add(new FunctionParameter() { ParamName = paramName, ParamOrder = i, ParamType = paramType });
+        }
+
+        if (compiledFunctions is not null && compiledFunctions.TryGetValue(functionName, out var compiledLambda))
+        {
+            schemaReader.AddSymbol(new FunctionSymbol(functionName, funcCtx.Start.Line, funcCtx.Start.Column, parameters));
+            return new Function(functionName, parameters, compiledLambda);
         }
 
         var tree = ParseFunctionExpression(

--- a/src/Valtuutus.Core/Lang/SchemaReaders/SchemaReader.cs
+++ b/src/Valtuutus.Core/Lang/SchemaReaders/SchemaReader.cs
@@ -13,9 +13,9 @@ internal class SchemaReader
     private readonly SchemaAttributeReader _schemaAttributeReader;
     private readonly SchemaPermissionReader _schemaPermissionReader;
 
-    public SchemaReader()
+    public SchemaReader(IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
     {
-        _schemaFunctionReader = new SchemaFunctionReader(this);
+        _schemaFunctionReader = new SchemaFunctionReader(this, compiledFunctions);
         _schemaAttributeReader = new SchemaAttributeReader(this);
         _schemaPermissionReader = new SchemaPermissionReader(this);
         _schemaRelationReader = new SchemaRelationReader(this);

--- a/src/Valtuutus.Lang.SourceGen/FunctionExpressionTranspiler.cs
+++ b/src/Valtuutus.Lang.SourceGen/FunctionExpressionTranspiler.cs
@@ -1,0 +1,217 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Valtuutus.Lang.SourceGen;
+
+public enum FunctionParamType
+{
+    Int,
+    String,
+    Decimal,
+    Boolean
+}
+
+public sealed record FunctionTranspileParameter(string Name, FunctionParamType Type);
+
+public sealed record FunctionTranspileResult
+{
+    public bool Success { get; init; }
+    public string? FunctionName { get; init; }
+    public IReadOnlyList<FunctionTranspileParameter> Parameters { get; init; } = System.Array.Empty<FunctionTranspileParameter>();
+    public string? BodyExpression { get; init; }
+    public string? Error { get; init; }
+
+    public static FunctionTranspileResult Ok(string functionName, IReadOnlyList<FunctionTranspileParameter> parameters, string body) =>
+        new() { Success = true, FunctionName = functionName, Parameters = parameters, BodyExpression = body };
+
+    public static FunctionTranspileResult Fail(string error) =>
+        new() { Success = false, Error = error };
+}
+
+internal sealed class FunctionTranspileException : System.Exception
+{
+    public FunctionTranspileException(string message) : base(message) { }
+}
+
+public static class FunctionExpressionTranspiler
+{
+    public static FunctionTranspileResult Transpile(ValtuutusParser.FunctionDefinitionContext funcCtx)
+    {
+        var functionName = funcCtx.ID().GetText();
+
+        try
+        {
+            var parameters = new List<FunctionTranspileParameter>();
+            var paramTypes = new Dictionary<string, FunctionParamType>();
+
+            var ids = funcCtx.parameterList().ID();
+            var types = funcCtx.parameterList().type();
+            for (int i = 0; i < ids.Length; i++)
+            {
+                var paramName = ids[i].GetText();
+                var paramType = ToFunctionParamType(types[i].GetText());
+                parameters.Add(new FunctionTranspileParameter(paramName, paramType));
+                paramTypes[paramName] = paramType;
+            }
+
+            var body = EmitBooleanExpression(paramTypes, funcCtx.functionBody().functionExpression());
+            return FunctionTranspileResult.Ok(functionName, parameters, body);
+        }
+        catch (FunctionTranspileException ex)
+        {
+            return FunctionTranspileResult.Fail($"Function '{functionName}': {ex.Message}");
+        }
+    }
+
+    private static FunctionParamType ToFunctionParamType(string typeText) => typeText switch
+    {
+        "int" => FunctionParamType.Int,
+        "string" => FunctionParamType.String,
+        "bool" => FunctionParamType.Boolean,
+        "decimal" => FunctionParamType.Decimal,
+        _ => throw new FunctionTranspileException($"Unknown parameter type '{typeText}'")
+    };
+
+    private static string EmitBooleanExpression(IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        ValtuutusParser.FunctionExpressionContext exprCtx)
+    {
+        return exprCtx switch
+        {
+            ValtuutusParser.EqualityExpressionContext eqCtx => EmitComparison(paramTypes, "==", eqCtx.functionExpression(0), eqCtx.functionExpression(1)),
+            ValtuutusParser.InequalityExpressionContext neqCtx => EmitComparison(paramTypes, "!=", neqCtx.functionExpression(0), neqCtx.functionExpression(1)),
+            ValtuutusParser.GreaterExpressionContext gtCtx => EmitOrderingComparison(paramTypes, ">", gtCtx.functionExpression(0), gtCtx.functionExpression(1)),
+            ValtuutusParser.LessExpressionContext ltCtx => EmitOrderingComparison(paramTypes, "<", ltCtx.functionExpression(0), ltCtx.functionExpression(1)),
+            ValtuutusParser.GreaterOrEqualExpressionContext gteCtx => EmitOrderingComparison(paramTypes, ">=", gteCtx.functionExpression(0), gteCtx.functionExpression(1)),
+            ValtuutusParser.LessOrEqualExpressionContext lteCtx => EmitOrderingComparison(paramTypes, "<=", lteCtx.functionExpression(0), lteCtx.functionExpression(1)),
+            ValtuutusParser.AndExpressionContext andCtx => $"({EmitBooleanExpression(paramTypes, andCtx.functionExpression(0))}) && ({EmitBooleanExpression(paramTypes, andCtx.functionExpression(1))})",
+            ValtuutusParser.OrExpressionContext orCtx => $"({EmitBooleanExpression(paramTypes, orCtx.functionExpression(0))}) || ({EmitBooleanExpression(paramTypes, orCtx.functionExpression(1))})",
+            ValtuutusParser.NotExpressionContext notCtx => $"!({EmitBooleanExpression(paramTypes, notCtx.functionExpression())})",
+            // no extra wrap: callers of a boolean sub-expression already parenthesize it
+            ValtuutusParser.ParenthesisExpressionContext parenCtx => EmitBooleanExpression(paramTypes, parenCtx.functionExpression()),
+            ValtuutusParser.IdentifierExpressionContext or ValtuutusParser.LiteralExpressionContext => EmitImplicitBooleanEquality(paramTypes, exprCtx),
+            _ => throw new FunctionTranspileException("Unsupported function expression type")
+        };
+    }
+
+    private static (string Left, string Right, FunctionParamType Type) EmitValidatedOperandPair(
+        IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        ValtuutusParser.FunctionExpressionContext leftCtx, ValtuutusParser.FunctionExpressionContext rightCtx)
+    {
+        var (leftCode, leftType) = EmitOperandExpression(paramTypes, leftCtx);
+        var (rightCode, rightType) = EmitOperandExpression(paramTypes, rightCtx);
+
+        if (leftType != rightType)
+        {
+            throw new FunctionTranspileException(
+                $"Incompatible types, comparing {leftType} and {rightType}");
+        }
+
+        return (leftCode, rightCode, leftType);
+    }
+
+    private static string EmitComparison(IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        string op, ValtuutusParser.FunctionExpressionContext leftCtx, ValtuutusParser.FunctionExpressionContext rightCtx)
+    {
+        var (leftCode, rightCode, _) = EmitValidatedOperandPair(paramTypes, leftCtx, rightCtx);
+
+        return $"({leftCode}) {op} ({rightCode})";
+    }
+
+    private static string EmitOrderingComparison(IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        string op, ValtuutusParser.FunctionExpressionContext leftCtx, ValtuutusParser.FunctionExpressionContext rightCtx)
+    {
+        var (leftCode, rightCode, leftType) = EmitValidatedOperandPair(paramTypes, leftCtx, rightCtx);
+
+        return leftType switch
+        {
+            FunctionParamType.Int or FunctionParamType.Decimal =>
+                $"global::System.Nullable.Compare({leftCode}, {rightCode}) {op} 0",
+            FunctionParamType.String =>
+                $"string.Compare({leftCode}, {rightCode}, global::System.StringComparison.Ordinal) {op} 0",
+            FunctionParamType.Boolean =>
+                throw new FunctionTranspileException("Ordering comparisons are not supported for boolean operands"),
+            _ => throw new FunctionTranspileException($"Unsupported operand type {leftType}")
+        };
+    }
+
+    private static string EmitImplicitBooleanEquality(IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        ValtuutusParser.FunctionExpressionContext exprCtx)
+    {
+        if (exprCtx is ValtuutusParser.LiteralExpressionContext litCtx)
+        {
+            if (litCtx.literal().BOOLEAN_LITERAL() == null)
+            {
+                throw new FunctionTranspileException($"Expected boolean literal, got {litCtx.literal().GetText()}");
+            }
+
+            var (code, _) = EmitLiteral(litCtx.literal());
+            return $"({code}) == (true)";
+        }
+
+        if (exprCtx is ValtuutusParser.IdentifierExpressionContext idCtx)
+        {
+            var (code, type) = EmitParameterRef(paramTypes, idCtx);
+            if (type != FunctionParamType.Boolean)
+            {
+                throw new FunctionTranspileException($"Expected boolean parameter, got {type}");
+            }
+
+            return $"({code}) == (true)";
+        }
+
+        throw new FunctionTranspileException("Unsupported function expression type");
+    }
+
+    private static (string Code, FunctionParamType Type) EmitOperandExpression(
+        IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        ValtuutusParser.FunctionExpressionContext exprCtx)
+    {
+        return exprCtx switch
+        {
+            ValtuutusParser.IdentifierExpressionContext idCtx => EmitParameterRef(paramTypes, idCtx),
+            ValtuutusParser.LiteralExpressionContext litCtx => EmitLiteral(litCtx.literal()),
+            _ => throw new FunctionTranspileException("Expected parameter or literal operand")
+        };
+    }
+
+    private static (string Code, FunctionParamType Type) EmitParameterRef(
+        IReadOnlyDictionary<string, FunctionParamType> paramTypes,
+        ValtuutusParser.IdentifierExpressionContext idCtx)
+    {
+        var id = idCtx.ID().GetText();
+        if (!paramTypes.TryGetValue(id, out var type))
+        {
+            throw new FunctionTranspileException($"'{id}' is not defined in the function context.");
+        }
+
+        // Schema DSL parameter names may collide with C# reserved keywords (e.g. "class").
+        // Verbatim-escape unconditionally rather than special-casing detected keywords.
+        return ($"@{id}", type);
+    }
+
+    private static (string Code, FunctionParamType Type) EmitLiteral(ValtuutusParser.LiteralContext literalCtx)
+    {
+        if (literalCtx.STRING_LITERAL() != null)
+        {
+            var value = literalCtx.STRING_LITERAL().GetText().Trim('"');
+            return (SymbolDisplay.FormatLiteral(value, true), FunctionParamType.String);
+        }
+
+        if (literalCtx.INT_LITERAL() != null)
+        {
+            return (literalCtx.INT_LITERAL().GetText(), FunctionParamType.Int);
+        }
+
+        if (literalCtx.DECIMAL_LITERAL() != null)
+        {
+            return (literalCtx.DECIMAL_LITERAL().GetText() + "m", FunctionParamType.Decimal);
+        }
+
+        if (literalCtx.BOOLEAN_LITERAL() != null)
+        {
+            return (literalCtx.BOOLEAN_LITERAL().GetText(), FunctionParamType.Boolean);
+        }
+
+        throw new FunctionTranspileException("Unknown literal");
+    }
+}

--- a/src/Valtuutus.Lang.SourceGen/IsExternalInit.cs
+++ b/src/Valtuutus.Lang.SourceGen/IsExternalInit.cs
@@ -1,0 +1,10 @@
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices
+{
+    // Polyfill required to use C# 9 'init' accessors and records when targeting netstandard2.0,
+    // which doesn't ship this marker type in its reference assemblies.
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Valtuutus.Lang.SourceGen/SchemaConstGenerator.cs
+++ b/src/Valtuutus.Lang.SourceGen/SchemaConstGenerator.cs
@@ -35,28 +35,32 @@ public class SchemaConstGenerator : IIncrementalGenerator
         
         context.RegisterSourceOutput(vttFiles, (sourceProductionContext, file) =>
         {
-            if (!string.IsNullOrEmpty(file?.Content))
+            if (string.IsNullOrEmpty(file?.Content))
             {
-                var generatedSource = ProcessVttFile(file!.Content!);
-                sourceProductionContext.AddSource($"SchemaConsts.g.cs", SourceText.From(generatedSource, Encoding.UTF8));
+                return;
             }
-        });
 
+            var str = new AntlrInputStream(file!.Content!);
+            var lexer = new ValtuutusLexer(str);
+            var tokens = new CommonTokenStream(lexer);
+            var parser = new ValtuutusParser(tokens);
+            var tree = parser.schema();
+
+            var constsSource = ProcessVttFile(tree);
+            sourceProductionContext.AddSource("SchemaConsts.g.cs", SourceText.From(constsSource, Encoding.UTF8));
+
+            var functionsSource = SchemaFunctionsEmitter.Emit(tree, sourceProductionContext.ReportDiagnostic);
+            sourceProductionContext.AddSource("SchemaFunctions.g.cs", SourceText.From(functionsSource, Encoding.UTF8));
+        });
     }
-    
-    private static string ProcessVttFile(string vttContent)
+
+    private static string ProcessVttFile(ValtuutusParser.SchemaContext tree)
     {
         // Custom logic to process the .vtt content
         StringBuilder sb = new StringBuilder();
-        var str = new AntlrInputStream(vttContent);
-        var lexer = new ValtuutusLexer(str);
-        var tokens = new CommonTokenStream(lexer);
-        var parser = new ValtuutusParser(tokens);
-        
-        var tree = parser.schema();
 
         var cultureInfo = CultureInfo.InvariantCulture;
-        
+
         sb.AppendLine("""
                       namespace Valtuutus.Lang;
 

--- a/src/Valtuutus.Lang.SourceGen/SchemaFunctionsEmitter.cs
+++ b/src/Valtuutus.Lang.SourceGen/SchemaFunctionsEmitter.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Antlr4.Runtime;
+using Microsoft.CodeAnalysis;
+
+namespace Valtuutus.Lang.SourceGen;
+
+/// <summary>
+/// Walks all `fn` definitions in a .vtt schema's text and emits a complete generated
+/// C# source file (a static <c>SchemaFunctionsGen</c> class) wrapping each transpiled
+/// function body into a native method plus a name-keyed dispatch dictionary.
+/// </summary>
+public static class SchemaFunctionsEmitter
+{
+    private static readonly DiagnosticDescriptor TranspileErrorDescriptor = new(
+        id: "VTTFN001",
+        title: "Schema function transpile error",
+        messageFormat: "{0}",
+        category: "Valtuutus.Lang.SourceGen",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static string Emit(string vttContent, Action<Diagnostic> reportDiagnostic)
+    {
+        var str = new AntlrInputStream(vttContent);
+        var lexer = new ValtuutusLexer(str);
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new ValtuutusParser(tokens);
+        var tree = parser.schema();
+
+        return Emit(tree, reportDiagnostic);
+    }
+
+    internal static string Emit(ValtuutusParser.SchemaContext tree, Action<Diagnostic> reportDiagnostic)
+    {
+        var methods = new StringBuilder();
+        var dictionaryEntries = new StringBuilder();
+        var emittedMethodNames = new HashSet<string>();
+
+        foreach (var funcCtx in tree.functionDefinition())
+        {
+            var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+            if (!result.Success)
+            {
+                reportDiagnostic(Diagnostic.Create(TranspileErrorDescriptor, Location.None, result.Error));
+                continue;
+            }
+
+            var methodName = ToPascalCase(result.FunctionName!);
+
+            if (!emittedMethodNames.Add(methodName))
+            {
+                reportDiagnostic(Diagnostic.Create(
+                    TranspileErrorDescriptor,
+                    Location.None,
+                    $"Function '{result.FunctionName}' generates a duplicate method name '{methodName}' (already used by a previous function in this schema)."));
+                continue;
+            }
+
+            methods.AppendLine($"\tpublic static bool {methodName}(IDictionary<string, object?> args)");
+            methods.AppendLine("\t{");
+            foreach (var p in result.Parameters)
+            {
+                // Verbatim-escape the local var name unconditionally, mirroring FunctionExpressionTranspiler's
+                // parameter references, since either may be a C# reserved keyword (e.g. "class").
+                methods.AppendLine($"\t\tvar @{p.Name} = {CastExpression(p.Type)}args[\"{p.Name}\"];");
+            }
+            methods.AppendLine($"\t\treturn {result.BodyExpression};");
+            methods.AppendLine("\t}");
+            methods.AppendLine();
+
+            dictionaryEntries.AppendLine($"\t\t[\"{result.FunctionName}\"] = {methodName},");
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine();
+        sb.AppendLine("namespace Valtuutus.Lang;");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine("/// Auto-generated class containing schema DSL functions compiled to native C# at build time.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine("public static class SchemaFunctionsGen");
+        sb.AppendLine("{");
+        sb.Append(methods);
+        sb.AppendLine("\tpublic static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>");
+        sb.AppendLine("\t{");
+        sb.Append(dictionaryEntries);
+        sb.AppendLine("\t};");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Converts a schema function name (camelCase or snake_case) into a PascalCase C#
+    /// method name, capitalizing the first letter of each underscore-separated segment
+    /// while leaving the rest of each segment untouched (so "isActiveStatus" keeps its
+    /// internal camelCasing rather than being lowercased by <see cref="System.Globalization.TextInfo.ToTitleCase(string)"/>).
+    /// </summary>
+    private static string ToPascalCase(string name)
+    {
+        var sb = new StringBuilder();
+        foreach (var segment in name.Split('_'))
+        {
+            if (segment.Length == 0)
+            {
+                continue;
+            }
+
+            sb.Append(char.ToUpperInvariant(segment[0]));
+            if (segment.Length > 1)
+            {
+                sb.Append(segment, 1, segment.Length - 1);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string CastExpression(FunctionParamType type) => type switch
+    {
+        FunctionParamType.Int => "(int?)",
+        FunctionParamType.String => "(string?)",
+        FunctionParamType.Decimal => "(decimal?)",
+        FunctionParamType.Boolean => "(bool?)",
+        _ => throw new ArgumentOutOfRangeException(nameof(type))
+    };
+}

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -88,6 +88,7 @@ namespace Valtuutus.Core.Data
                 "AttributeName",
                 "EntityId"})]
         System.Threading.Tasks.Task<System.Collections.Generic.Dictionary<System.ValueTuple<string, string>, Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributesFilter filter, Valtuutus.Core.Engines.LookupEntity.EntityScope? scope, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Valtuutus.Core.Pools.PooledList<Valtuutus.Core.AttributeTuple>> GetAttributesSingleEntity(Valtuutus.Core.Data.EntityAttributesFilter filter, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributesWithEntityIds(Valtuutus.Core.Data.AttributeFilter filter, System.Collections.Generic.IEnumerable<string> entitiesIds, System.Threading.CancellationToken cancellationToken);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "AttributeName",

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -27,8 +27,8 @@ namespace Valtuutus.Core.Configuration
 {
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data

--- a/tests/Valtuutus.Lang.SourceGen.IntegrationTests/GeneratedSchemaFunctionsSpecs.cs
+++ b/tests/Valtuutus.Lang.SourceGen.IntegrationTests/GeneratedSchemaFunctionsSpecs.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+
+namespace Valtuutus.Lang.SourceGen.IntegrationTests;
+
+public class GeneratedSchemaFunctionsSpecs
+{
+    [Fact]
+    public void ShouldExposeCompiledFunctionMethod()
+    {
+        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeTrue();
+
+        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = 2 })
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldExposeFunctionInAllDictionaryByOriginalName()
+    {
+        SchemaFunctionsGen.All.Should().ContainKey("isActiveStatus");
+
+        SchemaFunctionsGen.All["isActiveStatus"](new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldHandleNullAttributeValueWithoutThrowing()
+    {
+        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = null })
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldCompileAndExecuteFunctionWithKeywordParameterName()
+    {
+        SchemaFunctionsGen.CheckClass(new Dictionary<string, object?> { ["class"] = "admin" })
+            .Should().BeTrue();
+
+        SchemaFunctionsGen.CheckClass(new Dictionary<string, object?> { ["class"] = "guest" })
+            .Should().BeFalse();
+    }
+}

--- a/tests/Valtuutus.Lang.SourceGen.IntegrationTests/schema1.vtt
+++ b/tests/Valtuutus.Lang.SourceGen.IntegrationTests/schema1.vtt
@@ -24,3 +24,4 @@ entity project {
 }
 
 fn isActiveStatus(status int) => status == 1;
+fn checkClass(class string) => class == "admin";

--- a/tests/Valtuutus.Lang.SourceGen.Tests/FunctionExpressionTranspilerSpecs.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/FunctionExpressionTranspilerSpecs.cs
@@ -1,0 +1,189 @@
+using Xunit;
+using Antlr4.Runtime;
+using System.Collections.Generic;
+
+namespace Valtuutus.Lang.SourceGen.Tests;
+
+public class FunctionExpressionTranspilerSpecs
+{
+    private static ValtuutusParser.FunctionDefinitionContext ParseFunction(string fnText)
+    {
+        var input = new AntlrInputStream(fnText);
+        var lexer = new ValtuutusLexer(input);
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new ValtuutusParser(tokens);
+        return parser.schema().functionDefinition(0);
+    }
+
+    [Fact]
+    public void Should_emit_int_literal_equality()
+    {
+        var funcCtx = ParseFunction("fn isActiveStatus(status int) => status == 1;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("isActiveStatus", result.FunctionName);
+        Assert.Single(result.Parameters);
+        Assert.Equal("status", result.Parameters[0].Name);
+        Assert.Equal(FunctionParamType.Int, result.Parameters[0].Type);
+        Assert.Equal("(@status) == (1)", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_string_literal_with_escaping()
+    {
+        var funcCtx = ParseFunction("fn notDeleted(status string) => status != \"deleted\";");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("(@status) != (\"deleted\")", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_decimal_literal_with_m_suffix()
+    {
+        var funcCtx = ParseFunction("fn checkPrice(price decimal) => price == 99.99;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("(@price) == (99.99m)", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_boolean_literal_equality()
+    {
+        var funcCtx = ParseFunction("fn checkActive(is_active bool) => is_active == true;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("(@is_active) == (true)", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_fail_on_undefined_parameter_reference()
+    {
+        var funcCtx = ParseFunction("fn broken(status int) => other == 1;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.False(result.Success);
+        Assert.Contains("other", result.Error);
+    }
+
+    [Fact]
+    public void Should_fail_on_comparison_type_mismatch()
+    {
+        var funcCtx = ParseFunction("fn broken(status int, name string) => status == name;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.False(result.Success);
+        Assert.Contains("Incompatible types", result.Error);
+    }
+
+    [Fact]
+    public void Should_fail_on_ordering_comparison_type_mismatch()
+    {
+        var funcCtx = ParseFunction("fn broken(status int, name string) => status < name;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.False(result.Success);
+        Assert.Contains("Incompatible types", result.Error);
+    }
+
+    [Fact]
+    public void Should_emit_int_ordering_via_nullable_compare()
+    {
+        var funcCtx = ParseFunction("fn withinThreshold(value int, threshold int) => value < threshold;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("global::System.Nullable.Compare(@value, @threshold) < 0", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_decimal_ordering_via_nullable_compare()
+    {
+        var funcCtx = ParseFunction("fn checkPrice(price decimal, maxPrice decimal) => price <= maxPrice;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("global::System.Nullable.Compare(@price, @maxPrice) <= 0", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_string_ordering_via_string_compare_ordinal()
+    {
+        var funcCtx = ParseFunction("fn checkTitle(a string, b string) => a > b;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("string.Compare(@a, @b, global::System.StringComparison.Ordinal) > 0", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_fail_on_boolean_ordering_comparison()
+    {
+        var funcCtx = ParseFunction("fn broken(a bool, b bool) => a < b;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.False(result.Success);
+        Assert.Contains("not supported for boolean", result.Error);
+    }
+
+    [Fact]
+    public void Should_emit_and_or_not_paren()
+    {
+        var funcCtx = ParseFunction(
+            "fn checkTransaction(is_verified bool, is_public bool) => is_verified == true or (is_public == true and not(is_verified == true));");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal(
+            "((@is_verified) == (true)) || (((@is_public) == (true)) && (!((@is_verified) == (true))))",
+            result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_emit_implicit_boolean_identifier_as_equality_true()
+    {
+        var funcCtx = ParseFunction("fn checkActive(is_active bool) => is_active;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("(@is_active) == (true)", result.BodyExpression);
+    }
+
+    [Fact]
+    public void Should_fail_implicit_boolean_on_non_boolean_parameter()
+    {
+        var funcCtx = ParseFunction("fn broken(status int) => status;");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.False(result.Success);
+        Assert.Contains("Expected boolean parameter", result.Error);
+    }
+
+    [Fact]
+    public void Should_escape_csharp_keyword_parameter_name_with_at_prefix()
+    {
+        var funcCtx = ParseFunction("fn checkClass(class string) => class == \"admin\";");
+
+        var result = FunctionExpressionTranspiler.Transpile(funcCtx);
+
+        Assert.True(result.Success);
+        Assert.Equal("(@class) == (\"admin\")", result.BodyExpression);
+    }
+}

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SchemaFunctionsEmitterSpecs.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SchemaFunctionsEmitterSpecs.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Valtuutus.Lang.SourceGen.Tests;
+
+public class SchemaFunctionsEmitterSpecs
+{
+    [Fact]
+    public void Should_emit_method_and_all_dictionary_for_single_function()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit(
+            "entity user {}\nfn isActiveStatus(status int) => status == 1;",
+            diagnostics.Add);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("public static bool IsActiveStatus(IDictionary<string, object?> args)", source);
+        Assert.Contains("var @status = (int?)args[\"status\"];", source);
+        Assert.Contains("return (@status) == (1);", source);
+        Assert.Contains("[\"isActiveStatus\"] = IsActiveStatus,", source);
+    }
+
+    [Fact]
+    public void Should_emit_empty_all_dictionary_when_no_functions()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit("entity user {}", diagnostics.Add);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("public static class SchemaFunctionsGen", source);
+        Assert.DoesNotContain("public static bool", source);
+    }
+
+    [Fact]
+    public void Should_report_diagnostic_and_skip_function_on_transpile_error()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit(
+            "fn broken(status int) => other == 1;\nfn ok(status int) => status == 1;",
+            diagnostics.Add);
+
+        Assert.Single(diagnostics);
+        Assert.DoesNotContain("Broken", source);
+        Assert.Contains("public static bool Ok(IDictionary<string, object?> args)", source);
+        Assert.DoesNotContain("[\"broken\"]", source);
+        Assert.Contains("[\"ok\"] = Ok,", source);
+    }
+
+    [Fact]
+    public void Should_convert_snake_case_function_name_to_pascal_case_method_name()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit(
+            "fn is_active_status(status int) => status == 1;",
+            diagnostics.Add);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("public static bool IsActiveStatus(IDictionary<string, object?> args)", source);
+        Assert.Contains("[\"is_active_status\"] = IsActiveStatus,", source);
+    }
+
+    [Fact]
+    public void Should_report_diagnostic_and_skip_function_on_pascal_case_name_collision()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit(
+            "fn isActive(status int) => status == 1;\nfn is_active(status int) => status == 1;",
+            diagnostics.Add);
+
+        Assert.Single(diagnostics);
+        Assert.Contains("public static bool IsActive(IDictionary<string, object?> args)", source);
+        Assert.Contains("[\"isActive\"] = IsActive,", source);
+        Assert.DoesNotContain("[\"is_active\"]", source);
+    }
+
+    [Fact]
+    public void Should_emit_compilable_code_for_csharp_keyword_parameter_name()
+    {
+        var diagnostics = new List<Diagnostic>();
+        var source = SchemaFunctionsEmitter.Emit(
+            "fn checkClass(class string) => class == \"admin\";",
+            diagnostics.Add);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("var @class = (string?)args[\"class\"];", source);
+        Assert.Contains("return (@class) == (\"admin\");", source);
+    }
+}

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema1.vtt#SchemaFunctions.g.verified.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema1.vtt#SchemaFunctions.g.verified.cs
@@ -1,0 +1,23 @@
+﻿//HintName: SchemaFunctions.g.cs
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Valtuutus.Lang;
+
+/// <summary>
+/// Auto-generated class containing schema DSL functions compiled to native C# at build time.
+/// </summary>
+public static class SchemaFunctionsGen
+{
+	public static bool IsActiveStatus(IDictionary<string, object?> args)
+	{
+		var @status = (int?)args["status"];
+		return (@status) == (1);
+	}
+
+	public static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+	{
+		["isActiveStatus"] = IsActiveStatus,
+	};
+}

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema2.vtt#SchemaFunctions.g.verified.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema2.vtt#SchemaFunctions.g.verified.cs
@@ -1,0 +1,16 @@
+﻿//HintName: SchemaFunctions.g.cs
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Valtuutus.Lang;
+
+/// <summary>
+/// Auto-generated class containing schema DSL functions compiled to native C# at build time.
+/// </summary>
+public static class SchemaFunctionsGen
+{
+	public static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+	{
+	};
+}

--- a/tests/Valtuutus.Lang.Tests/CompiledFunctionsSpecs.cs
+++ b/tests/Valtuutus.Lang.Tests/CompiledFunctionsSpecs.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Valtuutus.Core.Lang.SchemaReaders;
+
+namespace Valtuutus.Lang.Tests;
+
+public class CompiledFunctionsSpecs
+{
+    [Fact]
+    public void Should_use_compiled_function_delegate_when_name_matches()
+    {
+        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        {
+            // Deliberately returns the opposite of what the DSL body says, to prove
+            // the compiled delegate is what actually executes, not the Expression-tree fallback.
+            ["isActiveStatus"] = _ => false
+        };
+
+        var schema = new SchemaReader(compiledFunctions).Parse(@"
+            fn isActiveStatus(status int) => status == 1;
+        ");
+
+        schema.Should().NotBeNull();
+        schema.AsT0.Functions["isActiveStatus"]
+            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Should_fall_back_to_expression_compile_when_name_not_in_map()
+    {
+        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        {
+            ["someOtherFunction"] = _ => false
+        };
+
+        var schema = new SchemaReader(compiledFunctions).Parse(@"
+            fn isActiveStatus(status int) => status == 1;
+        ");
+
+        schema.Should().NotBeNull();
+        schema.AsT0.Functions["isActiveStatus"]
+            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Should_behave_identically_to_parameterless_constructor_when_no_map_given()
+    {
+        var schema = new SchemaReader().Parse(@"
+            fn isActiveStatus(status int) => status == 1;
+        ");
+
+        schema.Should().NotBeNull();
+        schema.AsT0.Functions["isActiveStatus"]
+            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeTrue();
+    }
+}

--- a/tests/Valtuutus.Lang.Tests/ConfigureSchemaSpecs.cs
+++ b/tests/Valtuutus.Lang.Tests/ConfigureSchemaSpecs.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Schemas;
+
+namespace Valtuutus.Lang.Tests;
+
+public class ConfigureSchemaSpecs
+{
+    [Fact]
+    public void Should_use_compiled_function_when_registered_via_AddValtuutusCore()
+    {
+        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        {
+            // Deliberately returns the opposite of what the DSL body (`status == 1`) would produce,
+            // to prove the compiled delegate registered via AddValtuutusCore is what actually executes.
+            ["isActiveStatus"] = _ => false
+        };
+
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(@"
+            entity user {}
+            entity project {
+                attribute status int;
+                permission edit := isActiveStatus(status);
+            }
+            fn isActiveStatus(status int) => status == 1;
+        ", compiledFunctions);
+
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<Schema>();
+
+        schema.Functions["isActiveStatus"]
+            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Should_build_schema_without_compiledFunctions_parameter_unchanged()
+    {
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(@"
+            entity user {}
+            entity project {
+                attribute status int;
+                permission edit := isActiveStatus(status);
+            }
+            fn isActiveStatus(status int) => status == 1;
+        ");
+
+        var provider = services.BuildServiceProvider();
+        var schema = provider.GetRequiredService<Schema>();
+
+        schema.Functions["isActiveStatus"]
+            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `Valtuutus.Lang.SourceGen` to transpile schema DSL `fn` bodies directly to C# (`SchemaFunctionsGen`) instead of building+compiling a `System.Linq.Expressions` tree at schema-load time, avoiding the NativeAOT interpreter fallback cost on the hot Check path.
- `SchemaReader`/`SchemaFunctionReader` accept an optional `compiledFunctions` map consulted by name before falling back to the existing Expression-tree path.
- `AddValtuutusCore` overloads gain an optional `compiledFunctions` parameter: `services.AddValtuutusCore(schemaText, SchemaFunctionsGen.All)`.
- Ordering comparisons emit `Nullable.Compare`/`string.Compare(..., Ordinal)` rather than native operators to preserve the null-handling semantics of the path being replaced. Boolean-typed ordering comparisons are rejected with a diagnostic instead of silently reproducing a latent no-op in the old path. Parameter names are verbatim-escaped (`@`) since the DSL allows C# keywords as identifiers.

Fixes #216

## Test plan
- [x] `dotnet build Valtuutus.sln` — 0 errors
- [x] `dotnet test Valtuutus.sln` — all suites green across net8/9/10/11
- [x] New unit tests: transpiler (literals/params/comparisons/and-or-not/parens/keyword-escaping), emitter (method+dictionary emission, diagnostics, name-collision guard)
- [x] Snapshot tests for the generator output (`SchemaFunctions.g.cs`)
- [x] Integration test compiling+executing the real generated `SchemaFunctionsGen` (including a C#-keyword-named parameter, proving the `@`-escape actually compiles)
- [x] Runtime tests proving `compiledFunctions` is consulted over the Expression-tree fallback, and that `AddValtuutusCore` wires it through end-to-end