### PR TITLE
fix: prevent parallel publish runs on release created+published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ on:
 env:
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
+concurrency:
+  group: publish-${{ github.event.release.tag_name || inputs.package_version }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Non-draft releases fire both `created` and `published` events almost simultaneously, causing the NuGet publish workflow to run twice in parallel (observed on v1.1.0 release).
- Add a `concurrency` group keyed on the release tag so the second run queues instead of racing. `cancel-in-progress: false` so an in-flight push is never interrupted.