### PR TITLE
perf: index InMemory store by entity/subject type to avoid full-table scans

### DIFF
--- a/src/Valtuutus.Data.InMemory/AttributesStore.cs
+++ b/src/Valtuutus.Data.InMemory/AttributesStore.cs
@@ -14,6 +14,7 @@ public sealed class AttributesStore : IDisposable
     }
 
     private readonly Dictionary<(string, string), List<Entry>> _byEntityTypeAttr = new();
+    private readonly Dictionary<string, List<Entry>> _byEntityType = new();
     private readonly List<Entry> _all = new();
     private readonly ReaderWriterLockSlim _rwls = new(LockRecursionPolicy.NoRecursion);
 
@@ -140,9 +141,9 @@ public sealed class AttributesStore : IDisposable
     public void GetAllEntityIds(string entityType, SnapToken snap, HashSet<string> target)
     {
         using var _ = Read();
-        foreach (var e in _all)
+        if (!_byEntityType.TryGetValue(entityType, out var bucket)) return;
+        foreach (var e in bucket)
         {
-            if (e.Attribute.EntityType != entityType) continue;
             if (!IsVisible(e, snap)) continue;
             target.Add(e.Attribute.EntityId);
         }
@@ -152,14 +153,29 @@ public sealed class AttributesStore : IDisposable
     {
         var list = attributes as IList<AttributeTuple> ?? attributes.ToList();
         using var _ = Write();
-        foreach (var existing in _all)
+
+        // Group incoming attributes by (EntityType, Attribute) so tombstoning only walks the
+        // buckets this batch actually touches, instead of scanning every attribute ever written.
+        var incomingByKey = new Dictionary<(string EntityType, string Attribute), HashSet<string>>();
+        foreach (var a in list)
         {
-            if (existing.DeletedTxId is not null) continue;
-            if (list.Any(a => a.EntityId == existing.Attribute.EntityId &&
-                              a.EntityType == existing.Attribute.EntityType &&
-                              a.Attribute == existing.Attribute.Attribute))
-                existing.DeletedTxId = transactId;
+            var key = (a.EntityType, a.Attribute);
+            if (!incomingByKey.TryGetValue(key, out var entityIds))
+                incomingByKey[key] = entityIds = new HashSet<string>();
+            entityIds.Add(a.EntityId);
         }
+
+        foreach (var (key, entityIds) in incomingByKey)
+        {
+            if (!_byEntityTypeAttr.TryGetValue(key, out var existingBucket)) continue;
+            foreach (var existing in existingBucket)
+            {
+                if (existing.DeletedTxId is not null) continue;
+                if (entityIds.Contains(existing.Attribute.EntityId))
+                    existing.DeletedTxId = transactId;
+            }
+        }
+
         foreach (var a in list)
         {
             var entry = new Entry(a, transactId);
@@ -167,6 +183,11 @@ public sealed class AttributesStore : IDisposable
             if (!_byEntityTypeAttr.TryGetValue(key, out var bucket))
                 _byEntityTypeAttr[key] = bucket = new List<Entry>();
             bucket.Add(entry);
+
+            if (!_byEntityType.TryGetValue(a.EntityType, out var typeBucket))
+                _byEntityType[a.EntityType] = typeBucket = new List<Entry>();
+            typeBucket.Add(entry);
+
             _all.Add(entry);
         }
     }

--- a/src/Valtuutus.Data.InMemory/RelationsStore.cs
+++ b/src/Valtuutus.Data.InMemory/RelationsStore.cs
@@ -16,6 +16,8 @@ public sealed class RelationsStore : IDisposable
 
     private readonly Dictionary<(string, string, string), List<Entry>> _byEntityRelation = new();
     private readonly Dictionary<(string, string, string), List<Entry>> _byRelationSubjectType = new();
+    private readonly Dictionary<string, List<Entry>> _byEntityType = new();
+    private readonly Dictionary<string, List<Entry>> _bySubjectType = new();
     private readonly List<Entry> _all = new();
     private readonly ReaderWriterLockSlim _rwls = new(LockRecursionPolicy.NoRecursion);
 
@@ -354,9 +356,10 @@ public sealed class RelationsStore : IDisposable
     {
         using var _ = Read();
         var result = new HashSet<string>();
-        foreach (var e in _all)
+        if (!_byEntityType.TryGetValue(entityType, out var bucket))
+            return result;
+        foreach (var e in bucket)
         {
-            if (e.Relation.EntityType != entityType) continue;
             if (!IsVisible(e, snap)) continue;
             result.Add(e.Relation.EntityId);
         }
@@ -367,9 +370,10 @@ public sealed class RelationsStore : IDisposable
     {
         using var _ = Read();
         var result = new HashSet<string>();
-        foreach (var e in _all)
+        if (!_bySubjectType.TryGetValue(subjectType, out var bucket))
+            return result;
+        foreach (var e in bucket)
         {
-            if (e.Relation.SubjectType != subjectType) continue;
             if (!e.Relation.IsDirectSubject()) continue;
             if (!IsVisible(e, snap)) continue;
             result.Add(e.Relation.SubjectId);
@@ -393,6 +397,14 @@ public sealed class RelationsStore : IDisposable
             if (!_byRelationSubjectType.TryGetValue(sk, out var b2))
                 _byRelationSubjectType[sk] = b2 = new List<Entry>();
             b2.Add(entry);
+
+            if (!_byEntityType.TryGetValue(r.EntityType, out var b3))
+                _byEntityType[r.EntityType] = b3 = new List<Entry>();
+            b3.Add(entry);
+
+            if (!_bySubjectType.TryGetValue(r.SubjectType, out var b4))
+                _bySubjectType[r.SubjectType] = b4 = new List<Entry>();
+            b4.Add(entry);
 
             _all.Add(entry);
         }

--- a/tests/Valtuutus.Data.InMemory.Tests/AttributesStoreSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/AttributesStoreSpecs.cs
@@ -1,0 +1,152 @@
+using System.Text.Json.Nodes;
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+
+namespace Valtuutus.Data.InMemory.Tests;
+
+public sealed class AttributesStoreSpecs
+{
+    private static SnapToken SnapAt(Ulid id) => new(id.ToString());
+
+    // Ulid generation isn't guaranteed monotonic within the same tick, so order two freshly
+    // generated values by comparison instead of relying on wall-clock gaps between writes.
+    private static (Ulid earlier, Ulid later) OrderedPair()
+    {
+        var a = Ulid.NewUlid();
+        var b = Ulid.NewUlid();
+        return a.CompareTo(b) <= 0 ? (a, b) : (b, a);
+    }
+
+    private static AttributeTuple Attr(string entityType, string entityId, string attribute, int value = 1)
+        => new(entityType, entityId, attribute, JsonValue.Create(value)!);
+
+    [Fact]
+    public void GetAllEntityIds_returns_only_ids_for_the_requested_entity_type()
+    {
+        using var store = new AttributesStore();
+        var tx = Ulid.NewUlid();
+        store.Write(tx, new[]
+        {
+            Attr("project", "p1", "isActive"),
+            Attr("project", "p2", "isActive"),
+            Attr("organization", "o1", "isActive"),
+        });
+
+        var target = new HashSet<string>();
+        store.GetAllEntityIds("project", SnapAt(tx), target);
+
+        Assert.Equal(new HashSet<string> { "p1", "p2" }, target);
+    }
+
+    [Fact]
+    public void GetAllEntityIds_excludes_tuples_created_after_the_snapshot()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { Attr("project", "p1", "isActive") });
+        var snap = SnapAt(tx1);
+
+        store.Write(tx2, new[] { Attr("project", "p2", "isActive") });
+
+        var target = new HashSet<string>();
+        store.GetAllEntityIds("project", snap, target);
+
+        Assert.Equal(new HashSet<string> { "p1" }, target);
+    }
+
+    [Fact]
+    public void GetAllEntityIds_excludes_deleted_tuples()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { Attr("project", "p1", "isActive") });
+
+        store.Delete(tx2, new[] { new DeleteAttributesFilter { EntityType = "project", EntityId = "p1" } });
+
+        var target = new HashSet<string>();
+        store.GetAllEntityIds("project", SnapAt(tx2), target);
+
+        Assert.Empty(target);
+    }
+
+    [Fact]
+    public void Write_supersedes_prior_value_for_the_same_entity_and_attribute()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { Attr("project", "p1", "isActive", 1) });
+        store.Write(tx2, new[] { Attr("project", "p1", "isActive", 2) });
+
+        var current = store.GetAttribute(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p1", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+
+        Assert.Equal(2, current!.Value.GetValue<int>());
+
+        // The superseded value must be invisible at the later snapshot too — not just replaced going forward.
+        var all = store.GetAttributes(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p1", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+        Assert.Single(all);
+    }
+
+    [Fact]
+    public void Write_does_not_supersede_the_same_attribute_on_a_different_entity()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { Attr("project", "p1", "isActive", 1) });
+        store.Write(tx2, new[] { Attr("project", "p2", "isActive", 2) });
+
+        var p1 = store.GetAttribute(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p1", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+
+        Assert.Equal(1, p1!.Value.GetValue<int>());
+    }
+
+    [Fact]
+    public void Write_does_not_supersede_a_different_attribute_on_the_same_entity()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { Attr("project", "p1", "isActive", 1) });
+        store.Write(tx2, new[] { Attr("project", "p1", "isPublic", 1) });
+
+        var isActive = store.GetAttribute(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p1", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+
+        Assert.NotNull(isActive);
+    }
+
+    [Fact]
+    public void Write_supersedes_correct_entity_when_batch_touches_multiple_entity_ids_for_the_same_attribute()
+    {
+        using var store = new AttributesStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[]
+        {
+            Attr("project", "p1", "isActive", 1),
+            Attr("project", "p2", "isActive", 1),
+        });
+
+        store.Write(tx2, new[] { Attr("project", "p1", "isActive", 2) });
+
+        var p1 = store.GetAttribute(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p1", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+        var p2 = store.GetAttribute(new EntityAttributeFilter
+        {
+            EntityType = "project", EntityId = "p2", Attribute = "isActive", SnapToken = SnapAt(tx2)
+        });
+
+        Assert.Equal(2, p1!.Value.GetValue<int>());
+        Assert.Equal(1, p2!.Value.GetValue<int>());
+    }
+}

--- a/tests/Valtuutus.Data.InMemory.Tests/RelationsStoreSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/RelationsStoreSpecs.cs
@@ -1,0 +1,82 @@
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+
+namespace Valtuutus.Data.InMemory.Tests;
+
+public sealed class RelationsStoreSpecs
+{
+    private static SnapToken SnapAt(Ulid id) => new(id.ToString());
+
+    // Ulid generation isn't guaranteed monotonic within the same tick, so order two freshly
+    // generated values by comparison instead of relying on wall-clock gaps between writes.
+    private static (Ulid earlier, Ulid later) OrderedPair()
+    {
+        var a = Ulid.NewUlid();
+        var b = Ulid.NewUlid();
+        return a.CompareTo(b) <= 0 ? (a, b) : (b, a);
+    }
+
+    [Fact]
+    public void GetAllEntityIds_returns_only_ids_for_the_requested_entity_type()
+    {
+        using var store = new RelationsStore();
+        var tx = Ulid.NewUlid();
+        store.Write(tx, new[]
+        {
+            new RelationTuple("project", "p1", "owner", "user", "u1"),
+            new RelationTuple("project", "p2", "owner", "user", "u2"),
+            new RelationTuple("organization", "o1", "admin", "user", "u1"),
+        });
+
+        var result = store.GetAllEntityIds("project", SnapAt(tx));
+
+        Assert.Equal(new HashSet<string> { "p1", "p2" }, result);
+    }
+
+    [Fact]
+    public void GetAllEntityIds_excludes_tuples_created_after_the_snapshot()
+    {
+        using var store = new RelationsStore();
+        var (tx1, tx2) = OrderedPair();
+        store.Write(tx1, new[] { new RelationTuple("project", "p1", "owner", "user", "u1") });
+        var snap = SnapAt(tx1);
+
+        store.Write(tx2, new[] { new RelationTuple("project", "p2", "owner", "user", "u2") });
+
+        var result = store.GetAllEntityIds("project", snap);
+
+        Assert.Equal(new HashSet<string> { "p1" }, result);
+    }
+
+    [Fact]
+    public void GetAllEntityIds_excludes_deleted_tuples()
+    {
+        using var store = new RelationsStore();
+        var tx1 = Ulid.NewUlid();
+        store.Write(tx1, new[] { new RelationTuple("project", "p1", "owner", "user", "u1") });
+
+        var tx2 = Ulid.NewUlid();
+        store.Delete(tx2, new[] { new DeleteRelationsFilter { EntityType = "project", EntityId = "p1" } });
+
+        var result = store.GetAllEntityIds("project", SnapAt(tx2));
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetAllSubjectIds_returns_only_direct_subjects_of_the_requested_type()
+    {
+        using var store = new RelationsStore();
+        var tx = Ulid.NewUlid();
+        store.Write(tx, new[]
+        {
+            new RelationTuple("project", "p1", "owner", "user", "u1"),
+            new RelationTuple("project", "p1", "viewer", "group", "g1", "member"),
+            new RelationTuple("organization", "o1", "admin", "user", "u2"),
+        });
+
+        var result = store.GetAllSubjectIds("user", SnapAt(tx));
+
+        Assert.Equal(new HashSet<string> { "u1", "u2" }, result);
+    }
+}


### PR DESCRIPTION
## What
`RelationsStore.GetAllEntityIds`/`GetAllSubjectIds` and `AttributesStore.GetAllEntityIds` scanned the entire in-memory store on every unscoped `LookupEntity`/`LookupSubject` call — O(total tuples) instead of O(matching bucket). Added `_byEntityType`/`_bySubjectType` bucket dicts mirroring the existing relation/attribute bucket pattern.

`AttributesStore.Write` also tombstoned superseded values by scanning every attribute ever written with a `list.Any(...)` check per entry (O(n*m) per write batch), ignoring the existing `_byEntityTypeAttr` bucket. Now groups the incoming batch by `(EntityType, Attribute)` and only walks the matching buckets.

## Why
Found while looking into why InMemory benchmark numbers showed millisecond-scale timings for what should be sub-microsecond in-process lookups — traced to these full-table scans given the benchmark seed data (50k users + orgs/teams/projects).

## Testing
- New `RelationsStoreSpecs.cs` / `AttributesStoreSpecs.cs`: direct unit tests against the store (type filtering, snapshot visibility, tombstone/deletion, upsert scoping across entities/attributes) — written and confirmed green against the old O(n) implementation first, then kept green through the refactor.
- Full solution test suite (`dotnet test Valtuutus.sln -c Release`, all 4 TFMs): all green, no regressions (InMemory 235, Postgres 229, SqlServer 362, Lang 65, Api 6, SourceGen 23).