### PR TITLE
perf: extend LookupEntityEngine sibling-relation batching to constrained/negate Intersect paths

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
+++ b/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
@@ -99,6 +99,33 @@ public abstract class BenchmarkBase
         }, CancellationToken.None);
 
     /// <summary>
+    /// team.constrained_sibling_batch := isActive(active) and owner and member — an Intersect
+    /// mixing one attribute-expression leaf with 2 batchable direct-@user-relation siblings
+    /// (owner, member). Exercises LookupIntersectionConstrained's non-attribute-child loop
+    /// batching added in #243 (deferred out of #237's generic-path-only scope).
+    /// </summary>
+    [Benchmark(Baseline = true), BenchmarkCategory("LookupEntity_ConstrainedSiblingBatch")]
+    public async Task<LookupEntityPage> LookupEntity_ConstrainedSiblingBatch()
+        => await _lookupEntityEngine.LookupEntity(new()
+        {
+            Permission = "constrained_sibling_batch", EntityType = "team",
+            SubjectType = "user", SubjectId = UserId
+        }, CancellationToken.None);
+
+    /// <summary>
+    /// team.negate_sibling_batch := owner and member and not(banned) — an Intersect mixing 2
+    /// batchable direct-@user-relation siblings (owner, member) with a Negate child. Exercises
+    /// LookupIntersectionWithNegate's positive-child loop batching added in #243.
+    /// </summary>
+    [Benchmark(Baseline = true), BenchmarkCategory("LookupEntity_NegateSiblingBatch")]
+    public async Task<LookupEntityPage> LookupEntity_NegateSiblingBatch()
+        => await _lookupEntityEngine.LookupEntity(new()
+        {
+            Permission = "negate_sibling_batch", EntityType = "team",
+            SubjectType = "user", SubjectId = UserId
+        }, CancellationToken.None);
+
+    /// <summary>
     /// project.reviewers has two indirect variants (team#member, group#member) — neither is
     /// the "user" subject type directly, so both require a dependent query and can fire
     /// concurrently instead of serializing.

--- a/benchmarks/Valtuutus.Benchmarks/schema.vtt
+++ b/benchmarks/Valtuutus.Benchmarks/schema.vtt
@@ -9,11 +9,15 @@ entity organization {
 entity team {
     relation owner @user;
     relation member @user;
+    relation banned @user;
     relation org @organization;
+    attribute active bool;
     permission edit := org.admin or owner;
     permission delete := org.admin or owner;
     permission invite := org.admin and (owner or member);
     permission remove_user := owner;
+    permission constrained_sibling_batch := isActive(active) and owner and member;
+    permission negate_sibling_batch := owner and member and not(banned);
 }
 entity group {
     relation member @user;
@@ -39,3 +43,4 @@ entity folder {
 }
 
 fn isActiveStatus(status int) => status == 1;
+fn isActive(active bool) => active == true;

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -256,16 +256,11 @@ public sealed class LookupEntityEngine(
             if (live.Count == 0) return ListPool<LookupEntityResult>.Rent();
         }
 
-        if (!isUnion && HasMixedAttributeAndRelationChildren(live))
-            return await LookupIntersectionConstrained(req, live, ct);
-
-        if (!isUnion && HasNegateAndPositiveChildren(live))
-            return await LookupIntersectionWithNegate(req, live, ct);
-
         // Batch sibling direct-relation leaves on req.EntityType into a single provider call
-        // instead of N separate LookupRelationLeaf round trips. Only fires for the plain
-        // Union/Intersect fallthrough here — LookupIntersectionConstrained and
-        // LookupIntersectionWithNegate don't get this yet (tracked separately, #243).
+        // instead of N separate LookupRelationLeaf round trips. Computed once off the full live
+        // list, before routing to a specialized dispatch below — IsBatchableDirectRelation only
+        // matches plain top-level relation leaves, so attribute-expression and Negate children in
+        // live are naturally skipped here regardless of which path ends up consuming batchResults.
         Dictionary<string, List<LookupEntityResult>>? batchResults = null;
         List<string>? toFetch = null;
         for (var i = 0; i < live.Count; i++)
@@ -286,6 +281,12 @@ public sealed class LookupEntityEngine(
             foreach (var row in rows)
                 batchResults[row.Relation].Add(new LookupEntityResult(row.EntityType, row.EntityId, row.SubjectType, row.SubjectId));
         }
+
+        if (!isUnion && HasMixedAttributeAndRelationChildren(live))
+            return await LookupIntersectionConstrained(req, live, batchResults, ct);
+
+        if (!isUnion && HasNegateAndPositiveChildren(live))
+            return await LookupIntersectionWithNegate(req, live, batchResults, ct);
 
         var pool = ArrayPool<Task<List<LookupEntityResult>>>.Shared;
         var buffer = pool.Rent(live.Count);
@@ -319,7 +320,8 @@ public sealed class LookupEntityEngine(
     }
 
     private async Task<List<LookupEntityResult>> LookupIntersectionConstrained(
-        LookupEntityRequestInternal req, List<PermissionNode> children, CancellationToken ct)
+        LookupEntityRequestInternal req, List<PermissionNode> children,
+        Dictionary<string, List<LookupEntityResult>>? batchResults, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
@@ -337,9 +339,7 @@ public sealed class LookupEntityEngine(
                     child.LeafNode!.Type == PermissionNodeLeafType.Expression)
                     attrLeaves.Add(child.LeafNode.ExpressionNode!);
                 else
-                    nonAttrBuffer[nonAttrCount++] = child.Type == PermissionNodeType.Expression
-                        ? LookupExpression(req, child.ExpressionNode!, ct)
-                        : LookupLeaf(req, child.LeafNode!, ct);
+                    nonAttrBuffer[nonAttrCount++] = ResolveChild(req, batchResults, child, ct);
             }
             nonAttrResults = await Task.WhenAll(new ArraySegment<Task<List<LookupEntityResult>>>(nonAttrBuffer, 0, nonAttrCount));
         }
@@ -832,7 +832,8 @@ public sealed class LookupEntityEngine(
     // Evaluates positive children first, then subtracts the Negate children's matches
     // in-memory — avoids the full-table-scan GetEntityIdsExcluding DB call.
     private async Task<List<LookupEntityResult>> LookupIntersectionWithNegate(
-        LookupEntityRequestInternal req, List<PermissionNode> children, CancellationToken ct)
+        LookupEntityRequestInternal req, List<PermissionNode> children,
+        Dictionary<string, List<LookupEntityResult>>? batchResults, CancellationToken ct)
     {
         using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
 
@@ -857,9 +858,7 @@ public sealed class LookupEntityEngine(
                 }
                 else
                 {
-                    positiveBuffer[positiveCount++] = child.Type == PermissionNodeType.Expression
-                        ? LookupExpression(req, child.ExpressionNode!, ct)
-                        : LookupLeaf(req, child.LeafNode!, ct);
+                    positiveBuffer[positiveCount++] = ResolveChild(req, batchResults, child, ct);
                 }
             }
 

--- a/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseLookupEntityEngineSpecs.cs
@@ -690,6 +690,88 @@ public abstract class BaseLookupEntityEngineSpecs : IAsyncLifetime
     }
 
     /// <summary>
+    /// team.constrained_test := isActive(active) and owner and member — an Intersect mixing one
+    /// attribute-expression leaf with two plain direct-@user-relation siblings (owner, member),
+    /// the shape LookupIntersectionConstrained's non-attribute-child loop batches (#243). Proves
+    /// the batched dispatch still requires ALL three children to match: both relations plus the
+    /// attribute.
+    /// </summary>
+    [Fact]
+    public async Task LookupEntity_ConstrainedIntersectionWithSiblingDirectRelations_BatchesCorrectly()
+    {
+        const string schema = """
+            entity user {}
+            entity team {
+                relation owner @user;
+                relation member @user;
+                attribute active bool;
+                permission constrained_test := isActive(active) and owner and member;
+            }
+            fn isActive(active bool) => active == true;
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("team", "t1", "owner", "user", "alice"),
+                new RelationTuple("team", "t1", "member", "user", "alice"),
+                new RelationTuple("team", "t2", "owner", "user", "alice"),
+                // t2: alice is owner but not member — relation-intersection fails.
+                new RelationTuple("team", "t3", "owner", "user", "alice"),
+                new RelationTuple("team", "t3", "member", "user", "alice"),
+                // t3: alice is both owner and member, but "active" is false — attribute fails.
+            ],
+            [
+                new AttributeTuple("team", "t1", "active", JsonValue.Create(true)),
+                new AttributeTuple("team", "t2", "active", JsonValue.Create(true)),
+                new AttributeTuple("team", "t3", "active", JsonValue.Create(false)),
+            ], schema);
+
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("team", "constrained_test", "user", "alice"),
+            CancellationToken.None);
+
+        result.EntityIds.Should().BeEquivalentTo(["t1"]);
+    }
+
+    /// <summary>
+    /// team.negate_test := owner and member and not(banned) — an Intersect mixing two plain
+    /// direct-@user-relation siblings (owner, member) with a Negate child, the shape
+    /// LookupIntersectionWithNegate's positive-child loop batches (#243). Proves the batched
+    /// dispatch still requires both positive relations to match AND the negate to exclude.
+    /// </summary>
+    [Fact]
+    public async Task LookupEntity_NegateIntersectionWithSiblingDirectRelations_BatchesCorrectly()
+    {
+        const string schema = """
+            entity user {}
+            entity team {
+                relation owner @user;
+                relation member @user;
+                relation banned @user;
+                permission negate_test := owner and member and not(banned);
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("team", "t1", "owner", "user", "alice"),
+                new RelationTuple("team", "t1", "member", "user", "alice"),
+                new RelationTuple("team", "t2", "owner", "user", "alice"),
+                new RelationTuple("team", "t2", "member", "user", "alice"),
+                new RelationTuple("team", "t2", "banned", "user", "alice"),
+                // t2: alice is owner and member, but also banned — negate excludes it.
+                new RelationTuple("team", "t3", "owner", "user", "alice"),
+                // t3: alice is owner but not member — relation-intersection fails.
+            ], [], schema);
+
+        var result = await engine.LookupEntity(
+            new LookupEntityRequest("team", "negate_test", "user", "alice"),
+            CancellationToken.None);
+
+        result.EntityIds.Should().BeEquivalentTo(["t1"]);
+    }
+
+    /// <summary>
     /// Exercises paginated lookup without scope: verifies ContinuationToken is null when the total
     /// result count exactly equals PageSize.
     /// </summary>

--- a/utils/Valtuutus.Seeder/Seeder.cs
+++ b/utils/Valtuutus.Seeder/Seeder.cs
@@ -156,6 +156,16 @@ public static class Seeder
         relations.Add(new RelationTuple("team", fanoutTeamId, "member", "user", benchmarkUserId));
         relations.Add(new RelationTuple("group", fanoutGroupId, "member", "user", benchmarkUserId));
 
+        // Constrained/Negate sibling-batch benchmark data (#243). Extends #237's sibling-relation
+        // batching to LookupIntersectionConstrained (mixed attribute + relation children) and
+        // LookupIntersectionWithNegate (mixed positive + Negate children). benchmarkUser is both
+        // owner and member of this team — the batchable sibling pair — with "active" true and no
+        // "banned" tuple, so both new permissions resolve true for it.
+        const string siblingBatchTeamId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeee01";
+        relations.Add(new RelationTuple("team", siblingBatchTeamId, "owner", "user", benchmarkUserId));
+        relations.Add(new RelationTuple("team", siblingBatchTeamId, "member", "user", benchmarkUserId));
+        attributes.Add(new AttributeTuple("team", siblingBatchTeamId, "active", JsonValue.Create(true)));
+
         return (relations, attributes);
     }
 }


### PR DESCRIPTION
## Summary
- Threads the `ResolveChild`/batch-dict shape #237 introduced into `LookupIntersectionConstrained`'s non-attribute-child loop and `LookupIntersectionWithNegate`'s positive-child loop, computed once off the full `live` list before routing to either specialized dispatch.
- 2+ sibling direct-relation leaves mixed with an attribute leaf (`isActive(active) and owner and member`) or a `Negate` child (`owner and member and not(banned)`) now fold into one `GetRelationsWithSubjectsIdsMultiRelation` call instead of N separate round trips.
- Adds correctness tests for both shapes (`intersect(attrLeaf, relA, relB)`, `intersect(relA, relB, not(relC))`) to `BaseLookupEntityEngineSpecs.cs`.
- Extends the benchmark schema/seeder with a `team.constrained_sibling_batch` / `team.negate_sibling_batch` pair and two new `BenchmarkBase` scenarios — no existing scenario had 2+ batchable siblings under either mixed-attribute or mixed-negate Intersect, so neither path had benchmark coverage before this.

Closes #243.

## Test plan
- [x] `dotnet build` — no new warnings/errors
- [x] Full `Valtuutus.Data.InMemory.Tests` suite (224 tests) — pass
- [x] `LookupEntityEngineSpecs` filter against Postgres (54) and SqlServer (108) — pass
- [x] Benchmark smoke-run (`--job Dry`) of both new scenarios across InMemory/Postgres/SqlServer — completes with non-zero allocations, no exceptions