### PR TITLE
fix: Core AOT crashes in the runtime fn Expression-tree fallback path

### DIFF
--- a/src/Valtuutus.Core/Lang/ExpressionNode.cs
+++ b/src/Valtuutus.Core/Lang/ExpressionNode.cs
@@ -93,6 +93,19 @@ internal record struct LiteralValueUnion : IComparable<LiteralValueUnion>
     public static bool operator <=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) <= 0;
 
     public static bool operator >=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) >= 0;
+
+    // Named wrappers around the operators above, so ExpressionNode.cs's comparison nodes can pass an
+    // explicit MethodInfo into Expression.Equal/NotEqual/LessThan/etc. instead of relying on those
+    // factories' by-name operator-method search (GetUserDefinedBinaryOperator), which throws under
+    // NativeAOT once trimming removes an operator that's otherwise only reachable via reflection.
+    // Calling the operators here directly (a == b, a < b, ...) also keeps them reachable for the
+    // trimmer, since this is now a normal static call site rather than a reflection-only one.
+    internal static bool AreEqual(LiteralValueUnion left, LiteralValueUnion right) => left == right;
+    internal static bool AreNotEqual(LiteralValueUnion left, LiteralValueUnion right) => left != right;
+    internal static bool IsLessThan(LiteralValueUnion left, LiteralValueUnion right) => left < right;
+    internal static bool IsGreaterThan(LiteralValueUnion left, LiteralValueUnion right) => left > right;
+    internal static bool IsLessThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left <= right;
+    internal static bool IsGreaterThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left >= right;
 }
 
 internal abstract record LeafFunctionNode : FunctionNode<LiteralValueUnion>
@@ -237,12 +250,15 @@ internal abstract record BinaryFunctionNode<TOut, TIn> : FunctionNode<TOut>
 
 internal record LessOrEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsLessThanOrEqual).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.LessThanOrEqual(leftExpression, rightExpression);
+        var comparison = Expression.LessThanOrEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }
@@ -252,12 +268,15 @@ internal record LessOrEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralVa
 
 internal record LessExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsLessThan).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.LessThan(leftExpression, rightExpression);
+        var comparison = Expression.LessThan(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }
@@ -267,12 +286,15 @@ internal record LessExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnio
 
 internal record GreaterOrEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsGreaterThanOrEqual).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.GreaterThanOrEqual(leftExpression, rightExpression);
+        var comparison = Expression.GreaterThanOrEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }
@@ -282,12 +304,15 @@ internal record GreaterOrEqualExpressionFnNode : BinaryFunctionNode<bool, Litera
 
 internal record GreaterExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsGreaterThan).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.GreaterThan(leftExpression, rightExpression);
+        var comparison = Expression.GreaterThan(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }
@@ -297,12 +322,15 @@ internal record GreaterExpressionFnNode : BinaryFunctionNode<bool, LiteralValueU
 
 internal record NotEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.AreNotEqual).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.NotEqual(leftExpression, rightExpression);
+        var comparison = Expression.NotEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }
@@ -312,12 +340,15 @@ internal record NotEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValue
 
 internal record EqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnion>
 {
+    private static readonly MethodInfo Method =
+        ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.AreEqual).Method;
+
     internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
-        var comparison = Expression.Equal(leftExpression, rightExpression);
+        var comparison = Expression.Equal(leftExpression, rightExpression, liftToNull: false, method: Method);
 
         return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
     }

--- a/src/Valtuutus.Core/Lang/ExpressionNode.cs
+++ b/src/Valtuutus.Core/Lang/ExpressionNode.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using System.Reflection;
 using Valtuutus.Lang;
 
 namespace Valtuutus.Core.Lang;
@@ -156,12 +157,21 @@ internal record BooleanLiteralFnNode : LeafFunctionNode
 
 internal record ParameterIdFnNode : LeafFunctionNode
 {
+    // IDictionary<string, object?>.get_Item, resolved once via a typeof() on the exact interface
+    // (a linker-recognized pattern that doesn't require DynamicallyAccessedMembers/produce a
+    // warning) rather than Expression.Property(instance, "Item", args), whose *overload* is
+    // unconditionally [RequiresUnreferencedCode] and throws under trimming/NativeAOT. Calling the
+    // indexer's own get_Item directly (not a wrapper method) keeps the compiled/interpreted tree
+    // identical in shape to the original code -- no extra call frame on this hot path.
+    private static readonly MethodInfo DictionaryIndexerGetMethod =
+        typeof(IDictionary<string, object?>).GetProperty("Item")!.GetGetMethod()!;
+
     internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
         var key = Expression.Constant(ParameterName);
 
-        var indexExpression = Expression.Property(args, "Item", key);
+        var indexExpression = Expression.Call(args, DictionaryIndexerGetMethod, key);
 
         var newLiteralValueUnionExpression = ParameterType switch
         {


### PR DESCRIPTION
## Summary

Two crashes in the same fallback path — `ExpressionNode.cs`'s runtime `System.Linq.Expressions` tree builder, used for schema `fn` bodies not covered by `SchemaFunctionsGen` (#216). Both found while publishing/running the #218 AOT spike (#225) with the source generator deliberately unwired, to exercise this exact path under a real AOT-published binary.

1. **`ParameterIdFnNode.GetExpression`** built the `fn` parameter accessor via `Expression.Property(args, "Item", key)`, which is unconditionally `[RequiresUnreferencedCode]` and throws at runtime under trimming. Fixed by resolving `IDictionary<string, object?>.get_Item` once via `typeof(IDictionary<...>).GetProperty("Item")` (a linker-recognized pattern) instead, and calling it directly — same call shape as before, no added overhead, actually cheaper since the lookup now happens once instead of per `GetExpression()` call.

2. **The six comparison nodes** (`EqualExpressionFnNode`, `NotEqualExpressionFnNode`, `LessExpressionFnNode`, `GreaterExpressionFnNode`, `LessOrEqualExpressionFnNode`, `GreaterOrEqualExpressionFnNode`) call `Expression.Equal`/`NotEqual`/`LessThan`/etc. on `LiteralValueUnion` operands without an explicit `MethodInfo`. Those factories search for a matching operator overload by reflection when no method is given, and `LiteralValueUnion`'s operators are only ever reached through that search — so trimming removes them and the search throws `ArgumentException`, **with zero publish-time warning** (unlike issue 1, this one is silent until you actually run the binary). Fixed by adding named static wrapper methods on `LiteralValueUnion` (so the trimmer sees a real call site and keeps the operators alive) and passing their `MethodInfo` explicitly into each `Expression` factory, skipping the reflection search.

`And`/`Or`/`Not` operate on primitive `bool` and don't need operator-overload search (intrinsic type), so they were never at risk.

## Test plan

- [x] `dotnet test tests/Valtuutus.Lang.Tests` — 65/65 pass across net8.0/9.0/10.0/11.0
- [x] `dotnet test tests/Valtuutus.Data.InMemory.Tests` — 207/207 pass across all TFMs
- [x] Published the #218 Core AOT sample with `SchemaFunctionsGen.All` deliberately omitted (forcing the actual runtime fallback) and a schema exercising all six comparisons (`>`, `<`, `>=`, `<=`, `!=`, `==`) plus `not`/`and` — zero warnings, correct `true` and `false` results for both branches, no crash