### PR TITLE
fix: caching composes with CheckEngineV2 instead of dropping/wrapping V1

### DIFF
--- a/Caching.md
+++ b/Caching.md
@@ -59,6 +59,20 @@ builder.Services.AddValtuutusCore("""
 ```
 That's it. Now all your queries to the engines will be cached to reduce the load in your database. (It is not required to use a database provider to use caching)
 
+## Composing with CheckEngineV2
+
+`AddCaching` decorates whichever `ICheckEngine` is registered at the point it runs, so if you opt into
+the V2 check engine (`AddValtuutusCheckV2`) call it **before** `.AddCaching()`:
+```csharp
+builder.Services.AddValtuutusCore("...");
+builder.Services.AddValtuutusCheckV2(); // opt-in, before AddCaching
+
+builder.Services.AddPostgres(...)
+    .AddConcurrentQueryLimit(3)
+    .AddCaching(); // <--- decorates CheckEngineV2
+```
+Calling `AddValtuutusCheckV2()` after `.AddCaching()` replaces the cached engine outright and you lose caching.
+
 ## Multi node scenario
 ⚠️ If you are writing/deleting data from a multi node scenario, it is highly recommended to use a backplane for Fusion Cache. 
 That way, any writes/deletes in the data will automatically invalidate the cache in all instances.

--- a/Valtuutus.sln
+++ b/Valtuutus.sln
@@ -87,6 +87,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valtuutus.Seeder", "utils\V
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valtuutus.Data.Db.Tests", "tests\Valtuutus.Data.Db.Tests\Valtuutus.Data.Db.Tests.csproj", "{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Valtuutus.Data.Caching.Tests", "tests\Valtuutus.Data.Caching.Tests\Valtuutus.Data.Caching.Tests.csproj", "{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -349,6 +351,18 @@ Global
 		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x64.Build.0 = Release|Any CPU
 		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x86.ActiveCfg = Release|Any CPU
 		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F}.Release|x86.Build.0 = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|x64.Build.0 = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Debug|x86.Build.0 = Debug|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|x64.ActiveCfg = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|x64.Build.0 = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|x86.ActiveCfg = Release|Any CPU
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -378,5 +392,6 @@ Global
 		{55B5D5C8-1404-412A-916D-DFDDECA18A85} = {6346B56F-2846-48A9-8F2F-B2926AF3560C}
 		{D9D56C6E-33A3-4025-962E-28F49B5B7684} = {F05F0F65-6685-4DDE-B159-120B4901ACBF}
 		{2D0CA9BE-F34F-4627-AFBF-529C4C35AE7F} = {D383AD39-3BE1-43F8-BF40-E3F7A6D1CD1D}
+		{14EF2D11-E0FA-4AAD-880D-0FA4CB6FF816} = {D383AD39-3BE1-43F8-BF40-E3F7A6D1CD1D}
 	EndGlobalSection
 EndGlobal

--- a/src/Valtuutus.Core/Configuration/ConfigureCheckV2.cs
+++ b/src/Valtuutus.Core/Configuration/ConfigureCheckV2.cs
@@ -9,7 +9,8 @@ public static class ConfigureCheckV2
 {
     /// <summary>
     /// Opt-in: replaces the recursive check engine with the plan/executor engine (CheckEngineV2).
-    /// Call after <see cref="ConfigureSchema.AddValtuutusCore(IServiceCollection, string, IReadOnlyDictionary{string, Func{IDictionary{string, object?}, bool}}?)"/>.
+    /// Call after <see cref="ConfigureSchema.AddValtuutusCore(IServiceCollection, string, IReadOnlyDictionary{string, Func{IDictionary{string, object?}, bool}}?)"/>,
+    /// and before <c>AddCaching</c> (Valtuutus.Data.Caching) if you use it, since it replaces the registered <c>ICheckEngine</c> outright.
     /// Explain requests are still served by the V1 engine.
     /// </summary>
     public static IServiceCollection AddValtuutusCheckV2(this IServiceCollection services)

--- a/src/Valtuutus.Data.Caching/CachedCheckEngine.cs
+++ b/src/Valtuutus.Data.Caching/CachedCheckEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Engines.Check;
 using Valtuutus.Core.Observability;
@@ -9,9 +10,12 @@ public sealed class CachedCheckEngine : ICheckEngine
 {
     private readonly IDataReaderProvider _reader;
     private readonly IFusionCache _cache;
-    private readonly CheckEngine _engine;
+    private readonly ICheckEngine _engine;
 
-    public CachedCheckEngine(IDataReaderProvider reader, IFusionCache cache, CheckEngine engine)
+    public CachedCheckEngine(
+        IDataReaderProvider reader,
+        IFusionCache cache,
+        [FromKeyedServices(Consts.InnerCheckEngineKey)] ICheckEngine engine)
     {
         _reader = reader;
         _cache = cache;

--- a/src/Valtuutus.Data.Caching/CachedLookupEntityEngine.cs
+++ b/src/Valtuutus.Data.Caching/CachedLookupEntityEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Engines.LookupEntity;
 using Valtuutus.Core.Observability;
@@ -9,9 +10,12 @@ public sealed class CachedLookupEntityEngine : ILookupEntityEngine
 {
     private readonly IDataReaderProvider _reader;
     private readonly IFusionCache _cache;
-    private readonly LookupEntityEngine _engine;
+    private readonly ILookupEntityEngine _engine;
 
-    public CachedLookupEntityEngine(IDataReaderProvider reader, LookupEntityEngine engine, IFusionCache cache)
+    public CachedLookupEntityEngine(
+        IDataReaderProvider reader,
+        [FromKeyedServices(Consts.InnerLookupEntityEngineKey)] ILookupEntityEngine engine,
+        IFusionCache cache)
     {
         _reader = reader;
         _engine = engine;

--- a/src/Valtuutus.Data.Caching/CachedLookupSubjectEngine.cs
+++ b/src/Valtuutus.Data.Caching/CachedLookupSubjectEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Engines.LookupSubject;
 using Valtuutus.Core.Observability;
@@ -9,9 +10,12 @@ public sealed class CachedLookupSubjectEngine : ILookupSubjectEngine
 {
     private readonly IDataReaderProvider _reader;
     private readonly IFusionCache _cache;
-    private readonly LookupSubjectEngine _engine;
+    private readonly ILookupSubjectEngine _engine;
 
-    public CachedLookupSubjectEngine(IDataReaderProvider reader, LookupSubjectEngine engine, IFusionCache cache)
+    public CachedLookupSubjectEngine(
+        IDataReaderProvider reader,
+        [FromKeyedServices(Consts.InnerLookupSubjectEngineKey)] ILookupSubjectEngine engine,
+        IFusionCache cache)
     {
         _reader = reader;
         _engine = engine;

--- a/src/Valtuutus.Data.Caching/Consts.cs
+++ b/src/Valtuutus.Data.Caching/Consts.cs
@@ -3,4 +3,15 @@
 public static class Consts
 {
     public const string LatestSnapTokenKey = "latest-snaptoken";
+
+    /// <summary>
+    /// Keyed-service key under which <c>AddCaching</c> re-registers whatever <c>ICheckEngine</c>
+    /// was previously registered (V1 <c>CheckEngine</c> or the opt-in <c>CheckEngineV2</c>), so
+    /// <see cref="CachedCheckEngine"/> can decorate it regardless of which one it is.
+    /// </summary>
+    public const string InnerCheckEngineKey = "valtuutus:caching:inner-check-engine";
+
+    public const string InnerLookupEntityEngineKey = "valtuutus:caching:inner-lookup-entity-engine";
+
+    public const string InnerLookupSubjectEngineKey = "valtuutus:caching:inner-lookup-subject-engine";
 }

--- a/src/Valtuutus.Data.Caching/DependencyInjectionExtensions.cs
+++ b/src/Valtuutus.Data.Caching/DependencyInjectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Engines.Check;
 using Valtuutus.Core.Engines.LookupEntity;
 using Valtuutus.Core.Engines.LookupSubject;
@@ -10,18 +9,19 @@ namespace Valtuutus.Data.Caching;
 public static class DependencyInjectionExtensions
 {
     /// <summary>
-    /// Adds InMemory data reader and writer to the service collection
+    /// Wraps whichever <c>ICheckEngine</c>/<c>ILookupEntityEngine</c>/<c>ILookupSubjectEngine</c> is
+    /// currently registered (V1 or the opt-in V2 check engine) in a FusionCache-backed decorator.
+    /// Call this after any engine-selection call (e.g. <c>AddValtuutusCheckV2</c>) so it decorates
+    /// the engine actually in effect, rather than the other way around.
     /// </summary>
     /// <param name="builder">Valtuutus data builder</param>
     /// <returns></returns>
     public static IValtuutusDataBuilder AddCaching(this IValtuutusDataBuilder builder)
     {
-        builder.Services.RemoveAll(typeof(ICheckEngine));
-        builder.Services.RemoveAll(typeof(ILookupEntityEngine));
-        builder.Services.RemoveAll(typeof(ILookupSubjectEngine));
-        builder.Services.AddScoped<CheckEngine>();
-        builder.Services.AddScoped<LookupEntityEngine>();
-        builder.Services.AddScoped<LookupSubjectEngine>();
+        RedirectToKeyedInner<ICheckEngine>(builder.Services, Consts.InnerCheckEngineKey);
+        RedirectToKeyedInner<ILookupEntityEngine>(builder.Services, Consts.InnerLookupEntityEngineKey);
+        RedirectToKeyedInner<ILookupSubjectEngine>(builder.Services, Consts.InnerLookupSubjectEngineKey);
+
         builder.Services.AddScoped<ICheckEngine, CachedCheckEngine>();
         builder.Services.AddScoped<ILookupEntityEngine, CachedLookupEntityEngine>();
         builder.Services.AddScoped<ILookupSubjectEngine, CachedLookupSubjectEngine>();
@@ -36,5 +36,25 @@ public static class DependencyInjectionExtensions
         };
 
         return builder;
+    }
+
+    /// <summary>
+    /// Takes whatever implementation is currently registered as <typeparamref name="TService"/> and
+    /// re-registers it under a keyed slot, so a decorator can be registered as the plain
+    /// <typeparamref name="TService"/> without needing to know which concrete engine it is wrapping.
+    /// </summary>
+    private static void RedirectToKeyedInner<TService>(IServiceCollection services, string key)
+        where TService : class
+    {
+        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(TService));
+        if (descriptor?.ImplementationType is null)
+        {
+            throw new InvalidOperationException(
+                $"AddCaching requires {typeof(TService).Name} to already be registered with a concrete " +
+                "implementation type (e.g. via AddValtuutusCore, or AddValtuutusCheckV2 for ICheckEngine).");
+        }
+
+        services.Remove(descriptor);
+        services.Add(new ServiceDescriptor(typeof(TService), key, descriptor.ImplementationType, descriptor.Lifetime));
     }
 }

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Valtuutus.Data.Caching.Tests/DependencyInjectionExtensionsSpecs.cs
+++ b/tests/Valtuutus.Data.Caching.Tests/DependencyInjectionExtensionsSpecs.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Engines.LookupEntity;
+using Valtuutus.Core.Engines.LookupSubject;
+using Xunit;
+
+namespace Valtuutus.Data.Caching.Tests;
+
+public class DependencyInjectionExtensionsSpecs
+{
+    private const string Schema = @"
+        entity user {}
+        entity project {
+            relation owner @user;
+            permission edit := owner;
+        }
+    ";
+
+    [Fact]
+    public void AddCaching_without_CheckV2_wraps_the_V1_engine()
+    {
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(Schema);
+        services.AddValtuutusData().AddCaching();
+
+        GetUnkeyed<ICheckEngine>(services).ImplementationType.Should().Be(typeof(CachedCheckEngine));
+        GetKeyed<ICheckEngine>(services, Consts.InnerCheckEngineKey).KeyedImplementationType.Should().Be(typeof(CheckEngine));
+    }
+
+    [Fact]
+    public void AddCaching_after_CheckV2_wraps_CheckEngineV2_instead_of_V1()
+    {
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(Schema);
+        services.AddValtuutusCheckV2();
+        services.AddValtuutusData().AddCaching();
+
+        GetUnkeyed<ICheckEngine>(services).ImplementationType.Should().Be(typeof(CachedCheckEngine));
+
+        var innerType = GetKeyed<ICheckEngine>(services, Consts.InnerCheckEngineKey).KeyedImplementationType;
+        innerType.Should().NotBeNull();
+        innerType!.Name.Should().Be("CheckEngineV2");
+        innerType.Should().NotBe(typeof(CheckEngine));
+    }
+
+    [Fact]
+    public void AddCaching_before_CheckV2_loses_caching_documenting_the_required_order()
+    {
+        // AddValtuutusCheckV2 replaces the unkeyed ICheckEngine descriptor outright, so calling it after
+        // AddCaching wipes CachedCheckEngine. AddCaching must be the last call in the chain.
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(Schema);
+        services.AddValtuutusData().AddCaching();
+        services.AddValtuutusCheckV2();
+
+        GetUnkeyed<ICheckEngine>(services).ImplementationType.Should().NotBe(typeof(CachedCheckEngine));
+    }
+
+    [Fact]
+    public void AddCaching_wraps_lookup_entity_and_lookup_subject_engines()
+    {
+        var services = new ServiceCollection();
+        services.AddValtuutusCore(Schema);
+        services.AddValtuutusData().AddCaching();
+
+        GetUnkeyed<ILookupEntityEngine>(services).ImplementationType.Should().Be(typeof(CachedLookupEntityEngine));
+        GetKeyed<ILookupEntityEngine>(services, Consts.InnerLookupEntityEngineKey).KeyedImplementationType.Should().Be(typeof(LookupEntityEngine));
+
+        GetUnkeyed<ILookupSubjectEngine>(services).ImplementationType.Should().Be(typeof(CachedLookupSubjectEngine));
+        GetKeyed<ILookupSubjectEngine>(services, Consts.InnerLookupSubjectEngineKey).KeyedImplementationType.Should().Be(typeof(LookupSubjectEngine));
+    }
+
+    [Fact]
+    public void AddCaching_throws_a_clear_error_when_no_engine_is_registered_yet()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddValtuutusData().AddCaching();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ICheckEngine*");
+    }
+
+    private static ServiceDescriptor GetUnkeyed<TService>(IServiceCollection services)
+        => services.Last(d => d.ServiceType == typeof(TService) && !d.IsKeyedService);
+
+    private static ServiceDescriptor GetKeyed<TService>(IServiceCollection services, string key)
+        => services.Last(d => d.ServiceType == typeof(TService) && d.IsKeyedService && Equals(d.ServiceKey, key));
+}

--- a/tests/Valtuutus.Data.Caching.Tests/Valtuutus.Data.Caching.Tests.csproj
+++ b/tests/Valtuutus.Data.Caching.Tests/Valtuutus.Data.Caching.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>$(NetLibVersion);</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="ZiggyCreatures.FusionCache" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Valtuutus.Core\Valtuutus.Core.csproj" />
+      <ProjectReference Include="..\..\src\Valtuutus.Data\Valtuutus.Data.csproj" />
+      <ProjectReference Include="..\..\src\Valtuutus.Data.Caching\Valtuutus.Data.Caching.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- `AddCaching` decorated the concrete V1 `CheckEngine`/`LookupEntityEngine`/`LookupSubjectEngine` directly, so it silently dropped caching or ignored `CheckEngineV2` depending on registration order (no order worked for "caching over V2").
- It now captures whatever `ICheckEngine`/`ILookupEntityEngine`/`ILookupSubjectEngine` is registered at the point it runs, re-registers it under a keyed service, and decorates that — composing with V1 or the opt-in V2 engine transparently. `AddValtuutusCheckV2()` must still run before `.AddCaching()`; documented in `Caching.md` and the `AddValtuutusCheckV2` XML doc.
- Added `tests/Valtuutus.Data.Caching.Tests` covering both engines/orders and a guard-clause test for missing registrations.

Fixes #258

## Test plan
- [x] `dotnet test tests/Valtuutus.Data.Caching.Tests` passes on net8/9/10/11
- [x] `dotnet build Valtuutus.sln` — 0 errors across all 23 projects