### PR TITLE
fix: annotate SqlServer GetFieldType return for AOT trim analysis

### DIFF
--- a/src/Valtuutus.Data.SqlServer/AttributeTupleDataReader.cs
+++ b/src/Valtuutus.Data.SqlServer/AttributeTupleDataReader.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Valtuutus.Core;
 
 namespace Valtuutus.Data.SqlServer;
@@ -44,6 +45,7 @@ internal sealed class AttributeTupleDataReader : DbDataReader
         throw new IndexOutOfRangeException(name);
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
     public override Type GetFieldType(int ordinal) => typeof(string);
 
     public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();

--- a/src/Valtuutus.Data.SqlServer/RelationTupleDataReader.cs
+++ b/src/Valtuutus.Data.SqlServer/RelationTupleDataReader.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Valtuutus.Core;
 
 namespace Valtuutus.Data.SqlServer;
@@ -44,6 +45,7 @@ internal sealed class RelationTupleDataReader : DbDataReader
         throw new IndexOutOfRangeException(name);
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
     public override Type GetFieldType(int ordinal) => typeof(string);
 
     public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

- `RelationTupleDataReader.GetFieldType` / `AttributeTupleDataReader.GetFieldType` override `DbDataReader.GetFieldType(int)` without matching its `[return: DynamicallyAccessedMembers(PublicProperties | PublicFields)]` annotation, which the Native AOT trim analyzer flags as IL2093.
- Found while publishing the #218 Native AOT spike (#225) — fixing here since it's independent of that spike's other findings and belongs in `dev` directly.

## Test plan

- [x] `dotnet build src/Valtuutus.Data.SqlServer` — 0 errors
- [x] `dotnet build tests/Valtuutus.Data.SqlServer.Tests` — 0 errors
- [x] Re-published the #218 SqlServer AOT sample against this fix — the two IL2093 warnings are gone, all other (pre-existing, unrelated) warnings unchanged