### PR TITLE
fix+perf: LookupEntityEngine Scope/Negate bug and schema-driven pruning

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
+++ b/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
@@ -84,8 +84,10 @@ public abstract class BenchmarkBase
 
     /// <summary>
     /// TTU diamond: folder.view := owner or editor, both @group#member pointing to the
-    /// same group. Both branches issue (group, member, [userId]) — second branch is a
-    /// pure memo hit with the optimization, two full traversals without.
+    /// same group. LookupEntityEngine has no general-purpose memo (only AttributeCache, which
+    /// is attribute-fetch-only) — the speedup here instead comes from GetRelationsJoined/
+    /// JoinedLookup (LookupEntityEngine.cs), which collapses each branch's two-hop
+    /// dependent-then-main traversal into a single joined query.
     /// </summary>
     [Benchmark(Baseline = true), BenchmarkCategory("LookupEntity_Diamond")]
     public async Task<LookupEntityPage> LookupEntity_Diamond()

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -53,6 +53,10 @@ public sealed class LookupEntityEngine(
         }
 
         var snapToken = await SnapTokenUtils.ResolveLatest(reader, req.SnapToken, cancellationToken);
+
+        if (!schema.CanSubjectTypeReach(req.EntityType, req.Permission, req.SubjectType))
+            return new LookupEntityPage([], null);
+
         var internalReq = new LookupEntityRequestInternal
         {
             Permission = req.Permission,
@@ -158,32 +162,86 @@ public sealed class LookupEntityEngine(
         };
     }
 
+    // A leaf that is a direct, non-indirect permission reference and is statically unreachable
+    // for req.FinalSubjectType (per schema-precomputed reachability) can only ever contribute an
+    // empty result. FinalSubjectType — not SubjectType — is the right field to prune against:
+    // SubjectType gets reassigned per recursion hop (e.g. to an intermediate group type while
+    // walking a group#member chain, see LookupRelationCore), while FinalSubjectType stays fixed
+    // as the true ultimate subject for the whole LookupEntity call, same as LookupRelation's
+    // existing (weaker, single-hop) guard already compares against.
+    private bool IsStaticallyDeadForSubject(LookupEntityRequestInternal req, PermissionNode child)
+    {
+        if (child.Type != PermissionNodeType.Leaf) return false;
+        var leaf = child.LeafNode!;
+        if (leaf.Type != PermissionNodeLeafType.Permission) return false;
+        var permLeaf = leaf.PermissionNode!;
+        if (permLeaf.IsIndirect) return false;
+        return !schema.CanSubjectTypeReach(req.EntityType, permLeaf.Permission, req.FinalSubjectType);
+    }
+
     private async Task<List<LookupEntityResult>> LookupExpressionChildren(LookupEntityRequestInternal req,
         List<PermissionNode> children, bool isUnion, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
-        if (!isUnion && HasMixedAttributeAndRelationChildren(children))
-            return await LookupIntersectionConstrained(req, children, ct);
+        var totalCount = children.Count;
 
-        if (!isUnion && HasNegateAndPositiveChildren(children))
-            return await LookupIntersectionWithNegate(req, children, ct);
+        if (!isUnion)
+        {
+            // Intersect: a single statically-unreachable child makes the whole node empty —
+            // short-circuit without spawning a task for it or any sibling.
+            for (var i = 0; i < totalCount; i++)
+            {
+                if (IsStaticallyDeadForSubject(req, children[i]))
+                    return ListPool<LookupEntityResult>.Rent();
+            }
+        }
+
+        // Union: drop statically-dead children before spawning anything for them — they can
+        // only contribute an empty result.
+        var live = children;
+        if (isUnion)
+        {
+            List<PermissionNode>? filtered = null;
+            for (var i = 0; i < totalCount; i++)
+            {
+                if (!IsStaticallyDeadForSubject(req, children[i]))
+                {
+                    filtered?.Add(children[i]);
+                    continue;
+                }
+
+                if (filtered is null)
+                {
+                    filtered = new List<PermissionNode>(totalCount);
+                    for (var j = 0; j < i; j++) filtered.Add(children[j]);
+                }
+            }
+            if (filtered is not null) live = filtered;
+            if (live.Count == 0) return ListPool<LookupEntityResult>.Rent();
+        }
+
+        if (!isUnion && HasMixedAttributeAndRelationChildren(live))
+            return await LookupIntersectionConstrained(req, live, ct);
+
+        if (!isUnion && HasNegateAndPositiveChildren(live))
+            return await LookupIntersectionWithNegate(req, live, ct);
 
         var pool = ArrayPool<Task<List<LookupEntityResult>>>.Shared;
-        var buffer = pool.Rent(children.Count);
+        var buffer = pool.Rent(live.Count);
         try
         {
-            for (var i = 0; i < children.Count; i++)
+            for (var i = 0; i < live.Count; i++)
             {
-                var child = children[i];
+                var child = live[i];
                 buffer[i] = child.Type == PermissionNodeType.Expression
                     ? LookupExpression(req, child.ExpressionNode!, ct)
                     : LookupLeaf(req, child.LeafNode!, ct);
             }
 
             return isUnion
-                ? await UnionEntities(buffer, children.Count)
-                : await IntersectEntities(buffer, children.Count);
+                ? await UnionEntities(buffer, live.Count)
+                : await IntersectEntities(buffer, live.Count);
         }
         finally
         {
@@ -664,6 +722,30 @@ public sealed class LookupEntityEngine(
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
+        // GetEntityIdsExcluding is a global complement over the whole entity type — it has no
+        // Scope concept, unlike every other leaf path here. Resolve scope the same way
+        // LookupAttribute does and filter the complement down to it, so a scoped Negate/not(...)
+        // can't leak entities from outside the requested scope.
+        HashSet<string>? scopedEntityIds = null;
+        if (req.Scope is { } scope)
+        {
+            using var scopeRelations = await reader.GetRelationsWithSubjectsIds(
+                new EntityRelationFilter
+                {
+                    EntityType = req.EntityType,
+                    Relation = scope.Relation,
+                    SnapToken = req.SnapToken ?? SnapToken.MinValue
+                },
+                [scope.SubjectId],
+                scope.SubjectType,
+                null,
+                ct);
+            if (scopeRelations.Count == 0)
+                return ListPool<LookupEntityResult>.Rent();
+            scopedEntityIds = new HashSet<string>(scopeRelations.Count);
+            foreach (var r in scopeRelations) scopedEntityIds.Add(r.EntityId);
+        }
+
         var matching = await (child.Type == PermissionNodeType.Expression
             ? LookupExpression(req, child.ExpressionNode!, ct)
             : LookupLeaf(req, child.LeafNode!, ct));
@@ -684,7 +766,10 @@ public sealed class LookupEntityEngine(
 
         var result = ListPool<LookupEntityResult>.Rent();
         foreach (var id in complementIds)
+        {
+            if (scopedEntityIds is not null && !scopedEntityIds.Contains(id)) continue;
             result.Add(new LookupEntityResult(req.EntityType, id));
+        }
         return result;
     }
 

--- a/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
@@ -809,4 +809,141 @@ public abstract class BaseLookupEntityEngineSpecs : IAsyncLifetime
         // doc3 and doc4: alice has neither relation → included
         result.EntityIds.Should().BeEquivalentTo(["doc3", "doc4"]);
     }
+
+    [Fact]
+    public async Task ScopedLookup_TopLevelNegate_ExcludesOutOfScopeEntities()
+    {
+        const string schema = """
+            entity user {}
+            entity org {}
+            entity document {
+                relation org @org;
+                relation owner @user;
+                permission non_owner := not(owner);
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("document", "doc1", "org", "org", "org1"),
+                new RelationTuple("document", "doc1", "owner", "user", "alice"),
+                new RelationTuple("document", "doc2", "org", "org", "org1"),
+                new RelationTuple("document", "doc2", "owner", "user", "bob"),
+                new RelationTuple("document", "doc3", "org", "org", "org2"),
+                new RelationTuple("document", "doc3", "owner", "user", "bob"),
+            ], [], schema);
+
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("document", "non_owner", "user", "alice")
+            {
+                Scope = new EntityScope("org", "org", "org1")
+            },
+            CancellationToken.None);
+
+        // doc1: alice owns it → fails not(owner)
+        // doc2: in scope (org1), alice doesn't own it → passes
+        // doc3: alice doesn't own it either, but it's out of scope (org2) — must still be
+        // excluded. Without the fix, GetEntityIdsExcluding ignores Scope entirely and doc3
+        // would incorrectly leak into the result.
+        result.EntityIds.Should().BeEquivalentTo(["doc2"]);
+    }
+
+    [Fact]
+    public async Task ScopedLookup_UnionNestedNegate_ExcludesOutOfScopeEntities()
+    {
+        const string schema = """
+            entity user {}
+            entity org {}
+            entity document {
+                relation org @org;
+                relation owner @user;
+                relation viewer @user;
+                permission special := viewer or not(owner);
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("document", "doc1", "org", "org", "org1"),
+                new RelationTuple("document", "doc1", "owner", "user", "alice"),
+                new RelationTuple("document", "doc2", "org", "org", "org1"),
+                new RelationTuple("document", "doc2", "owner", "user", "bob"),
+                new RelationTuple("document", "doc3", "org", "org", "org2"),
+                new RelationTuple("document", "doc3", "owner", "user", "bob"),
+            ], [], schema);
+
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("document", "special", "user", "alice")
+            {
+                Scope = new EntityScope("org", "org", "org1")
+            },
+            CancellationToken.None);
+
+        // Same fix, exercised via a Negate node reached as a Union child (LookupExpressionChildren's
+        // Union branch dispatches it through LookupExpression -> LookupNegate, same function as the
+        // top-level case above) rather than as the whole permission tree.
+        // doc1: alice owns → not(owner) fails, alice isn't viewer either → excluded
+        // doc2: in scope, alice doesn't own → passes
+        // doc3: alice doesn't own either, but out of scope → must still be excluded
+        result.EntityIds.Should().BeEquivalentTo(["doc2"]);
+    }
+
+    [Fact]
+    public async Task LookupEntity_UnionWithHeterogeneousSubjectType_PrunesDeadBranchCorrectly()
+    {
+        const string schema = """
+            entity user {}
+            entity service_account {}
+            entity organization {
+                relation admin @user;
+                relation bot @service_account;
+                permission access := admin or bot;
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("organization", "org1", "admin", "user", "alice"),
+                new RelationTuple("organization", "org2", "bot", "service_account", "svc1"),
+            ], [], schema);
+
+        // subjectType=user: the "bot" branch (service_account-only) is statically unreachable and
+        // gets pruned before any task is spawned for it. org2 (only reachable via bot) must not
+        // appear, and org1 (via admin) must still be found correctly despite its sibling being
+        // pruned out of the Union.
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("organization", "access", "user", "alice"),
+            CancellationToken.None);
+
+        result.EntityIds.Should().BeEquivalentTo(["org1"]);
+    }
+
+    [Fact]
+    public async Task LookupEntity_IntersectWithHeterogeneousSubjectType_PrunesToEmpty()
+    {
+        const string schema = """
+            entity user {}
+            entity service_account {}
+            entity organization {
+                relation admin @user;
+                relation bot @service_account;
+                permission strict_access := admin and bot;
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("organization", "org1", "admin", "user", "alice"),
+                new RelationTuple("organization", "org1", "bot", "service_account", "svc1"),
+            ], [], schema);
+
+        // subjectType=user: "bot" is statically unreachable for a user subject, so the whole
+        // Intersect is provably empty regardless of what tuples exist — even though org1 has
+        // both an admin=alice AND a bot=svc1 tuple, a user can never satisfy "bot".
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("organization", "strict_access", "user", "alice"),
+            CancellationToken.None);
+
+        result.EntityIds.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
Closes #233.

## Summary
- **Bug fix**: `LookupNegate`'s `GetEntityIdsExcluding` call has no `Scope` concept, unlike every other leaf path in `LookupEntityEngine` (`LookupAttribute`, `LookupRelationLeaf`, `JoinedLookup`). A scoped `LookupEntity` call whose permission tree contains `not(...)` — at the top level or as a Union child — silently returned entities from outside the requested scope. Fixed by resolving `Scope` into an entity-id set (same pattern `LookupAttribute` already uses) and filtering the complement against it.
- **Perf**: `LookupEntityEngine` walks the same `PermissionNode` tree as `CheckEngine` but never got `Schema.CanSubjectTypeReach` wired in (#232). Adds the same two pieces here: an entrypoint guard in `LookupEntity` so a fully-dead top-level query returns empty without recursing, and a dead-branch pruning pre-pass in `LookupExpressionChildren` so Union/Intersect children that are statically unreachable get filtered before a task is spawned for them. Pruned against `req.FinalSubjectType`, not `req.SubjectType` — the latter gets reassigned per recursion hop (e.g. to an intermediate group type while walking a `group#member` chain), while `FinalSubjectType` stays fixed as the true ultimate subject, matching the convention `LookupRelation`'s existing single-hop guard already uses.
- **Docs**: corrects the `LookupEntity_Diamond` benchmark comment, which claimed a "memo hit" — this engine has no general-purpose memo (only `AttributeCache`, attribute-fetch-only); the actual mechanism is the `GetRelationsJoined`/`JoinedLookup` two-hop query collapse.

Sibling-relation batching (the other idea originally scoped on #233) is tracked separately as #237/#238 — a larger change (new provider methods across 3 providers) that needs its own PR.

## Test plan
- [x] `dotnet build` on the full solution
- [x] `Valtuutus.Data.InMemory.Tests` (211 tests × 4 target frameworks)
- [x] `Valtuutus.Data.Postgres.Tests` (216 tests × 4 target frameworks)
- [x] `Valtuutus.Data.SqlServer.Tests` (340 tests × 4 target frameworks)
- [x] `Valtuutus.Api.Tests`, `Valtuutus.Lang.Tests`, `Valtuutus.Lang.SourceGen.Tests`, `Valtuutus.Lang.SourceGen.IntegrationTests`
- [x] New tests: Scope + top-level Negate, Scope + Union-nested Negate, Union pruning correctness, Intersect pruning-to-empty correctness — run against all three real providers
- [x] `LookupEntity`/`LookupEntity_Diamond`/`LookupEntity_Scoped` benchmarked before/after against a clean `dev` baseline — all within noise, allocations byte-identical (the guard/pruning pre-pass costs nothing when there's nothing to prune)