### PR TITLE
feat: CheckV2 sibling-relation batching + relational plan-rewrite seam

### DIFF
--- a/Valtuutus.sln
+++ b/Valtuutus.sln
@@ -85,6 +85,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "utils", "utils", "{F05F0F65
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valtuutus.Seeder", "utils\Valtuutus.Seeder\Valtuutus.Seeder.csproj", "{D9D56C6E-33A3-4025-962E-28F49B5B7684}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valtuutus.Data.Db.Tests", "tests\Valtuutus.Data.Db.Tests\Valtuutus.Data.Db.Tests.csproj", "{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -335,6 +337,18 @@ Global
 		{D9D56C6E-33A3-4025-962E-28F49B5B7684}.Release|x64.Build.0 = Release|Any CPU
 		{D9D56C6E-33A3-4025-962E-28F49B5B7684}.Release|x86.ActiveCfg = Release|Any CPU
 		{D9D56C6E-33A3-4025-962E-28F49B5B7684}.Release|x86.Build.0 = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|x64.Build.0 = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Debug|x86.Build.0 = Debug|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x64.ActiveCfg = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x64.Build.0 = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -363,5 +377,6 @@ Global
 		{06CB4A28-2FBE-4534-96D1-F844AE2CAF4D} = {D383AD39-3BE1-43F8-BF40-E3F7A6D1CD1D}
 		{55B5D5C8-1404-412A-916D-DFDDECA18A85} = {6346B56F-2846-48A9-8F2F-B2926AF3560C}
 		{D9D56C6E-33A3-4025-962E-28F49B5B7684} = {F05F0F65-6685-4DDE-B159-120B4901ACBF}
+		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F} = {D383AD39-3BE1-43F8-BF40-E3F7A6D1CD1D}
 	EndGlobalSection
 EndGlobal

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlan.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlan.cs
@@ -7,15 +7,25 @@ internal sealed record CheckPlan(PlanNode Root, int SlotCount);
 
 // Registered as a DI singleton next to the Schema singleton: a schema reload produces a new
 // container/schema and therefore a fresh cache, which is what stands in for `schemaVersion`
-// in the design doc's cache key.
-internal sealed class CheckPlanCache(Schema schema)
+// in the design doc's cache key. Rewriters come from DI (any assembly may register
+// IPlanRewriter implementations; Valtuutus.Data.Db registers RelationalPlanRewriter via
+// AddDbSetup) and are applied in registration order, once per plan key.
+internal sealed class CheckPlanCache(Schema schema, IEnumerable<IPlanRewriter>? rewriters = null)
 {
+    private readonly Schema _schema = schema;
+    private readonly IPlanRewriter[] _rewriters = rewriters?.ToArray() ?? [];
     private readonly ConcurrentDictionary<PlanKey, CheckPlan> _plans = new();
 
     public CheckPlan GetOrCompile(string entityType, string permission, string? subjectType)
         => _plans.GetOrAdd(new PlanKey(entityType, permission, subjectType),
-            static (key, s) => PlanCompiler.Compile(s, key.EntityType, key.Permission, key.SubjectType),
-            schema);
+            static (key, self) =>
+            {
+                var plan = PlanCompiler.Compile(self._schema, key.EntityType, key.Permission, key.SubjectType);
+                foreach (var rewriter in self._rewriters)
+                    plan = plan with { Root = rewriter.Rewrite(plan.Root, self._schema) };
+                return plan;
+            },
+            this);
 
     private readonly record struct PlanKey(string EntityType, string Permission, string? SubjectType);
 }

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -412,6 +412,22 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 });
                 break;
 
+            case MultiDirectNode md:
+                SubmitOp(new PendingOp
+                {
+                    Token = idx, Kind = OpKind.HasAnyOfDirectRelations,
+                    EntityType = frame.EntityType, EntityId = frame.EntityId, Relations = md.Relations
+                });
+                break;
+
+            case PhysicalCheckNode p:
+                SubmitOp(new PendingOp
+                {
+                    Token = idx, Kind = OpKind.CheckOp,
+                    EntityType = frame.EntityType, EntityId = frame.EntityId, Op = p.Op
+                });
+                break;
+
             case MemoNode m:
             {
                 var slots = frame.Slots!;
@@ -613,6 +629,21 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 break;
 
             case AttributeExprNode:
+                CompleteFrame(idx, completion.Result);
+                break;
+
+            case MultiDirectNode md:
+            {
+                var matched = (HashSet<string>)completion.Payload!;
+                // Count checks are duplicate-safe: the return type is a set (dedup is a documented
+                // property of HasAnyOfDirectRelations), and Relations is duplicate-free by
+                // construction (a repeated ref is memo-wrapped and never grouped).
+                var result = md.RequireAll ? matched.Count == md.Relations.Length : matched.Count > 0;
+                CompleteFrame(idx, result);
+                break;
+            }
+
+            case PhysicalCheckNode:
                 CompleteFrame(idx, completion.Result);
                 break;
 

--- a/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
@@ -12,6 +12,8 @@ internal enum OpKind : byte
     HasAnyDirectRelation,   // EntityType = sub entity type, EntityIds, Relation = computed relation
     GetRelations,           // payload: PooledList<RelationTuple>; Relation = tupleset/relation name
     GetIndirectRelations,   // payload: PooledList<RelationTuple>
+    HasAnyOfDirectRelations, // payload: HashSet<string>; Relations = sibling relation names
+    CheckOp,                // Op = rewriter-installed ICheckOp; executor is opaque to its contents
 }
 
 internal readonly struct PendingOp
@@ -25,6 +27,8 @@ internal readonly struct PendingOp
     public string? SubEntityType { get; init; }
     public string? ComputedRelation { get; init; }
     public PermissionNodeLeafExp? Expr { get; init; }
+    public string[]? Relations { get; init; }
+    public ICheckOp? Op { get; init; }
 }
 
 internal interface IOpCompletionSink
@@ -88,6 +92,14 @@ internal sealed class DefaultPhysicalExecutor(Schema schema) : IPhysicalExecutor
                 case OpKind.GetIndirectRelations:
                     sink.CompleteWithPayload(op.Token, await Reader.GetIndirectRelations(
                         Filter(op, op.Relation!, ctx), ct).ConfigureAwait(false));
+                    break;
+                case OpKind.HasAnyOfDirectRelations:
+                    sink.CompleteWithPayload(op.Token, await Reader.HasAnyOfDirectRelations(
+                        op.EntityType, op.EntityId, op.Relations!, ctx.SubjectId!, ctx.SnapToken, ct).ConfigureAwait(false));
+                    break;
+                case OpKind.CheckOp:
+                    sink.Complete(op.Token, await op.Op!.Execute(Reader, ctx, op.EntityType, op.EntityId, ct)
+                        .ConfigureAwait(false));
                     break;
                 default:
                     sink.Fail(op.Token, new InvalidOperationException($"Unknown op kind {op.Kind}"));

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
@@ -14,7 +14,89 @@ internal static class PlanCompiler
         var root = CompileRoot(schema, entityType, permission);
         root = PruneAndFold(root, schema, entityType, subjectType);
         var (consed, slotCount) = HashCons(root);
+        // V1 parity: batching only fires when the subject type is known (CheckEngine.cs:564);
+        // plans are keyed per subjectType, so that runtime condition is a compile-time one here.
+        if (!string.IsNullOrEmpty(subjectType))
+            consed = GroupSiblingDirectRelations(consed, schema, entityType);
         return new CheckPlan(consed, slotCount);
+    }
+
+    // Plan-time form of V1's runtime check-then-batch (CheckEngine.cs:559-577): ≥2 sibling
+    // Union/Intersect children that are plain same-entity direct-relation refs collapse into one
+    // MultiDirectNode, answered by a single HasAnyOfDirectRelations round trip. V1's memo
+    // exclusion has no plan-time equivalent — the fused batch may re-fetch a relation the
+    // dynamic memo already knows, which costs no extra round trip; deliberate divergence.
+    // Runs post-hash-consing: a shared ref is MemoNode-wrapped by then and fails the PlanRefNode
+    // type test below — that non-match IS the fusion barrier (design doc, "MemoNode barrier rule").
+    private static PlanNode GroupSiblingDirectRelations(PlanNode root, Schema schema, string entityType)
+    {
+        // Ref-equality memo so a MemoNode shared by several parents rewrites to ONE instance,
+        // preserving the DAG interchange form instead of silently duplicating shared subtrees.
+        var visited = new Dictionary<PlanNode, PlanNode>(ReferenceEqualityComparer.Instance);
+        return Walk(root);
+
+        PlanNode Walk(PlanNode node)
+        {
+            if (visited.TryGetValue(node, out var done)) return done;
+            PlanNode result;
+            switch (node)
+            {
+                case UnionNode u: result = GroupChildren(u.Children, isUnion: true); break;
+                case IntersectNode i: result = GroupChildren(i.Children, isUnion: false); break;
+                case NegateNode n:
+                {
+                    var child = Walk(n.Child);
+                    result = ReferenceEquals(child, n.Child) ? n : new NegateNode(child);
+                    break;
+                }
+                case MemoNode m:
+                {
+                    var child = Walk(m.Child);
+                    result = ReferenceEquals(child, m.Child) ? m : new MemoNode(m.SlotId, child);
+                    break;
+                }
+                default: result = node; break;
+            }
+            visited[node] = result;
+            return result;
+        }
+
+        PlanNode GroupChildren(ImmutableArray<PlanNode> children, bool isUnion)
+        {
+            List<string>? batchable = null;
+            foreach (var child in children)
+                if (IsBatchableDirectRef(child, out var relation))
+                    (batchable ??= []).Add(relation);
+
+            if (batchable is not { Count: >= 2 })
+            {
+                var rebuilt = ImmutableArray.CreateBuilder<PlanNode>(children.Length);
+                foreach (var child in children) rebuilt.Add(Walk(child));
+                var arr = rebuilt.MoveToImmutable();
+                return isUnion ? new UnionNode(arr) : new IntersectNode(arr);
+            }
+
+            var multi = new MultiDirectNode(batchable.ToArray(), RequireAll: !isUnion);
+            var kept = ImmutableArray.CreateBuilder<PlanNode>(children.Length - batchable.Count + 1);
+            kept.Add(multi);
+            foreach (var child in children)
+                if (!IsBatchableDirectRef(child, out _))
+                    kept.Add(Walk(child));
+            if (kept.Count == 1) return multi;
+            var keptArr = kept.MoveToImmutable();
+            return isUnion ? new UnionNode(keptArr) : new IntersectNode(keptArr);
+        }
+
+        // Mirror of V1 IsBatchableDirectRelation (CheckEngine.cs:411-423) over the compiled IR.
+        bool IsBatchableDirectRef(PlanNode node, out string relation)
+        {
+            relation = "";
+            if (node is not PlanRefNode p) return false;
+            if (schema.GetRelationType(entityType, p.Permission) != RelationType.DirectRelation) return false;
+            if (schema.GetRelation(entityType, p.Permission).HasSubRelationPaths) return false;
+            relation = p.Permission;
+            return true;
+        }
     }
 
     // Bottom-up interning: identical subtrees become one node; any node referenced more than

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
@@ -20,6 +20,18 @@ internal sealed record AttributeExprNode(PermissionNodeLeafExp Expr) : PlanNode;
 internal sealed record TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) : PlanNode;
 internal sealed record PlanRefNode(string Permission) : PlanNode; // same-entity ResolveDynamic re-entry
 
+// Fused sibling direct-relation batch (generic "sibling grouping" pass — design doc, Pipeline).
+// Replaces ≥2 batchable PlanRefNode siblings of one Union/Intersect: RequireAll=false under
+// Union (any relation matches), true under Intersect (every relation matches). Relations is
+// duplicate-free by construction — a repeated ref is hash-consed into a MemoNode and never
+// grouped. Array-typed record ⇒ reference equality; fine, this node is created after
+// hash-consing and never interned.
+internal sealed record MultiDirectNode(string[] Relations, bool RequireAll) : PlanNode;
+
+// Physical escape hatch: a rewriter-fused subtree carrying its own execution (design doc, IR).
+// Reference equality, never interned — created only after hash-consing, like MultiDirectNode.
+internal sealed record PhysicalCheckNode(ICheckOp Op) : PlanNode;
+
 internal sealed record UnionNode(ImmutableArray<PlanNode> Children) : PlanNode;
 internal sealed record IntersectNode(ImmutableArray<PlanNode> Children) : PlanNode;
 internal sealed record NegateNode(PlanNode Child) : PlanNode;

--- a/src/Valtuutus.Core/Engines/Check/V2/Rewriting.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/Rewriting.cs
@@ -1,0 +1,28 @@
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Schemas;
+
+namespace Valtuutus.Core.Engines.Check.V2;
+
+// Provider-owned execution of a fused subtree (design doc, "IR" / "Physical escape hatch").
+// Instances are created at plan-rewrite time and cached inside the plan — they must be
+// immutable and must not capture request-scoped state; runtime bindings (entity, subject,
+// snapshot) arrive as Execute arguments.
+internal interface ICheckOp
+{
+    ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+        string entityType, string entityId, CancellationToken ct);
+
+    // Explain fidelity: a fused op must be able to say what it replaced.
+    string Describe();
+}
+
+// The rewrite seam: implementations registered in DI run over every compiled plan
+// (CheckPlanCache applies them in registration order, once per plan key). Contract:
+// return unrecognized nodes unchanged; never unwrap a MemoNode — its child is shared by
+// multiple parents and fusing it into one duplicates work for the others (design doc,
+// "MemoNode barrier rule"); implementations must be stateless/thread-safe (one singleton
+// serves concurrent plan compiles).
+internal interface IPlanRewriter
+{
+    PlanNode Rewrite(PlanNode root, Schema schema);
+}

--- a/src/Valtuutus.Core/Valtuutus.Core.csproj
+++ b/src/Valtuutus.Core/Valtuutus.Core.csproj
@@ -20,6 +20,12 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Valtuutus.Data.InMemory.Tests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Valtuutus.Data.Db</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Valtuutus.Data.Db.Tests</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Valtuutus.Data.Db/CheckOps.cs
+++ b/src/Valtuutus.Data.Db/CheckOps.cs
@@ -1,0 +1,30 @@
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Engines.Check.V2;
+
+namespace Valtuutus.Data.Db;
+
+// Physical op for a fused sibling direct-relation batch — the declarative form of V1's runtime
+// check-then-batch: one round trip answers what would otherwise be N sibling children.
+internal sealed class HasAnyOfDirectRelationsOp(string[] relations, bool requireAll) : ICheckOp
+{
+    public async ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+        string entityType, string entityId, CancellationToken ct)
+    {
+        if (reader is not IRelationalCheckOps ops)
+            throw new InvalidOperationException(
+                $"RelationalPlanRewriter installed a relational op, but the registered " +
+                $"IDataReaderProvider ({reader.GetType().Name}) does not implement " +
+                $"{nameof(IRelationalCheckOps)}. Readers used with AddDbSetup must implement it.");
+
+        var matched = await ops.HasAnyOfDirectRelations(entityType, entityId, relations,
+            ctx.SubjectId!, ctx.SnapToken, ct).ConfigureAwait(false);
+        // Count checks are duplicate-safe: the return type is a set (a documented property of
+        // HasAnyOfDirectRelations) and `relations` is duplicate-free by construction — a
+        // repeated plan ref is memo-wrapped and never grouped.
+        return requireAll ? matched.Count == relations.Length : matched.Count > 0;
+    }
+
+    public string Describe()
+        => $"HasAnyOfDirectRelations([{string.Join(", ", relations)}], {(requireAll ? "all" : "any")})";
+}

--- a/src/Valtuutus.Data.Db/DependencyInjectionExtensions.cs
+++ b/src/Valtuutus.Data.Db/DependencyInjectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core.Engines.Check.V2;
 
 namespace Valtuutus.Data.Db;
 
@@ -17,6 +19,11 @@ public static class DependencyInjectionExtensions
     {
         services.AddScoped(factory);
         services.AddSingleton(options);
+        // V2 plan rewriter for relational providers. Harmless when V2 is not opted in (nothing
+        // resolves IPlanRewriter then); TryAddEnumerable keeps repeated AddDbSetup calls
+        // idempotent. Requires the registered IDataReaderProvider to implement
+        // IRelationalCheckOps — both in-repo relational providers do.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPlanRewriter, RelationalPlanRewriter>());
         return services;
     }
 }

--- a/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
+++ b/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
@@ -1,0 +1,19 @@
+using Valtuutus.Core.Data;
+
+namespace Valtuutus.Data.Db;
+
+/// <summary>
+/// Relational op catalog for the V2 check engine's plan rewriter (<c>RelationalPlanRewriter</c>).
+/// Relational providers (Postgres, SqlServer) implement this alongside
+/// <see cref="IDataReaderProvider"/> — today its members are a subset of that interface with
+/// identical signatures, so implementing it is declaration-only. When the core reader interface
+/// eventually shrinks to its primitive core (a major-version event), the specialized members
+/// survive here instead of vanishing. New rewrite rules grow this catalog — growth here reaches
+/// only the relational providers, never the core reader interface.
+/// </summary>
+public interface IRelationalCheckOps
+{
+    /// <inheritdoc cref="IDataReaderProvider.HasAnyOfDirectRelations"/>
+    Task<HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames,
+        string subjectId, SnapToken snapToken, CancellationToken cancellationToken);
+}

--- a/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
+++ b/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+using Valtuutus.Core.Engines.Check.V2;
+using Valtuutus.Core.Schemas;
+
+namespace Valtuutus.Data.Db;
+
+// The Data.Db half of the rewrite seam: pattern recognition over the compiled plan lives here,
+// ONCE, so relational providers only implement the op catalog (IRelationalCheckOps) and never
+// touch trees. Contract per IPlanRewriter: unrecognized nodes pass through unchanged (and
+// untouched subtrees come back reference-identical, preserving interning), never unwrap a
+// MemoNode (fusion barrier), stateless — one singleton serves every plan compile.
+internal sealed class RelationalPlanRewriter : IPlanRewriter
+{
+    public PlanNode Rewrite(PlanNode root, Schema schema) => Walk(root);
+
+    private static PlanNode Walk(PlanNode node)
+    {
+        switch (node)
+        {
+            case MultiDirectNode m:
+                return new PhysicalCheckNode(new HasAnyOfDirectRelationsOp(m.Relations, m.RequireAll));
+            case UnionNode u:
+                return RebuildIfChanged(u.Children, static c => new UnionNode(c), u);
+            case IntersectNode i:
+                return RebuildIfChanged(i.Children, static c => new IntersectNode(c), i);
+            case NegateNode n:
+            {
+                var child = Walk(n.Child);
+                return ReferenceEquals(child, n.Child) ? n : new NegateNode(child);
+            }
+            case MemoNode m:
+            {
+                var child = Walk(m.Child);
+                return ReferenceEquals(child, m.Child) ? m : new MemoNode(m.SlotId, child);
+            }
+            default:
+                return node;
+        }
+    }
+
+    private static PlanNode RebuildIfChanged(ImmutableArray<PlanNode> children,
+        Func<ImmutableArray<PlanNode>, PlanNode> rebuild, PlanNode original)
+    {
+        var builder = ImmutableArray.CreateBuilder<PlanNode>(children.Length);
+        var changed = false;
+        foreach (var child in children)
+        {
+            var walked = Walk(child);
+            changed |= !ReferenceEquals(walked, child);
+            builder.Add(walked);
+        }
+        return changed ? rebuild(builder.MoveToImmutable()) : original;
+    }
+}

--- a/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
+++ b/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
@@ -12,4 +12,10 @@
       <ProjectReference Include="..\Valtuutus.Data\Valtuutus.Data.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Valtuutus.Data.Db.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -12,7 +12,7 @@ using Valtuutus.Data.Db;
 
 namespace Valtuutus.Data.Postgres;
 
-public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvider
+public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvider, IRelationalCheckOps
 {
     private const string UnformattedSelectAttributes = @"SELECT
                     entity_type,

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Valtuutus.Data.SqlServer;
 
-public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvider
+public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvider, IRelationalCheckOps
 {
     private readonly DbConnectionFactory _connectionFactory;
 

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
@@ -1,4 +1,6 @@
-﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
+﻿[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/valtuutus/valtuutus")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace Valtuutus.Data.Db
 {
@@ -38,6 +40,10 @@ namespace Valtuutus.Data.Db
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Delete(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, Valtuutus.Core.Data.DeleteFilter filter, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
+    }
+    public interface IRelationalCheckOps
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
@@ -41,6 +41,10 @@ namespace Valtuutus.Data.Db
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
+    public interface IRelationalCheckOps
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+    }
     public interface IValtuutusDbOptions
     {
         string AttributesTableName { get; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -41,6 +41,10 @@ namespace Valtuutus.Data.Db
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
+    public interface IRelationalCheckOps
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+    }
     public interface IValtuutusDbOptions
     {
         string AttributesTableName { get; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
@@ -40,6 +40,10 @@ namespace Valtuutus.Data.Db
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
+    public interface IRelationalCheckOps
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+    }
     public interface IValtuutusDbOptions
     {
         string AttributesTableName { get; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
@@ -40,6 +40,10 @@ namespace Valtuutus.Data.Db
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
         System.Threading.Tasks.Task<Valtuutus.Core.Data.SnapToken> Write(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, System.Collections.Generic.IEnumerable<Valtuutus.Core.RelationTuple> relations, System.Collections.Generic.IEnumerable<Valtuutus.Core.AttributeTuple> attributes, System.Threading.CancellationToken ct);
     }
+    public interface IRelationalCheckOps
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+    }
     public interface IValtuutusDbOptions
     {
         string AttributesTableName { get; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.Postgres
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
     }
-    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public PostgresDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.Postgres
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
     }
-    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public PostgresDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.Postgres
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
     }
-    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public PostgresDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
@@ -7,7 +7,7 @@ namespace Valtuutus.Data.Postgres
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
     }
-    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public PostgresDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
@@ -7,7 +7,7 @@ namespace Valtuutus.Data.Postgres
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddPostgres(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Postgres.ValtuutusPostgresOptions? options = null) { }
     }
-    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class PostgresDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public PostgresDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
@@ -8,7 +8,7 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
@@ -7,7 +7,7 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
@@ -7,7 +7,7 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Data.Db.Tests/HasAnyOfDirectRelationsOpSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/HasAnyOfDirectRelationsOpSpecs.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using NSubstitute;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Engines.Check.V2;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+public class HasAnyOfDirectRelationsOpSpecs
+{
+    private static CheckRequestContext Ctx() => new()
+    {
+        SubjectType = "user", SubjectId = "u1",
+        SnapToken = new SnapToken("00000000000000000000000001"),
+        Context = new Dictionary<string, object>()
+    };
+
+    private static IDataReaderProvider RelationalReader(HashSet<string> matched)
+    {
+        var reader = Substitute.For<IDataReaderProvider, IRelationalCheckOps>();
+        ((IRelationalCheckOps)reader).HasAnyOfDirectRelations(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(),
+                Arg.Any<SnapToken>(), Arg.Any<CancellationToken>())
+            .Returns(matched);
+        return reader;
+    }
+
+    [Fact]
+    public async Task Any_mode_is_true_when_the_set_is_non_empty()
+    {
+        var op = new HasAnyOfDirectRelationsOp(["owner", "admin"], requireAll: false);
+        (await op.Execute(RelationalReader(["admin"]), Ctx(), "household", "1", default)).Should().BeTrue();
+        (await op.Execute(RelationalReader([]), Ctx(), "household", "1", default)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task All_mode_requires_every_relation()
+    {
+        var op = new HasAnyOfDirectRelationsOp(["owner", "admin"], requireAll: true);
+        (await op.Execute(RelationalReader(["owner", "admin"]), Ctx(), "household", "1", default)).Should().BeTrue();
+        (await op.Execute(RelationalReader(["owner"]), Ctx(), "household", "1", default)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Non_relational_reader_fails_with_a_pointed_message()
+    {
+        var op = new HasAnyOfDirectRelationsOp(["owner", "admin"], requireAll: false);
+        var reader = Substitute.For<IDataReaderProvider>(); // no IRelationalCheckOps
+        var act = () => op.Execute(reader, Ctx(), "household", "1", default).AsTask();
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*IRelationalCheckOps*");
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Valtuutus.Core.Engines.Check.V2;
+using Valtuutus.Core.Lang.SchemaReaders;
+using Valtuutus.Core.Schemas;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+public class RelationalPlanRewriterSpecs
+{
+    internal static Schema Parse(string text)
+    {
+        var result = new SchemaReader(null).Parse(text);
+        if (result.IsT1) throw new InvalidOperationException(string.Join(",", result.AsT1));
+        return result.AsT0;
+    }
+
+    private const string HouseholdSchema = """
+        entity user {}
+        entity organization { relation admin @user; }
+        entity household {
+            relation parent @organization;
+            relation owner @user;
+            relation admin @user;
+            relation member @user;
+            permission view := owner or admin or member;
+            permission escalate := owner or parent.admin;
+        }
+        """;
+
+    [Fact]
+    public void MultiDirect_rewrites_to_a_physical_HasAnyOfDirectRelations_op()
+    {
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "view", "user");
+        var rewritten = new RelationalPlanRewriter().Rewrite(plan.Root, Parse(HouseholdSchema));
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("HasAnyOfDirectRelations([owner, admin, member], any)");
+    }
+
+    [Fact]
+    public void Unrecognized_nodes_pass_through_as_the_same_instance()
+    {
+        // escalate := owner or parent.admin — one batchable ref + a TTU: nothing groups, nothing
+        // is recognizable, and the contract says untouched trees come back reference-identical.
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "escalate", "user");
+        var rewritten = new RelationalPlanRewriter().Rewrite(plan.Root, Parse(HouseholdSchema));
+        rewritten.Should().BeSameAs(plan.Root);
+    }
+
+    [Fact]
+    public void MemoNode_wrapper_survives_a_rewrite_with_its_slot_intact()
+    {
+        // Shared `owner` forces a MemoNode; the batchable pair {admin, member} under the union
+        // becomes a MultiDirect which the rewriter fuses — the MemoNode must keep its SlotId
+        // and must NOT be unwrapped (fusion barrier).
+        const string s = """
+            entity user {}
+            entity vault {
+                relation owner @user;
+                relation admin @user;
+                relation member @user;
+                permission open := (admin or member or owner) and not(owner);
+            }
+            """;
+        var schema = Parse(s);
+        var plan = PlanCompiler.Compile(schema, "vault", "open", "user");
+        var rewritten = new RelationalPlanRewriter().Rewrite(plan.Root, schema);
+
+        var intersect = rewritten.Should().BeOfType<IntersectNode>().Subject;
+        var union = intersect.Children[0].Should().BeOfType<UnionNode>().Subject;
+        union.Children.OfType<PhysicalCheckNode>().Should().ContainSingle()
+            .Which.Op.Describe().Should().Be("HasAnyOfDirectRelations([admin, member], any)");
+        var memo = union.Children.OfType<MemoNode>().Should().ContainSingle().Subject;
+        var negate = intersect.Children[1].Should().BeOfType<NegateNode>().Subject;
+        negate.Child.Should().BeOfType<MemoNode>().Which.SlotId.Should().Be(memo.SlotId);
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/Valtuutus.Data.Db.Tests.csproj
+++ b/tests/Valtuutus.Data.Db.Tests/Valtuutus.Data.Db.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>$(NetLibVersion);</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Valtuutus.Core\Valtuutus.Core.csproj" />
+      <ProjectReference Include="..\..\src\Valtuutus.Data.Db\Valtuutus.Data.Db.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
@@ -27,9 +27,23 @@ public class CheckPlanExecutorSpecs
     {
         public readonly List<(int Token, bool Result)> Completed = [];
         public readonly List<(int Token, Exception Error)> Failed = [];
+        public readonly List<(int Token, object Payload)> Payloads = [];
         public void Complete(int token, bool result) { lock (Completed) Completed.Add((token, result)); }
-        public void CompleteWithPayload(int token, object payload) => throw new NotSupportedException();
+        public void CompleteWithPayload(int token, object payload) { lock (Payloads) Payloads.Add((token, payload)); }
         public void Fail(int token, Exception error) { lock (Failed) Failed.Add((token, error)); }
+    }
+
+    // Records every submitted op, then forwards to the real executor — lets a test assert on
+    // query SHAPE (one batched op vs N singles) while the check still runs for real.
+    internal sealed class RecordingPhysicalExecutor(IPhysicalExecutor inner) : IPhysicalExecutor
+    {
+        public readonly List<PendingOp> Submitted = [];
+        public void Submit(ReadOnlySpan<PendingOp> ops, CheckRequestContext ctx, IOpCompletionSink sink, CancellationToken ct)
+        {
+            lock (Submitted)
+                foreach (var op in ops) Submitted.Add(op);
+            inner.Submit(ops, ctx, sink, ct);
+        }
     }
 
     // Test double letting a test deterministically simulate a genuinely still-in-flight op
@@ -435,11 +449,15 @@ public class CheckPlanExecutorSpecs
         // an unrelated request while r1's eventual completion is still pending — and when r1
         // finally lands, it would call sink.Complete against whatever _frames/_mailbox that
         // unrelated request has by then, using r1's now-stale token.
+        // r1 is an attribute, not a relation, so GroupSiblingDirectRelations (which only
+        // recognizes direct-relation refs) leaves it out and the union stays two independent
+        // ops — otherwise sibling-batching would fuse r0/r1 into one MultiDirectNode op,
+        // defeating this test's premise of one instant leg and one genuinely outstanding leg.
         const string s = """
             entity user {}
             entity doc {
                 relation r0 @user;
-                relation r1 @user;
+                attribute r1 bool;
                 permission view := r0 or r1;
             }
             """;
@@ -503,5 +521,108 @@ public class CheckPlanExecutorSpecs
             (await executor.ExecuteSingleAsync(new CheckRootRequest("doc", "2", "editor", null, 10), ctxBob, default))[0]
                 .Should().BeTrue($"iteration {i}: bob edits doc/2");
         }
+    }
+
+    private const string HouseholdSchema = """
+        entity user {}
+        entity household {
+            relation owner @user;
+            relation admin @user;
+            relation member @user;
+            permission view := owner or admin or member;
+            permission manage := owner and admin;
+        }
+        """;
+
+    [Fact]
+    public async Task MultiDirect_union_true_when_any_relation_matches()
+    {
+        (await RunCheck(HouseholdSchema, [new RelationTuple("household", "1", "member", "user", "u1")], null,
+            "household", "1", "view")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MultiDirect_union_false_when_no_relation_matches()
+    {
+        (await RunCheck(HouseholdSchema, [new RelationTuple("household", "1", "member", "user", "someone-else")], null,
+            "household", "1", "view")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MultiDirect_intersect_requires_every_relation()
+    {
+        RelationTuple[] onlyOwner = [new RelationTuple("household", "1", "owner", "user", "u1")];
+        (await RunCheck(HouseholdSchema, onlyOwner, null, "household", "1", "manage")).Should().BeFalse();
+
+        RelationTuple[] both =
+        [
+            new RelationTuple("household", "1", "owner", "user", "u1"),
+            new RelationTuple("household", "1", "admin", "user", "u1"),
+        ];
+        (await RunCheck(HouseholdSchema, both, null, "household", "1", "manage")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MultiDirect_intersect_is_not_fooled_by_duplicate_tuples()
+    {
+        // Two identical owner tuples, no admin: a count over ROWS would see 2 == 2 relations and
+        // wrongly pass; the HashSet return type guarantees set semantics (see the
+        // HasAnyOfDirectRelations doc remarks).
+        RelationTuple[] dupOwner =
+        [
+            new RelationTuple("household", "1", "owner", "user", "u1"),
+            new RelationTuple("household", "1", "owner", "user", "u1"),
+        ];
+        (await RunCheck(HouseholdSchema, dupOwner, null, "household", "1", "manage")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MultiDirect_submits_one_batched_op_instead_of_three_singles()
+    {
+        var (_, schema, reader) = await Arrange(HouseholdSchema,
+            [new RelationTuple("household", "1", "member", "user", "u1")]);
+        var snap = await Valtuutus.Core.Engines.SnapTokenUtils.ResolveLatest(reader, null, default);
+        var ctx = new CheckRequestContext
+            { SubjectType = "user", SubjectId = "u1", SnapToken = snap, Context = new Dictionary<string, object>() };
+        var recording = new RecordingPhysicalExecutor(new DefaultPhysicalExecutor(schema) { Reader = reader });
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("household", "1", "view", null, 10)], ctx, default);
+
+        results[0].Should().BeTrue();
+        recording.Submitted.Should().ContainSingle();
+        recording.Submitted[0].Kind.Should().Be(OpKind.HasAnyOfDirectRelations);
+        recording.Submitted[0].Relations.Should().Equal("owner", "admin", "member");
+    }
+
+    private sealed class FixedResultOp(bool value) : ICheckOp
+    {
+        public ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+            string entityType, string entityId, CancellationToken ct) => new(value);
+        public string Describe() => $"Fixed({value})";
+    }
+
+    private sealed class RootReplacingRewriter(ICheckOp op) : IPlanRewriter
+    {
+        public PlanNode Rewrite(PlanNode root, Schema schema) => new PhysicalCheckNode(op);
+    }
+
+    [Fact]
+    public async Task Executor_runs_a_PhysicalCheckNode_op_through_the_default_physical_executor()
+    {
+        // No tuples at all — a true result can only come from the injected op.
+        var (_, schema, reader) = await Arrange(DocSchema, []);
+        var snap = await Valtuutus.Core.Engines.SnapTokenUtils.ResolveLatest(reader, null, default);
+        var ctx = new CheckRequestContext
+            { SubjectType = "user", SubjectId = "u1", SnapToken = snap, Context = new Dictionary<string, object>() };
+        var cache = new CheckPlanCache(schema, [new RootReplacingRewriter(new FixedResultOp(true))]);
+        var executor = new CheckPlanExecutor(schema, cache)
+            { Physical = new DefaultPhysicalExecutor(schema) { Reader = reader } };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+
+        results[0].Should().BeTrue();
     }
 }

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using FluentAssertions;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
 using Valtuutus.Core.Engines.Check.V2;
 using Valtuutus.Core.Lang.SchemaReaders;
 using Valtuutus.Core.Schemas;
@@ -74,11 +76,21 @@ public class PlanCompilerSpecs
     [Fact]
     public void Union_permission_compiles_to_UnionNode_of_PlanRefs()
     {
-        var plan = PlanCompiler.Compile(Parse(BasicSchema), "organization", "view", "user");
+        // Grouping fuses the two batchable refs; compile with an unknown subject type to see
+        // the ungrouped logical shape (grouping requires subjectTypeKnown, V1 parity).
+        var plan = PlanCompiler.Compile(Parse(BasicSchema), "organization", "view", null);
         var union = plan.Root.Should().BeOfType<UnionNode>().Subject;
         union.Children.Should().HaveCount(2);
         union.Children[0].Should().Be(new PlanRefNode("admin"));
         union.Children[1].Should().Be(new PlanRefNode("member"));
+    }
+
+    [Fact]
+    public void Union_permission_groups_for_known_subjectType()
+    {
+        var plan = PlanCompiler.Compile(Parse(BasicSchema), "organization", "view", "user");
+        var multi = plan.Root.Should().BeOfType<MultiDirectNode>().Subject;
+        multi.Relations.Should().Equal("admin", "member");
     }
 
     [Fact]
@@ -183,5 +195,125 @@ public class PlanCompilerSpecs
         var inner = union.Children[1].Should().BeOfType<IntersectNode>().Subject;
         var second = inner.Children[1].Should().BeOfType<MemoNode>().Subject;
         second.SlotId.Should().Be(first.SlotId);
+    }
+
+    private const string HouseholdSchema = """
+        entity user {}
+        entity household {
+            relation owner @user;
+            relation admin @user;
+            relation member @user;
+            attribute open bool;
+            permission view := owner or admin or member;
+            permission manage := owner and admin;
+            permission browse := owner or admin or open;
+        }
+        """;
+
+    [Fact]
+    public void Union_of_batchable_refs_groups_to_MultiDirect()
+    {
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "view", "user");
+        var multi = plan.Root.Should().BeOfType<MultiDirectNode>().Subject;
+        multi.Relations.Should().Equal("owner", "admin", "member");
+        multi.RequireAll.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Intersect_of_batchable_refs_groups_with_RequireAll()
+    {
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "manage", "user");
+        var multi = plan.Root.Should().BeOfType<MultiDirectNode>().Subject;
+        multi.Relations.Should().Equal("owner", "admin");
+        multi.RequireAll.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Mixed_union_groups_only_the_batchable_refs()
+    {
+        // `open` is an attribute → PlanRefNode("open") is not a direct relation, stays a sibling.
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "browse", "user");
+        var union = plan.Root.Should().BeOfType<UnionNode>().Subject;
+        union.Children.Should().HaveCount(2);
+        var multi = union.Children[0].Should().BeOfType<MultiDirectNode>().Subject;
+        multi.Relations.Should().Equal("owner", "admin");
+        union.Children[1].Should().Be(new PlanRefNode("open"));
+    }
+
+    [Fact]
+    public void Null_subjectType_skips_grouping()
+    {
+        // V1 parity: batching requires subjectTypeKnown (CheckEngine.cs:564).
+        var plan = PlanCompiler.Compile(Parse(HouseholdSchema), "household", "view", null);
+        plan.Root.Should().BeOfType<UnionNode>().Which.Children.Should().AllBeOfType<PlanRefNode>();
+    }
+
+    [Fact]
+    public void Sub_relation_path_refs_are_not_grouped()
+    {
+        // V1 parity: IsBatchableDirectRelation excludes HasSubRelationPaths (CheckEngine.cs:420) —
+        // those leaves still need the GetIndirectRelations fan-out.
+        const string s = """
+            entity user {}
+            entity team { relation member @user; }
+            entity doc {
+                relation viewer @user @team#member;
+                relation editor @user @team#member;
+                permission read := viewer or editor;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "doc", "read", "user");
+        plan.Root.Should().BeOfType<UnionNode>().Which.Children.Should().AllBeOfType<PlanRefNode>();
+    }
+
+    [Fact]
+    public void Memo_wrapped_ref_stays_outside_the_batch()
+    {
+        // `owner` is referenced twice → hash-consing wraps it in a MemoNode. The MemoNode fails
+        // the PlanRefNode type test, so the union has only ONE plain batchable ref (`admin`) —
+        // below threshold, nothing groups. That non-match is the fusion barrier working.
+        const string s = """
+            entity user {}
+            entity vault {
+                relation owner @user;
+                relation admin @user;
+                permission locked := (owner or admin) and not(owner);
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "vault", "locked", "user");
+        var intersect = plan.Root.Should().BeOfType<IntersectNode>().Subject;
+        var union = intersect.Children[0].Should().BeOfType<UnionNode>().Subject;
+        union.Children.Should().HaveCount(2);
+        union.Children.OfType<MemoNode>().Should().ContainSingle();
+        union.Children.OfType<PlanRefNode>().Should().ContainSingle();
+    }
+
+    private sealed class ConstOp(bool value) : ICheckOp
+    {
+        public ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+            string entityType, string entityId, CancellationToken ct) => new(value);
+        public string Describe() => $"Const({value})";
+    }
+
+    private sealed class AttributeHijackingRewriter : IPlanRewriter
+    {
+        public PlanNode Rewrite(PlanNode root, Schema schema)
+            => root is AttributeTruthNode ? new PhysicalCheckNode(new ConstOp(true)) : root;
+    }
+
+    [Fact]
+    public void Cache_applies_registered_rewriters_to_compiled_plans()
+    {
+        var cache = new CheckPlanCache(Parse(BasicSchema), [new AttributeHijackingRewriter()]);
+        var plan = cache.GetOrCompile("organization", "public", "user");
+        var physical = plan.Root.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("Const(True)");
+    }
+
+    [Fact]
+    public void Cache_with_no_rewriters_leaves_plans_untouched()
+    {
+        var cache = new CheckPlanCache(Parse(BasicSchema));
+        cache.GetOrCompile("organization", "public", "user").Root.Should().Be(new AttributeTruthNode("public"));
     }
 }


### PR DESCRIPTION
## Summary
- Closes the V1 parity gap for sibling direct-relation batching in CheckEngineV2: a plan-time `GroupSiblingDirectRelations` compiler pass fuses ≥2 batchable same-entity direct-relation refs under one Union/Intersect into a `MultiDirectNode`, answered by a single `HasAnyOfDirectRelations` round trip (V1 parity — `CheckEngine.cs`'s runtime check-then-batch, now provider-neutral and plan-time).
- Extracts the provider rewrite seam (`ICheckOp`, `IPlanRewriter`, `PhysicalCheckNode` — internal, `InternalsVisibleTo` `Valtuutus.Data.Db`) and ships its first production consumer: `RelationalPlanRewriter` in `Valtuutus.Data.Db`, mapping `MultiDirectNode` → `PhysicalCheckNode(HasAnyOfDirectRelationsOp)` over the new public `IRelationalCheckOps` catalog. Postgres and SqlServer both implement it (declaration-only — the method already existed on both providers).
- New `Valtuutus.Data.Db.Tests` project for rewriter/op unit coverage.
- Deliberate, documented divergences from V1: no memo exclusion (batches statically, always ≥2 remaining, so round-trip count never regresses vs V1), no memo publication (memo is a cache, correctness unaffected), per-child guards match V1's batched-child bypass exactly.

## Test plan
- [x] Full `BaseCheckEngineSpecs`/`CheckEngineV2Specs` parity green on InMemory/Postgres/SqlServer, all 4 TFMs (net8/9/10/11)
- [x] New `Valtuutus.Data.Db.Tests` (rewriter + op unit tests) green
- [x] `Valtuutus.Api.Tests` public-API snapshots updated and reviewed (new public `IRelationalCheckOps`; Postgres/SqlServer base-type lists gain it; Core surface unchanged — seam stays internal)
- [x] Benchmarks (InMemory + Postgres, V1 vs V2): allocation flat-to-improved everywhere, no regressions; latency flat within noise. Round-trip reduction validated directly via `MultiDirect_submits_one_batched_op_instead_of_three_singles` and the full parity suite (the standing benchmark categories don't happen to exercise a same-entity sibling union)