### PR TITLE
docs: document SchemaFunctionsGen wiring for schema fn functions

### DIFF
--- a/Storing Data.md
+++ b/Storing Data.md
@@ -253,18 +253,6 @@ The `Stream` overload of `AddValtuutusCore` takes the same second argument.
 
 **This is opt-in and silent if omitted** — there's no compile-time or publish-time warning, only a runtime `ArgumentException` under Native AOT (or the extra Expression-tree overhead otherwise). If your schema uses custom `fn`, always pass `SchemaFunctionsGen.All` once you've added the source generator package. Function names not present in the map (e.g. schemas loaded from a source not known at compile time, such as a database or admin API) still fall back to the Expression-tree path automatically.
 
-> Consuming the generator via the NuGet package (`dotnet add package Valtuutus.Lang.SourceGen`, as shown above) is enough — its `Valtuutus.Lang.SourceGen.props` wires up the `.vtt` file as an `AdditionalFiles` input automatically. If you instead reference the generator via `ProjectReference` (e.g. within this repo), you need to wire that up yourself:
-> ```xml
-> <ItemGroup>
->   <ProjectReference Include="..\Valtuutus.Lang.SourceGen\Valtuutus.Lang.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-> </ItemGroup>
->
-> <ItemGroup>
->   <EmbeddedResource Include="schema.vtt" />
->   <AdditionalFiles Include="schema.vtt" />
-> </ItemGroup>
-> ```
-
 ### Snap Tokens
 
 Every `Write` and `Delete` call returns a `SnapToken`:

--- a/Storing Data.md
+++ b/Storing Data.md
@@ -237,6 +237,34 @@ bool canView = await checkEngine.Check(
     cancellationToken);
 ```
 
+### Schema functions
+
+If your schema defines custom `fn` blocks (see `Schema Reference.md`), the same source generator can also compile them at build time instead of leaving them to be interpreted at schema-load time.
+
+By default, a schema's `fn` bodies are compiled into a `System.Linq.Expressions` tree the first time the schema is parsed (`ParameterIdFnNode.GetExpression` in `src/Valtuutus.Core/Lang/ExpressionNode.cs`). This works fine under the normal JIT, but it relies on reflection that **throws at runtime under Native AOT**, and even outside AOT it's extra interpreter/allocation overhead paid on every call.
+
+`Valtuutus.Lang.SourceGen` avoids this by emitting `SchemaFunctionsGen.All` — a build-time-compiled `IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>` covering every `fn` in the schema. Pass it into `AddValtuutusCore` as the second argument:
+
+```csharp
+builder.Services.AddValtuutusCore(schemaText, SchemaFunctionsGen.All);
+```
+
+The `Stream` overload of `AddValtuutusCore` takes the same second argument.
+
+**This is opt-in and silent if omitted** — there's no compile-time or publish-time warning, only a runtime `ArgumentException` under Native AOT (or the extra Expression-tree overhead otherwise). If your schema uses custom `fn`, always pass `SchemaFunctionsGen.All` once you've added the source generator package. Function names not present in the map (e.g. schemas loaded from a source not known at compile time, such as a database or admin API) still fall back to the Expression-tree path automatically.
+
+> Consuming the generator via the NuGet package (`dotnet add package Valtuutus.Lang.SourceGen`, as shown above) is enough — its `Valtuutus.Lang.SourceGen.props` wires up the `.vtt` file as an `AdditionalFiles` input automatically. If you instead reference the generator via `ProjectReference` (e.g. within this repo), you need to wire that up yourself:
+> ```xml
+> <ItemGroup>
+>   <ProjectReference Include="..\Valtuutus.Lang.SourceGen\Valtuutus.Lang.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+> </ItemGroup>
+>
+> <ItemGroup>
+>   <EmbeddedResource Include="schema.vtt" />
+>   <AdditionalFiles Include="schema.vtt" />
+> </ItemGroup>
+> ```
+
 ### Snap Tokens
 
 Every `Write` and `Delete` call returns a `SnapToken`:


### PR DESCRIPTION
## Summary
- Expands the "Schema constants" section in `Storing Data.md` with a new "Schema functions" subsection covering `SchemaFunctionsGen.All`.
- Explains the runtime Expression-tree fallback (`ParameterIdFnNode.GetExpression`), why it's an AOT hazard, and how `AddValtuutusCore(schemaText, SchemaFunctionsGen.All)` avoids it.
- Calls out that this is silent if omitted, and documents the extra `AdditionalFiles`/`EmbeddedResource` wiring needed only when consuming the generator via `ProjectReference` instead of the NuGet package.

Closes #226.

## Test plan
- N/A — docs only.