### PR TITLE
perf: avoid nested-loop plan for JOIN-collapse queries on Postgres

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/PostgresBenchmarks.cs
+++ b/benchmarks/Valtuutus.Benchmarks/PostgresBenchmarks.cs
@@ -35,6 +35,20 @@ public class PostgresBenchmarks : BenchmarkBase
             sc => sc.AddPostgres(_ => DbFactory),
             Seeder.Seeder.GenerateData(),
             pgAssembly);
+
+        // The bulk seed write leaves relation_tuples/attributes with zero planner statistics
+        // (autovacuum's autoanalyze hasn't run yet). Without stats, Postgres defaults to ~1-row
+        // cost estimates everywhere and picks nested-loop plans over the wrong index for the
+        // GetRelationsJoined(ByEntityIds) two-hop-collapse queries — 1000x+ slower than the
+        // steady-state plan it picks once stats exist. Mirrors what autovacuum would do in
+        // production shortly after a bulk load, so benchmarks measure realistic query plans.
+        await using (var conn = new NpgsqlConnection(_pgContainer.GetConnectionString()))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "ANALYZE";
+            await cmd.ExecuteNonQueryAsync();
+        }
     }
 
     [GlobalCleanup]

--- a/benchmarks/Valtuutus.Benchmarks/SqlServerBenchmarks.cs
+++ b/benchmarks/Valtuutus.Benchmarks/SqlServerBenchmarks.cs
@@ -34,6 +34,18 @@ public class SqlServerBenchmarks : BenchmarkBase
             sc => sc.AddSqlServer(_ => DbFactory),
             Seeder.Seeder.GenerateData(),
             mssqlAssembly);
+
+        // Mirrors the Postgres ANALYZE call: AUTO_CREATE_STATISTICS/AUTO_UPDATE_STATISTICS are
+        // on by default and normally self-heal synchronously on first compile, but pin it
+        // explicitly so benchmark numbers reflect steady-state plans rather than whatever the
+        // very first query's auto-created (possibly low-sample) stats produced.
+        await using (var connection = new SqlConnection(_msSqlContainer.GetConnectionString()))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "UPDATE STATISTICS relation_tuples WITH FULLSCAN; UPDATE STATISTICS attributes WITH FULLSCAN;";
+            await command.ExecuteNonQueryAsync();
+        }
     }
 
     [GlobalCleanup]

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -198,14 +198,14 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                   AND r_main.entity_type = @entity_type
                   AND r_main.relation = @relation
                   AND r_main.subject_type = @sub_entity_type
-                  AND r_main.subject_id IN (
+                  AND r_main.subject_id = ANY(ARRAY(
                       SELECT entity_id FROM {relationsTable}
                       WHERE created_tx_id <= @snap_token AND (deleted_tx_id IS NULL OR deleted_tx_id > @snap_token)
                         AND entity_type = @sub_entity_type
                         AND relation = @sub_relation
                         AND subject_type = @subject_type
                         AND subject_id = @subject_id
-                  )
+                  ))
                 """,
             GetRelationsJoinedByEntityIds = $"""
                 SELECT r_dep.entity_type, r_dep.entity_id, r_dep.relation, r_dep.subject_type, r_dep.subject_id, r_dep.subject_relation
@@ -213,14 +213,14 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                 WHERE r_dep.created_tx_id <= @snap_token AND (r_dep.deleted_tx_id IS NULL OR r_dep.deleted_tx_id > @snap_token)
                   AND r_dep.entity_type = @sub_entity_type
                   AND r_dep.relation = @sub_relation
-                  AND r_dep.entity_id IN (
+                  AND r_dep.entity_id = ANY(ARRAY(
                       SELECT subject_id FROM {relationsTable}
                       WHERE created_tx_id <= @snap_token AND (deleted_tx_id IS NULL OR deleted_tx_id > @snap_token)
                         AND entity_type = @entity_type
                         AND entity_id = ANY(@entity_ids)
                         AND relation = @relation
                         AND subject_type = @sub_entity_type
-                  )
+                  ))
                 """,
             HasTupleToUserSetRelation = $"""
                 SELECT EXISTS(
@@ -321,14 +321,14 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                   AND r_main.entity_type = @entity_type
                   AND r_main.relation = @relation
                   AND r_main.subject_type = @sub_entity_type
-                  AND r_main.subject_id IN (
+                  AND r_main.subject_id = ANY(ARRAY(
                       SELECT entity_id FROM {relationsTable}
                       WHERE created_tx_id <= @snap_token AND (deleted_tx_id IS NULL OR deleted_tx_id > @snap_token)
                         AND entity_type = @sub_entity_type
                         AND relation = @sub_relation
                         AND subject_type = @subject_type
                         AND subject_id = @subject_id
-                  )
+                  ))
                 """,
             GetAttributesDictScoped = $"""
                 SELECT a.entity_type, a.entity_id, a.attribute, a.value


### PR DESCRIPTION
## Summary
- `GetRelationsJoined`/`GetRelationsJoinedByEntityIds`/`GetRelationsJoinedScoped` used `subject_id IN (subquery)`, which without table statistics (e.g. right after a bulk seed, before autovacuum's autoanalyze catches up) Postgres plans as a Nested Loop Semi Join over the larger side instead of the small subquery result — 1000x+ slower than the steady-state plan.
- Rewrote as `subject_id = ANY(ARRAY(subquery))`, which removes the join-order decision entirely (materializes the subquery once via InitPlan), so the query stays fast regardless of whether stats exist. Measured 72ms→0.6ms and 36ms→3.2ms with zero table stats present.
- Added `ANALYZE`/`UPDATE STATISTICS` after the benchmark seed writes so BenchmarkDotNet measures steady-state query plans instead of the just-bulk-loaded, zero-stats worst case.

## Test plan
- [x] `dotnet test tests/Valtuutus.Data.Postgres.Tests` — 229/229 passed (net8/9/10/11)
- [x] `PostgresBenchmarks.LookupEntity_SiblingBatch`: 62.5ms → 121us
- [x] `PostgresBenchmarks.LookupSubject`: 29.7ms → 64us
- [x] `PostgresBenchmarks.LookupSubject_SiblingBatch`: 102.1ms → 125us