### PR TITLE
perf: schema-driven pruning of statically-dead check branches

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
+++ b/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
@@ -34,6 +34,20 @@ public abstract class BenchmarkBase
             SubjectType = "user", SubjectId = UserId
         }, CancellationToken.None);
 
+    /// <summary>
+    /// Dead-branch scenario: "access := admin or bot", where "bot" is a relation only
+    /// reachable by a "service_account" subject. Checking with SubjectType="user" makes the
+    /// "bot" branch statically unreachable — with subject-type pruning it's skipped entirely
+    /// (no task spawned, no DB round-trip); without it, both branches are evaluated.
+    /// </summary>
+    [Benchmark(Baseline = true), BenchmarkCategory("Check_Prune")]
+    public async Task<bool> Check_Prune()
+        => await _checkEngine.Check(new()
+        {
+            Permission = "access", EntityType = "organization", EntityId = OrgId,
+            SubjectType = "user", SubjectId = UserId
+        }, CancellationToken.None);
+
     [Benchmark(Baseline = true), BenchmarkCategory("SubjectPermission")]
     public async Task<Dictionary<string, bool>> SubjectPermission()
         => await _checkEngine.SubjectPermission(new()

--- a/benchmarks/Valtuutus.Benchmarks/schema.vtt
+++ b/benchmarks/Valtuutus.Benchmarks/schema.vtt
@@ -1,7 +1,10 @@
 entity user {}
+entity service_account {}
 entity organization {
     relation admin @user;
     relation member @user;
+    relation bot @service_account;
+    permission access := admin or bot;
 }
 entity team {
     relation owner @user;

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -326,16 +326,94 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         return !inner;
     }
 
+    // Direct (non-indirect) leaf-permission children whose target entity type can never
+    // reach req.SubjectType (per schema-precomputed reachability) are guaranteed to evaluate
+    // to false. Filtering them out here — before a Task/CheckNode/pool-slot gets spent on
+    // them — is equivalent to what CheckInternal's guard would eventually do, just earlier.
+    private bool IsStaticallyDeadForSubject(CheckRequest req, PermissionNode child)
+    {
+        if (child.Type != PermissionNodeType.Leaf) return false;
+        var leaf = child.LeafNode!;
+        if (leaf.Type != PermissionNodeLeafType.Permission) return false;
+        var permLeaf = leaf.PermissionNode!;
+        if (permLeaf.IsIndirect) return false;
+        return !schema.CanSubjectTypeReach(req.EntityType, permLeaf.Permission, req.SubjectType!);
+    }
+
     private async Task<bool> CheckExpressionChild(CheckRequest req, List<PermissionNode> children, CheckMemo memo, CheckNode? node, bool isUnion, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
-        var count = children.Count;
+        var totalCount = children.Count;
+        if (totalCount == 0) return !isUnion;
+
+        var subjectTypeKnown = !string.IsNullOrEmpty(req.SubjectType);
+
+        if (subjectTypeKnown && !isUnion)
+        {
+            // Intersect: a single statically-unreachable child makes the whole node false —
+            // short-circuit without spawning a task for it or any sibling.
+            for (var i = 0; i < totalCount; i++)
+            {
+                if (!IsStaticallyDeadForSubject(req, children[i])) continue;
+                if (node is not null)
+                {
+                    for (var j = 0; j < totalCount; j++)
+                    {
+                        var (type, name) = GetNodeInfo(children[j]);
+                        node._children.Add(new CheckNode
+                        {
+                            Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId,
+                            SubjectType = req.SubjectType, SubjectId = req.SubjectId, Result = false,
+                            Detail = "subject type cannot reach permission"
+                        });
+                    }
+                }
+                return false;
+            }
+        }
+
+        // Union: drop statically-dead children before spawning anything for them — they can
+        // only contribute `false`. Pruned nodes are recorded in explain mode up front, so in
+        // that mode they appear before the live children below rather than in schema order.
+        var live = children;
+        if (subjectTypeKnown && isUnion)
+        {
+            List<PermissionNode>? filtered = null;
+            for (var i = 0; i < totalCount; i++)
+            {
+                if (!IsStaticallyDeadForSubject(req, children[i]))
+                {
+                    filtered?.Add(children[i]);
+                    continue;
+                }
+
+                if (filtered is null)
+                {
+                    filtered = new List<PermissionNode>(totalCount);
+                    for (var j = 0; j < i; j++) filtered.Add(children[j]);
+                }
+
+                if (node is not null)
+                {
+                    var (type, name) = GetNodeInfo(children[i]);
+                    node._children.Add(new CheckNode
+                    {
+                        Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId,
+                        SubjectType = req.SubjectType, SubjectId = req.SubjectId, Result = false,
+                        Detail = "subject type cannot reach permission"
+                    });
+                }
+            }
+            if (filtered is not null) live = filtered;
+        }
+
+        var count = live.Count;
         if (count == 0) return !isUnion;
 
         if (count == 1)
         {
-            var only = children[0];
+            var only = live[0];
             CheckNode? childNode = null;
             if (node is not null)
             {
@@ -359,7 +437,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             childNodes = new CheckNode[count];
             for (var i = 0; i < count; i++)
             {
-                var (type, name) = GetNodeInfo(children[i]);
+                var (type, name) = GetNodeInfo(live[i]);
                 childNodes[i] = new CheckNode { Type = type, Name = name, EntityType = req.EntityType, EntityId = req.EntityId, SubjectType = req.SubjectType, SubjectId = req.SubjectId };
             }
         }
@@ -374,7 +452,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         {
             for (var i = 0; i < count; i++)
             {
-                var child = children[i];
+                var child = live[i];
                 var childNode = childNodes?[i];
                 rawTasks[i] = child.Type == PermissionNodeType.Expression
                     ? CheckExpression(req, child, memo, childNode, ct)

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -566,6 +566,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 EntityType = only.SubjectType,
                 EntityId = only.SubjectId,
                 Permission = only.SubjectRelation,
+                SubjectType = req.SubjectType,
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
@@ -624,6 +625,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                     EntityType = relation.SubjectType,
                     EntityId = relation.SubjectId,
                     Permission = relation.SubjectRelation,
+                    SubjectType = req.SubjectType,
                     SubjectId = req.SubjectId,
                     SnapToken = req.SnapToken,
                     Depth = req.Depth
@@ -707,6 +709,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 EntityType = only.SubjectType,
                 EntityId = only.SubjectId,
                 Permission = only.SubjectRelation,
+                SubjectType = req.SubjectType,
                 SubjectId = req.SubjectId,
                 SnapToken = req.SnapToken,
                 Depth = req.Depth
@@ -745,6 +748,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                     EntityType = relation.SubjectType,
                     EntityId = relation.SubjectId,
                     Permission = relation.SubjectRelation,
+                    SubjectType = req.SubjectType,
                     SubjectId = req.SubjectId,
                     SnapToken = req.SnapToken,
                     Depth = req.Depth

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -540,25 +540,37 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
                 SnapToken = req.SnapToken ?? SnapToken.MinValue
             }, ct);
 
-        using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
+        // Attribute order/completeness from the reader isn't guaranteed across providers
+        // (a WHERE attribute IN (...) filter can return fewer rows than requested, in any
+        // order), so index-matching against attributeArguments isn't safe. Build a lookup
+        // once instead of rescanning `attributes` per function parameter.
+        var attributesByName = DictionaryPool<string, AttributeTuple>.Rent();
+        try
+        {
+            foreach (var a in attributes)
+                attributesByName[a.Attribute] = a;
 
-        using var fnArgs = paramToArg.ToLambdaArgs(
-            static (arg, state) =>
-            {
-                var (attrs, entityType, sch) = state;
-                foreach (var a in attrs)
+            using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
+
+            using var fnArgs = paramToArg.ToLambdaArgs(
+                static (arg, state) =>
                 {
-                    if (a.Attribute == arg.AttributeName)
-                        return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
-                }
-                return null;
-            },
-            (attributes, req.EntityType, schema),
-            req.Context);
+                    var (byName, entityType, sch) = state;
+                    return byName.TryGetValue(arg.AttributeName, out var a)
+                        ? a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type)
+                        : null;
+                },
+                (attributesByName, req.EntityType, schema),
+                req.Context);
 
-        var result = fn.Lambda(fnArgs.Dictionary);
-        if (node is not null) node.Detail = $"fn result={result}";
-        return result;
+            var result = fn.Lambda(fnArgs.Dictionary);
+            if (node is not null) node.Detail = $"fn result={result}";
+            return result;
+        }
+        finally
+        {
+            DictionaryPool<string, AttributeTuple>.Return(attributesByName);
+        }
     }
 
     private Task<bool> CheckLeafPermission(CheckRequest req, PermissionNodeLeafPermission leafPerm, CheckMemo memo, CheckNode? node, CancellationToken ct)

--- a/src/Valtuutus.Core/Engines/ContextUtils.cs
+++ b/src/Valtuutus.Core/Engines/ContextUtils.cs
@@ -9,12 +9,12 @@ internal static class ContextUtils
     // Like if the context prop is null or not found
     internal static bool IsContextValid(this PermissionNodeLeafExp node, IDictionary<string, object> context)
     {
-        return node.Args.All(a =>
-            a.Type != PermissionNodeExpArgumentType.ContextAccess
-            || (
-                context.ContainsKey(((PermissionNodeExpArgumentContextAccess)a).ContextPropertyName)
-                    && context[((PermissionNodeExpArgumentContextAccess)a).ContextPropertyName] is not null
-            )
-        );
+        foreach (var a in node.Args)
+        {
+            if (a.Type != PermissionNodeExpArgumentType.ContextAccess) continue;
+            var propertyName = ((PermissionNodeExpArgumentContextAccess)a).ContextPropertyName;
+            if (!context.TryGetValue(propertyName, out var value) || value is null) return false;
+        }
+        return true;
     }
 }

--- a/src/Valtuutus.Core/Schemas/Permission.cs
+++ b/src/Valtuutus.Core/Schemas/Permission.cs
@@ -173,6 +173,46 @@ internal record PermissionNode(PermissionNodeType Type)
             { ExpressionNode = new PermissionNodeOperation(PermissionOperation.Negate, [child]) };
     }
 
+    /// <summary>
+    /// Collapses nested same-operator Union/Intersect chains (e.g. the binary tree the DSL
+    /// parser produces for "a or b or c") into a single n-ary node, bottom-up. Each flattened
+    /// level splices an already-flattened same-operator child's children directly into the
+    /// parent, so arbitrarily deep chains collapse in one pass.
+    /// </summary>
+    internal static PermissionNode Flatten(PermissionNode node)
+    {
+        if (node.Type != PermissionNodeType.Expression) return node;
+        var expr = node.ExpressionNode!;
+
+        if (expr.Operation == PermissionOperation.Negate)
+        {
+            var flatChild = Flatten(expr.Children[0]);
+            return ReferenceEquals(flatChild, expr.Children[0]) ? node : Negate(flatChild);
+        }
+
+        var op = expr.Operation;
+        var flattenedChildren = new List<PermissionNode>(expr.Children.Count);
+        var changed = false;
+        foreach (var child in expr.Children)
+        {
+            var flatChild = Flatten(child);
+            if (flatChild.Type == PermissionNodeType.Expression && flatChild.ExpressionNode!.Operation == op)
+            {
+                flattenedChildren.AddRange(flatChild.ExpressionNode.Children);
+                changed = true;
+            }
+            else
+            {
+                flattenedChildren.Add(flatChild);
+                if (!ReferenceEquals(flatChild, child)) changed = true;
+            }
+        }
+
+        if (!changed) return node;
+        return new PermissionNode(PermissionNodeType.Expression)
+            { ExpressionNode = new PermissionNodeOperation(op, flattenedChildren) };
+    }
+
     public static PermissionNode Expression(string functionName, PermissionNodeExpArgument[] args)
     {
         return new PermissionNode(PermissionNodeType.Leaf)

--- a/src/Valtuutus.Core/Schemas/SchemaBuilder.cs
+++ b/src/Valtuutus.Core/Schemas/SchemaBuilder.cs
@@ -48,7 +48,7 @@ internal class EntitySchemaBuilder(string name, SchemaBuilder schemaBuilder)
 
     public EntitySchemaBuilder WithPermission(string permissionName, PermissionNode permissionTree)
     {
-        _permissions.Add(permissionName, new Permission(permissionName, permissionTree));
+        _permissions.Add(permissionName, new Permission(permissionName, PermissionNode.Flatten(permissionTree)));
         return this;
     }
 


### PR DESCRIPTION
## Summary
- Fix a bug where `SubjectType` silently dropped to `null` on 4 recursive `CheckRequest` construction sites in `CheckTupleToUserSet`/`CheckRelation`, disabling `Schema.CanSubjectTypeReach` pruning below the first hop and fragmenting the `CheckMemo` cache across those paths.
- Use that (now consistently-available) reachability data in `CheckExpressionChild` to prune Union/Intersect children that are statically unreachable for the request's subject type, before spawning a task for them — Union drops them, Intersect short-circuits to `false` immediately.
- Flatten nested same-operator Union/Intersect trees (the DSL parser emits binary trees for `a or b or c`) into a single n-ary node at schema-build time, removing redundant recursion levels.
- Two small allocation removals on the function-leaf check hot path (`ContextUtils.IsContextValid`, attribute lookup in `CheckLeafFn`).
- Add a `Check_Prune` benchmark scenario (heterogeneous subject types) so the pruning work has something real to measure — existing benchmarks only ever check a single terminal subject type (`user`), so the pruning had nothing to prune there.

## Results (InMemory provider, BenchmarkDotNet ShortRun)
- `Check_Prune`: 3.4us / 3.1KB -> 0.74us / 1.1KB (dead branch fully pruned, no task/DB round-trip)
- `Check_Complex` / `Check_Diamond` / `Check_Simple`: flat, no regression
- The SubjectType-propagation fix and tree-flattening are correct (all tests pass across every provider) but aren't proven with a benchmark number yet — the current schema doesn't have a scenario shaped to exercise either (mixed-principal group chains for the former, a 3+-way OR for the latter).

## Test plan
- [x] `dotnet build` on the full solution
- [x] `Valtuutus.Data.InMemory.Tests` (207 tests x 4 target frameworks)
- [x] `Valtuutus.Data.Postgres.Tests` (212 tests x 4 target frameworks)
- [x] `Valtuutus.Data.SqlServer.Tests` (332 tests x 4 target frameworks)
- [x] `Valtuutus.Lang.Tests`, `Valtuutus.Lang.SourceGen.Tests`, `Valtuutus.Lang.SourceGen.IntegrationTests`, `Valtuutus.Api.Tests`
- [x] Benchmarked each commit individually against the prior baseline