### PR TITLE
fix: Bencher upload overwrites per-provider benchmark results (Namespace collision)

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -15,8 +15,12 @@ permissions:
 
 jobs:
   benchmark_base_branch:
-    name: Continuous Benchmarking with Bencher
+    name: Continuous Benchmarking with Bencher (${{ matrix.provider }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [InMemoryBenchmarks, PostgresBenchmarks, SqlServerBenchmarks]
     steps:
       - uses: actions/checkout@v7
       - name: Setup dotnet
@@ -30,11 +34,11 @@ jobs:
           include-prerelease: true
       - name: Run Benchmarks
         run: |
-          dotnet run -f net10.0 -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
-      - name: Strip failed benchmarks from results
+          dotnet run -f net10.0 -c Release --filter "*${{ matrix.provider }}*" --project benchmarks/Valtuutus.Benchmarks/
+      - name: Strip failed benchmarks and disambiguate namespace by provider
         run: |
           for f in BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do
-            jq '.Benchmarks |= map(select(.Statistics != null))' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+            jq '.Benchmarks |= (map(select(.Statistics != null)) | map(.Namespace = .Namespace + ".${{ matrix.provider }}"))' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
           done
       - uses: bencherdev/bencher@main
       - name: Track base branch benchmarks with Bencher

--- a/.github/workflows/post_pr_benchmarks.yml
+++ b/.github/workflows/post_pr_benchmarks.yml
@@ -16,13 +16,15 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      BENCHMARK_RESULTS: benchmark_results
+      BENCHMARK_RESULTS: benchmark_results_.*
       PR_EVENT: event.json
     steps:
       - name: Download Benchmark Results
         uses: dawidd6/action-download-artifact@v21
         with:
           name: ${{ env.BENCHMARK_RESULTS }}
+          name_is_regexp: true
+          merge_multiple: true
           run_id: ${{ github.event.workflow_run.id }}
       - name: Download PR Event
         uses: dawidd6/action-download-artifact@v21

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -11,9 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark_base_branch:
-    name: Run Benchmarks
+  upload_pr_event:
+    name: Upload PR Event
     runs-on: ubuntu-latest
+    steps:
+      - name: Upload GitHub Pull Request Event
+        uses: actions/upload-artifact@v7
+        with:
+          name: event.json
+          path: ${{ github.event_path }}
+
+  benchmark_base_branch:
+    name: Run Benchmarks (${{ matrix.provider }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [InMemoryBenchmarks, PostgresBenchmarks, SqlServerBenchmarks]
     steps:
       - uses: actions/checkout@v7
       - name: Setup dotnet
@@ -27,14 +41,14 @@ jobs:
           include-prerelease: true
       - name: Run Benchmarks
         run: |
-          dotnet run -f net10.0 -c Release --filter '*' --project benchmarks/Valtuutus.Benchmarks/
+          dotnet run -f net10.0 -c Release --filter "*${{ matrix.provider }}*" --project benchmarks/Valtuutus.Benchmarks/
+      - name: Disambiguate benchmark namespace by provider
+        run: |
+          for f in BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do
+            jq '.Benchmarks[] |= (.Namespace = .Namespace + ".${{ matrix.provider }}")' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          done
       - name: Upload Benchmark Results
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark_results
+          name: benchmark_results_${{ matrix.provider }}
           path: BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json
-      - name: Upload GitHub Pull Request Event
-        uses: actions/upload-artifact@v7
-        with:
-          name: event.json
-          path: ${{ github.event_path }}


### PR DESCRIPTION
## Summary
- Bencher's `c_sharp_dot_net` adapter tracks results by `Namespace + Method` only (never reads `Type`), so InMemory/Postgres/SqlServer benchmarks all collapsed onto the same series (`Valtuutus.Benchmarks.Check_Complex`), each clobbering the previous.
- Split `pr_benchmarks.yml` and `base_benchmarks.yml` into a matrix (one job per provider), filtering `dotnet run` to only that provider's benchmark class.
- Patch each report's `Namespace` to embed the provider class name before upload/tracking, so results land as distinct series.
- Updated `post_pr_benchmarks.yml` to download all 3 per-provider artifacts (regex match + merge) instead of one shared `benchmark_results` artifact.
- Moved the PR-event upload into its own non-matrix job to avoid an artifact-name collision across matrix jobs.

Fixes #242

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all 3 changed workflow files
- [x] `actionlint` clean on all 3 changed workflow files
- [x] jq Namespace-patch and strip-failed transforms verified against mock BenchmarkDotNet report JSON
- [ ] Confirm on next PR run that Bencher shows 3 distinct series (InMemory/Postgres/SqlServer) instead of 1