### PR TITLE
perf: boot benchmark containers once per suite instead of per method

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/PostgresBenchmarks.cs
+++ b/benchmarks/Valtuutus.Benchmarks/PostgresBenchmarks.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using System.Data;
 using Testcontainers.PostgreSql;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Engines.LookupEntity;
+using Valtuutus.Core.Engines.LookupSubject;
 using Valtuutus.Data.Postgres;
 
 namespace Valtuutus.Benchmarks;
@@ -16,22 +19,23 @@ namespace Valtuutus.Benchmarks;
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class PostgresBenchmarks : BenchmarkBase
 {
-    private readonly PostgreSqlContainer _pgContainer = new PostgreSqlBuilder()
-        .WithUsername("Valtuutus")
-        .WithPassword("Valtuutus123")
-        .WithDatabase("Valtuutus")
-        .WithName($"pg-benchmarks-{Guid.NewGuid()}")
-        .Build();
+    // See SqlServerBenchmarks: GlobalSetup/GlobalCleanup fire once per benchmark case (once per
+    // method), not once per class, regardless of toolchain. Lazy<Task<T>> makes the
+    // container+migrate+seed run exactly once across all instances.
+    private static readonly Lazy<Task<(ServiceProvider ServiceProvider, ICheckEngine CheckEngine, ILookupEntityEngine LookupEntityEngine, ILookupSubjectEngine LookupSubjectEngine)>> Shared = new(InitializeAsync);
 
-    private ServiceProvider _serviceProvider = null!;
-
-    [GlobalSetup]
-    public async Task Setup()
+    private static async Task<(ServiceProvider, ICheckEngine, ILookupEntityEngine, ILookupSubjectEngine)> InitializeAsync()
     {
-        await _pgContainer.StartAsync();
-        IDbConnection DbFactory() => new NpgsqlConnection(_pgContainer.GetConnectionString());
+        var container = new PostgreSqlBuilder()
+            .WithUsername("Valtuutus")
+            .WithPassword("Valtuutus123")
+            .WithDatabase("Valtuutus")
+            .WithName($"pg-benchmarks-{Guid.NewGuid()}")
+            .Build();
+        await container.StartAsync();
+        IDbConnection DbFactory() => new NpgsqlConnection(container.GetConnectionString());
         var pgAssembly = typeof(ValtuutusPostgresOptions).Assembly;
-        (_serviceProvider, _checkEngine, _lookupEntityEngine, _lookupSubjectEngine) = await CommonSetup.MigrateAndSeed(
+        var (serviceProvider, checkEngine, lookupEntityEngine, lookupSubjectEngine) = await CommonSetup.MigrateAndSeed(
             sc => sc.AddPostgres(_ => DbFactory),
             Seeder.Seeder.GenerateData(),
             pgAssembly);
@@ -42,19 +46,32 @@ public class PostgresBenchmarks : BenchmarkBase
         // GetRelationsJoined(ByEntityIds) two-hop-collapse queries — 1000x+ slower than the
         // steady-state plan it picks once stats exist. Mirrors what autovacuum would do in
         // production shortly after a bulk load, so benchmarks measure realistic query plans.
-        await using (var conn = new NpgsqlConnection(_pgContainer.GetConnectionString()))
+        await using (var conn = new NpgsqlConnection(container.GetConnectionString()))
         {
             await conn.OpenAsync();
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = "ANALYZE";
             await cmd.ExecuteNonQueryAsync();
         }
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            serviceProvider.Dispose();
+        };
+
+        return (serviceProvider, checkEngine, lookupEntityEngine, lookupSubjectEngine);
+    }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        (_, _checkEngine, _lookupEntityEngine, _lookupSubjectEngine) = await Shared.Value;
     }
 
     [GlobalCleanup]
-    public async Task Cleanup()
+    public void Cleanup()
     {
-        await _pgContainer.DisposeAsync();
-        await _serviceProvider.DisposeAsync();
+        // No-op: shared container/provider are torn down once via ProcessExit above.
     }
 }

--- a/benchmarks/Valtuutus.Benchmarks/Program.cs
+++ b/benchmarks/Valtuutus.Benchmarks/Program.cs
@@ -16,5 +16,5 @@ var config = ManualConfig.CreateEmpty()
     .WithSummaryStyle(BenchmarkDotNet.Reports.SummaryStyle.Default)
     .AddColumnProvider(DefaultColumnProviders.Instance)
     .AddLogger(ConsoleLogger.Default)
-    .AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance));
+    .AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
 switcher.Run(args, config);

--- a/benchmarks/Valtuutus.Benchmarks/Program.cs
+++ b/benchmarks/Valtuutus.Benchmarks/Program.cs
@@ -7,14 +7,14 @@ using BenchmarkDotNet.Toolchains.InProcess.Emit;
 
 var switcher = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
 
-#if NET11_0_OR_GREATER
-// BDN 0.15.8 doesn't recognize net11.0 runtime; in-process toolchain runs on current runtime.
+// All [Benchmark] methods are read-only (no writes/inserts/updates), so sharing one
+// process/container/GlobalSetup across every benchmark case in a class is safe. Without
+// this, BDN's default out-of-process toolchain builds one child process per benchmark
+// case, re-running GlobalSetup (container start + migrate + seed) once per case instead
+// of once per class.
 var config = ManualConfig.CreateEmpty()
     .WithSummaryStyle(BenchmarkDotNet.Reports.SummaryStyle.Default)
     .AddColumnProvider(DefaultColumnProviders.Instance)
     .AddLogger(ConsoleLogger.Default)
     .AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance));
 switcher.Run(args, config);
-#else
-switcher.Run(args);
-#endif

--- a/benchmarks/Valtuutus.Benchmarks/SqlServerBenchmarks.cs
+++ b/benchmarks/Valtuutus.Benchmarks/SqlServerBenchmarks.cs
@@ -5,6 +5,9 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using System.Data;
 using Testcontainers.MsSql;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Engines.LookupEntity;
+using Valtuutus.Core.Engines.LookupSubject;
 using Valtuutus.Data.SqlServer;
 
 namespace Valtuutus.Benchmarks;
@@ -16,21 +19,24 @@ namespace Valtuutus.Benchmarks;
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class SqlServerBenchmarks : BenchmarkBase
 {
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder()
-        .WithImage("mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04")
-        .WithPassword("Valtuutus123!")
-        .WithName($"mssql-benchmarks-{Guid.NewGuid()}")
-        .Build();
+    // BenchmarkDotNet calls [GlobalSetup]/[GlobalCleanup] once per benchmark CASE (i.e. once
+    // per [Benchmark] method), not once per class, regardless of toolchain. With 14 methods
+    // here, a per-instance container would boot/migrate/seed 14 times. Lazy<Task<T>> makes the
+    // container+migrate+seed run exactly once across all instances; every later Setup() call
+    // just awaits the already-completed task.
+    private static readonly Lazy<Task<(ServiceProvider ServiceProvider, ICheckEngine CheckEngine, ILookupEntityEngine LookupEntityEngine, ILookupSubjectEngine LookupSubjectEngine)>> Shared = new(InitializeAsync);
 
-    private ServiceProvider _serviceProvider = null!;
-
-    [GlobalSetup]
-    public async Task Setup()
+    private static async Task<(ServiceProvider, ICheckEngine, ILookupEntityEngine, ILookupSubjectEngine)> InitializeAsync()
     {
-        await _msSqlContainer.StartAsync();
-        IDbConnection DbFactory() => new SqlConnection(_msSqlContainer.GetConnectionString());
+        var container = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04")
+            .WithPassword("Valtuutus123!")
+            .WithName($"mssql-benchmarks-{Guid.NewGuid()}")
+            .Build();
+        await container.StartAsync();
+        IDbConnection DbFactory() => new SqlConnection(container.GetConnectionString());
         var mssqlAssembly = typeof(ValtuutusSqlServerOptions).Assembly;
-        (_serviceProvider, _checkEngine, _lookupEntityEngine, _lookupSubjectEngine) = await CommonSetup.MigrateAndSeed(
+        var (serviceProvider, checkEngine, lookupEntityEngine, lookupSubjectEngine) = await CommonSetup.MigrateAndSeed(
             sc => sc.AddSqlServer(_ => DbFactory),
             Seeder.Seeder.GenerateData(),
             mssqlAssembly);
@@ -39,19 +45,35 @@ public class SqlServerBenchmarks : BenchmarkBase
         // on by default and normally self-heal synchronously on first compile, but pin it
         // explicitly so benchmark numbers reflect steady-state plans rather than whatever the
         // very first query's auto-created (possibly low-sample) stats produced.
-        await using (var connection = new SqlConnection(_msSqlContainer.GetConnectionString()))
+        await using (var connection = new SqlConnection(container.GetConnectionString()))
         {
             await connection.OpenAsync();
             await using var command = connection.CreateCommand();
             command.CommandText = "UPDATE STATISTICS relation_tuples WITH FULLSCAN; UPDATE STATISTICS attributes WITH FULLSCAN;";
             await command.ExecuteNonQueryAsync();
         }
+
+        // GlobalCleanup fires once per benchmark case too, so real teardown can't live there
+        // without tearing down the shared container after the first case. Tear down once, for
+        // real, when the whole process exits instead.
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            serviceProvider.Dispose();
+        };
+
+        return (serviceProvider, checkEngine, lookupEntityEngine, lookupSubjectEngine);
+    }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        (_, _checkEngine, _lookupEntityEngine, _lookupSubjectEngine) = await Shared.Value;
     }
 
     [GlobalCleanup]
-    public async Task Cleanup()
+    public void Cleanup()
     {
-        await _msSqlContainer.DisposeAsync();
-        await _serviceProvider.DisposeAsync();
+        // No-op: shared container/provider are torn down once via ProcessExit above.
     }
 }


### PR DESCRIPTION
## Summary
- `SqlServerBenchmarks`/`PostgresBenchmarks` each booted, migrated, and seeded a fresh Testcontainers instance 14 times per run (once per `[Benchmark]` method) because BenchmarkDotNet calls `GlobalSetup`/`GlobalCleanup` once per benchmark case, not once per class, regardless of toolchain.
- Container + service provider are now shared across all instances via a static `Lazy<Task<T>>`, so only the first benchmark case pays the boot/migrate/seed cost; the rest reuse it. Real teardown happens once via `ProcessExit` instead of per-case `GlobalCleanup`.
- All 14 benchmark methods are read-only (no writes/inserts/updates), so sharing state across them is safe.
- `Program.cs` now always uses the in-process toolchain (previously gated to net11.0+), avoiding a child-process spawn per benchmark case.

Verified locally: `SqlServerBenchmarks` full run now boots exactly one container for the whole suite (confirmed via `podman ps -a` staying at 1 entry throughout, clean teardown at the end), total run time 107.58s for all 15 cases.

## Test plan
- [x] `dotnet build` on net10.0 and net11.0
- [x] Ran `SqlServerBenchmarks` locally end-to-end, confirmed single container lifecycle and correct benchmark output