### PR TITLE
test: close CheckV2 pre-work — hazard stress specs, V2 gate counters, R1/R2 benchmark baselines

### DIFF
--- a/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
+++ b/benchmarks/Valtuutus.Benchmarks/BenchmarkBase.cs
@@ -15,6 +15,7 @@ public abstract class BenchmarkBase
     private const string DiamondFolderId = "cccccccc-cccc-cccc-cccc-cccccccccc01";
     private const string FanoutProjectId = "dddddddd-dddd-dddd-dddd-dddddddddd01";
     private const string SiblingBatchTeamId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeee04";
+    private const string MissUserId = "ffffffff-ffff-ffff-ffff-ffffffffff01"; // never seeded — deterministic miss
 
     protected ICheckEngine _checkEngine = null!;
     protected ILookupEntityEngine _lookupEntityEngine = null!;
@@ -209,5 +210,33 @@ public abstract class BenchmarkBase
         {
             EntityType = "folder", EntityId = DiamondFolderId,
             SubjectType = "user", SubjectId = UserId
+        }, CancellationToken.None);
+
+    /// <summary>
+    /// Userset miss path: folder.view := owner or editor, both @group#member, and the subject
+    /// belongs to no group. Forces the full expansion per relation (HasDirectRelation +
+    /// GetIndirectRelations + fan-out group member checks). Baseline for the planned userset
+    /// 2-hop join rewrite (R2), which should collapse this to a single round trip.
+    /// </summary>
+    [Benchmark(Baseline = true), BenchmarkCategory("Check_UsersetMiss")]
+    public async Task<bool> Check_UsersetMiss()
+        => await _checkEngine.Check(new()
+        {
+            Permission = "view", EntityType = "folder", EntityId = DiamondFolderId,
+            SubjectType = "user", SubjectId = MissUserId
+        }, CancellationToken.None);
+
+    /// <summary>
+    /// TTU + direct union miss path: team.edit := org.admin or owner, subject with no tuples
+    /// at all. Two round trips today (TTU fast-path join + direct EXISTS). Baseline for
+    /// boolean-combination fusion (R1), which should answer it with one fused
+    /// EXISTS-OR-EXISTS statement.
+    /// </summary>
+    [Benchmark(Baseline = true), BenchmarkCategory("Check_UnionTtuDirect")]
+    public async Task<bool> Check_UnionTtuDirect()
+        => await _checkEngine.Check(new()
+        {
+            Permission = "edit", EntityType = "team", EntityId = SiblingBatchTeamId,
+            SubjectType = "user", SubjectId = MissUserId
         }, CancellationToken.None);
 }

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -61,7 +61,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     {
         public bool Done;
         public bool Value;
-        public List<(int Parent, int RootIndex)>? Waiters;
+        public List<(int Parent, int RootIndex, int ChildIndex)>? Waiters;
     }
 
     private struct Frame
@@ -69,6 +69,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         public PlanNode Node;
         public int Parent;              // NoParent = reports into _results[RootIndex]
         public int RootIndex;
+        public int ChildIndex;          // position among an expression parent's children; -1 elsewhere
         public byte State;              // node-type-specific step counter
         public int Pending;             // outstanding children (expression / fan-out frames)
         public bool Completed;
@@ -90,7 +91,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     {
         public byte State;   // 0 empty, 1 in-flight, 2 done
         public bool Value;
-        public List<(int Parent, int RootIndex)>? Waiters;
+        public List<(int Parent, int RootIndex, int ChildIndex)>? Waiters;
     }
 
     private readonly record struct CheckMemoKey(
@@ -125,7 +126,19 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             while (_rootsPending > 0)
             {
                 var completion = await _mailbox.DequeueAsync(ct).ConfigureAwait(false);
-                if (completion.Error is not null) throw completion.Error;
+                if (completion.Error is not null)
+                {
+                    // Still counts as this token's op landing — must decrement _pendingOps like
+                    // OnOpCompleted would, or a fault permanently over-counts outstanding ops and
+                    // DrainStragglersAsync can never observe zero again.
+                    // Deliberately does NOT call OnOpCompleted (or otherwise CompleteFrame/Notify
+                    // this frame and its ancestors): that cascade would resolve the frame as if
+                    // the op had legitimately returned false, letting a Union/Intersect ancestor
+                    // short-circuit or resolve around the fault — silently masking it with a wrong
+                    // answer instead of propagating the exception. Only the counter may move here.
+                    _pendingOps--;
+                    throw completion.Error;
+                }
                 OnOpCompleted(completion);
                 DrainReady();
             }
@@ -195,7 +208,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     }
 
     private int SpawnFrame(PlanNode node, string entityType, string entityId, string? subjectRelation,
-        int depth, int parent, int rootIndex, int memoEntry = -1, MemoSlotState[]? slots = null)
+        int depth, int parent, int rootIndex, int memoEntry = -1, MemoSlotState[]? slots = null,
+        int childIndex = -1)
     {
         if (_frameCount == _frames.Length)
         {
@@ -207,7 +221,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         var idx = _frameCount++;
         _frames[idx] = new Frame
         {
-            Node = node, Parent = parent, RootIndex = rootIndex, EntityType = entityType,
+            Node = node, Parent = parent, RootIndex = rootIndex, ChildIndex = childIndex, EntityType = entityType,
             EntityId = entityId, SubjectRelation = subjectRelation, Depth = depth, MemoEntry = memoEntry,
             Slots = slots, NextReady = _readyHead,
         };
@@ -242,7 +256,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         {
             var entry = _memoEntries[entryIdx];
             if (entry.Done) { ValtuutusMetrics.MemoHits.Add(1); Notify(parent, rootIndex, entry.Value); return; }
-            (entry.Waiters ??= []).Add((parent, rootIndex));
+            (entry.Waiters ??= []).Add((parent, rootIndex, -1));
             _memoEntries[entryIdx] = entry;
             return;
         }
@@ -262,7 +276,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         _frames[newIdx].Slots = plan.SlotCount > 0 ? new MemoSlotState[plan.SlotCount] : null;
     }
 
-    private void Notify(int parent, int rootIndex, bool result)
+    private void Notify(int parent, int rootIndex, bool result, int childIndex = -1)
     {
         if (parent == NoParent)
         {
@@ -270,10 +284,10 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             _rootsPending--;
             return;
         }
-        ChildCompleted(parent, result);
+        ChildCompleted(parent, result, childIndex);
     }
 
-    private void ChildCompleted(int parentIdx, bool childResult)
+    private void ChildCompleted(int parentIdx, bool childResult, int childIndex = -1)
     {
         ref var parent = ref _frames[parentIdx];
         if (parent.Completed) return; // stale — parent already short-circuited
@@ -281,12 +295,27 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         switch (parent.Node)
         {
             case UnionNode:
-                if (childResult) { CompleteFrame(parentIdx, true); return; }
+                if (childResult)
+                {
+                    // V1 parity (BoolTaskCombinator.cs:81, CheckEngine.cs:602): short-circuit
+                    // counts only when a sibling was still unresolved; first-child counts when
+                    // the deciding value came from child index 0. Expression frames only —
+                    // deliberate divergence from V1, which also counted TTU fan-out
+                    // short-circuits (see design doc, M2).
+                    if (parent.Pending > 1) ValtuutusMetrics.ShortCircuits.Add(1);
+                    if (childIndex == 0) ValtuutusMetrics.FirstChildDecided.Add(1);
+                    CompleteFrame(parentIdx, true); return;
+                }
                 if (--parent.Pending == 0) CompleteFrame(parentIdx, false);
                 break;
 
             case IntersectNode:
-                if (!childResult) { CompleteFrame(parentIdx, false); return; }
+                if (!childResult)
+                {
+                    if (parent.Pending > 1) ValtuutusMetrics.ShortCircuits.Add(1);
+                    if (childIndex == 0) ValtuutusMetrics.FirstChildDecided.Add(1);
+                    CompleteFrame(parentIdx, false); return;
+                }
                 if (--parent.Pending == 0) CompleteFrame(parentIdx, true);
                 break;
 
@@ -314,8 +343,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 slot.Waiters = null;
                 CompleteFrame(parentIdx, childResult);
                 if (waiters is not null)
-                    foreach (var (p, r) in waiters)
-                        Notify(p, r, childResult);
+                    foreach (var (p, r, ci) in waiters)
+                        Notify(p, r, childResult, ci);
                 break;
             }
 
@@ -341,11 +370,11 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             entry.Waiters = null;
             _memoEntries[frame.MemoEntry] = entry;
             if (waiters is not null)
-                foreach (var (p, r) in waiters)
-                    Notify(p, r, result);
+                foreach (var (p, r, ci) in waiters)
+                    Notify(p, r, result, ci);
         }
 
-        Notify(frame.Parent, frame.RootIndex, result);
+        Notify(frame.Parent, frame.RootIndex, result, frame.ChildIndex);
     }
 
     // ── frame stepping ──────────────────────────────────────────────────────
@@ -436,7 +465,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 {
                     case 2: CompleteFrame(idx, slot.Value); break;
                     case 1:
-                        (slot.Waiters ??= []).Add((frame.Parent, frame.RootIndex));
+                        (slot.Waiters ??= []).Add((frame.Parent, frame.RootIndex, frame.ChildIndex));
                         // This frame dissolves into a waiter registration; mark completed so
                         // stale bookkeeping never routes to it again.
                         frame.Completed = true;
@@ -568,8 +597,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         ValtuutusMetrics.ExpressionNodes.Add(1);
         // All children spawn immediately — V1 parity (parallel siblings). SequentialFirst is a
         // later, metrics-gated policy applied here per plan annotation.
-        foreach (var child in children)
-            SpawnFrame(child, entityType, entityId, subjectRelation, depth, idx, rootIndex, slots: slots);
+        for (var i = 0; i < children.Length; i++)
+            SpawnFrame(children[i], entityType, entityId, subjectRelation, depth, idx, rootIndex,
+                slots: slots, childIndex: i);
     }
 
     // Avoids a heap-allocated PendingOp[1] for the collection-expression `[op]` (PendingOp has

--- a/src/Valtuutus.Core/Observability/ValtuutusMetrics.cs
+++ b/src/Valtuutus.Core/Observability/ValtuutusMetrics.cs
@@ -20,12 +20,16 @@ public static class ValtuutusMetrics
     internal static readonly Counter<long> ExpressionNodes =
         Meter.CreateCounter<long>("valtuutus.check.expression_nodes");
 
-    /// <summary>Expression nodes decided by the short-circuit value before all children finished.</summary>
+    /// <summary>Expression nodes decided by the short-circuit value before all children finished.
+    /// Emitted by both engines; under CheckEngineV2, counts Union/Intersect expression frames
+    /// only (V1 also counts TTU fan-out short-circuits).</summary>
     internal static readonly Counter<long> ShortCircuits =
         Meter.CreateCounter<long>("valtuutus.check.short_circuits");
 
     /// <summary>Expression nodes where child index 0 alone would have decided the node
-    /// (sequential-first scheduling would have saved the sibling queries).</summary>
+    /// (sequential-first scheduling would have saved the sibling queries).
+    /// Emitted by both engines; under CheckEngineV2, counts Union/Intersect expression frames
+    /// only (V1 also counts TTU fan-out short-circuits).</summary>
     internal static readonly Counter<long> FirstChildDecided =
         Meter.CreateCounter<long>("valtuutus.check.first_child_decided");
 

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
@@ -49,10 +49,13 @@ public class CheckPlanExecutorSpecs
     // Test double letting a test deterministically simulate a genuinely still-in-flight op
     // (unlike InMemory's real provider, which resolves synchronously and can never produce one).
     // Ops whose relation name is in HeldRelations don't complete until the test explicitly
-    // calls Release — everything else completes immediately with the configured result.
+    // calls a Release* method; ops whose relation is in FailRelations fail synchronously inside
+    // Submit — everything else completes immediately with the configured result.
     internal sealed class ControllablePhysicalExecutor : IPhysicalExecutor
     {
         public readonly HashSet<string> HeldRelations = [];
+        public readonly HashSet<string> FailRelations = [];
+        public Exception FailureException = new InvalidOperationException("boom");
         public bool ImmediateResult = true;
         private readonly Dictionary<string, List<(int Token, IOpCompletionSink Sink)>> _held = new();
 
@@ -60,7 +63,11 @@ public class CheckPlanExecutorSpecs
         {
             foreach (var op in ops)
             {
-                if (op.Relation is not null && HeldRelations.Contains(op.Relation))
+                if (op.Relation is not null && FailRelations.Contains(op.Relation))
+                {
+                    sink.Fail(op.Token, FailureException);
+                }
+                else if (op.Relation is not null && HeldRelations.Contains(op.Relation))
                 {
                     lock (_held)
                     {
@@ -75,16 +82,28 @@ public class CheckPlanExecutorSpecs
             }
         }
 
-        // Releases every op held under `relation` with `result`, targeting whichever sink was
-        // current when Submit ran for it — this is exactly how a genuine straggler behaves: it
-        // completes against whatever IOpCompletionSink it captured at dispatch time, regardless
-        // of what that instance is doing by the time it actually finishes.
+        // Releases every op held under `relation`, targeting whichever sink was current when
+        // Submit ran for it — this is exactly how a genuine straggler behaves: it completes
+        // against whatever IOpCompletionSink it captured at dispatch time, regardless of what
+        // that instance is doing by the time it actually finishes.
         public void Release(string relation, bool result)
         {
-            List<(int Token, IOpCompletionSink Sink)> list;
-            lock (_held) { list = _held.TryGetValue(relation, out var l) ? l : []; }
-            foreach (var (token, sink) in list)
-                sink.Complete(token, result);
+            foreach (var (token, sink) in Drain(relation)) sink.Complete(token, result);
+        }
+
+        public void ReleaseWithPayload(string relation, object payload)
+        {
+            foreach (var (token, sink) in Drain(relation)) sink.CompleteWithPayload(token, payload);
+        }
+
+        public void ReleaseWithFailure(string relation, Exception error)
+        {
+            foreach (var (token, sink) in Drain(relation)) sink.Fail(token, error);
+        }
+
+        private List<(int Token, IOpCompletionSink Sink)> Drain(string relation)
+        {
+            lock (_held) return _held.TryGetValue(relation, out var l) ? l : [];
         }
     }
 
@@ -594,6 +613,138 @@ public class CheckPlanExecutorSpecs
         recording.Submitted.Should().ContainSingle();
         recording.Submitted[0].Kind.Should().Be(OpKind.HasAnyOfDirectRelations);
         recording.Submitted[0].Relations.Should().Equal("owner", "admin", "member");
+    }
+
+    private const string StragglerSchema = """
+        entity user {}
+        entity doc {
+            relation r0 @user;
+            attribute r1 bool;
+            permission view := r0 or r1;
+        }
+        """;
+
+    private static CheckRequestContext Ctx() => new()
+        { SubjectType = "user", SubjectId = "u1", SnapToken = default, Context = new Dictionary<string, object>() };
+
+    [Fact]
+    public async Task Fail_faults_the_request_with_the_original_exception_and_drain_still_waits_for_the_held_sibling()
+    {
+        // Hazard: "failure = per-token, terminal, fail-fast" + post-fault completion. r0 fails
+        // synchronously inside Submit; r1 is genuinely outstanding. ExecuteAsync must throw
+        // r0's exception (not swallow it because r1 might still return true — authorization
+        // must not guess around missing data), and the instance must still not report idle
+        // until r1 lands. (CheckEngineV2 abandons a faulted executor rather than pooling it;
+        // this spec pins the executor-level contract that makes even pooling it safe.)
+        var (_, schema, _) = await Arrange(StragglerSchema, []);
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema));
+        var boom = new InvalidOperationException("r0 exploded");
+        var physical = new ControllablePhysicalExecutor { FailureException = boom };
+        physical.FailRelations.Add("r0");
+        physical.HeldRelations.Add("r1");
+        executor.Physical = physical;
+
+        var act = async () => await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(boom);
+
+        var drainTask = executor.DrainStragglersAsync();
+        await Task.Delay(50);
+        drainTask.IsCompleted.Should().BeFalse("r1 is still outstanding after the fault");
+        physical.Release("r1", true);
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Straggler_that_fails_after_the_answer_is_discarded_by_the_drain()
+    {
+        // Hazard: provider completing (with an error) after the request already answered.
+        // The caller has their result; a losing sibling's failure has nothing to propagate to.
+        var (_, schema, _) = await Arrange(StragglerSchema, []);
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema));
+        var physical = new ControllablePhysicalExecutor { ImmediateResult = true };
+        physical.HeldRelations.Add("r1");
+        executor.Physical = physical;
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        results[0].Should().BeTrue("r0 short-circuits the union");
+
+        var drainTask = executor.DrainStragglersAsync();
+        physical.ReleaseWithFailure("r1", new TimeoutException("late failure"));
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+        drainTask.IsCompletedSuccessfully.Should().BeTrue("a straggler's failure must be discarded, not thrown");
+
+        // The instance must still be fully usable afterwards (this is what pooling relies on).
+        physical.HeldRelations.Clear();
+        var again = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        again[0].Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Straggler_payload_after_short_circuit_is_processed_without_corrupting_the_next_call()
+    {
+        // Hazard: a TTU's GetRelations payload lands AFTER the union already short-circuited
+        // true. The drain must process (or discard) that late expansion without corrupting a
+        // subsequent request on the same pooled instance.
+        const string s = """
+            entity user {}
+            entity group { relation member @user; }
+            entity doc {
+                relation r0 @user;
+                relation shared @group;
+                permission view := r0 or shared.member;
+            }
+            """;
+        var (_, schema, _) = await Arrange(s, []);
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema));
+        var physical = new ControllablePhysicalExecutor { ImmediateResult = true };
+        physical.HeldRelations.Add("shared"); // holds the TTU's GetRelations op
+        executor.Physical = physical;
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        results[0].Should().BeTrue("r0 short-circuits before the TTU expansion arrives");
+
+        var drainTask = executor.DrainStragglersAsync();
+        // PooledList is a readonly struct rented from the shared pool; boxing it into the
+        // object-typed payload channel is exactly what DefaultPhysicalExecutor does for real.
+        var payload = Valtuutus.Core.Pools.PooledList<RelationTuple>.Rent();
+        payload.Add(new RelationTuple("doc", "1", "shared", "group", "g1"));
+        payload.Add(new RelationTuple("doc", "1", "shared", "group", "g2"));
+        physical.ReleaseWithPayload("shared", payload);
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        physical.HeldRelations.Clear();
+        var again = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        again[0].Should().BeTrue("the drained straggler expansion must not leak into this call");
+    }
+
+    [Fact]
+    public async Task Cancellation_with_an_outstanding_op_throws_and_the_drain_still_completes()
+    {
+        // Hazard: request-level cancellation. The provider must still complete every token
+        // (contract semantic 3); the executor surfaces OperationCanceledException to the
+        // caller and the instance drains to idle once the op lands.
+        var (_, schema, _) = await Arrange(StragglerSchema, []);
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema));
+        var physical = new ControllablePhysicalExecutor();
+        physical.HeldRelations.Add("r0");
+        physical.HeldRelations.Add("r1");
+        executor.Physical = physical;
+
+        using var cts = new CancellationTokenSource(50);
+        var act = async () => await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), cts.Token, memoizeRoots: false);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        var drainTask = executor.DrainStragglersAsync();
+        physical.Release("r0", false);
+        physical.Release("r1", false);
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+        drainTask.IsCompletedSuccessfully.Should().BeTrue();
     }
 
     private sealed class FixedResultOp(bool value) : ICheckOp

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/V2MetricsSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/V2MetricsSpecs.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Valtuutus.Core;
+using Valtuutus.Core.Engines.Check.V2;
+
+namespace Valtuutus.Data.InMemory.Tests.V2;
+
+public class V2MetricsSpecs
+{
+    // Counters are process-global statics and other tests run in parallel, so every assertion
+    // here is a ">= delta" over a window, never an exact count or a zero-check.
+    private static async Task<(long ShortCircuits, long FirstChildDecided, bool Result)> MeasureCheck(
+        RelationTuple[] tuples, AttributeTuple[]? attributes, string permission)
+    {
+        long shortCircuits = 0, firstChild = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (inst, l) =>
+        {
+            if (inst.Meter.Name == "Valtuutus" &&
+                inst.Name is "valtuutus.check.short_circuits" or "valtuutus.check.first_child_decided")
+                l.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<long>((inst, value, _, _) =>
+        {
+            if (inst.Name == "valtuutus.check.short_circuits") Interlocked.Add(ref shortCircuits, value);
+            else Interlocked.Add(ref firstChild, value);
+        });
+        listener.Start();
+
+        // `published or owner`: attribute child first so GroupSiblingDirectRelations cannot
+        // fuse the union into a single MultiDirectNode (which would remove the expression
+        // frame these counters hang off).
+        const string s = """
+            entity user {}
+            entity doc {
+                relation owner @user;
+                attribute published bool;
+                permission view := published or owner;
+                permission both := published and owner;
+            }
+            """;
+        var result = await CheckPlanExecutorSpecs.RunCheck(s, tuples, attributes, "doc", "1", permission);
+        return (Interlocked.Read(ref shortCircuits), Interlocked.Read(ref firstChild), result);
+    }
+
+    [Fact]
+    public async Task Short_circuit_with_a_live_sibling_increments_ShortCircuits()
+    {
+        // Both children would be true; whichever lands first decides while the other is
+        // still unresolved -> ShortCircuits must move.
+        var (sc, _, result) = await MeasureCheck(
+            [new RelationTuple("doc", "1", "owner", "user", "u1")],
+            [new AttributeTuple("doc", "1", "published", System.Text.Json.Nodes.JsonValue.Create(true))],
+            "view");
+        result.Should().BeTrue();
+        sc.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task Union_decided_by_child_zero_increments_FirstChildDecided()
+    {
+        // published (child 0) is true, owner is false: child 0's completion decides the union.
+        var (_, fcd, result) = await MeasureCheck(
+            [],
+            [new AttributeTuple("doc", "1", "published", System.Text.Json.Nodes.JsonValue.Create(true))],
+            "view");
+        result.Should().BeTrue();
+        fcd.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task Intersect_decided_false_by_child_zero_increments_FirstChildDecided()
+    {
+        // published (child 0) is absent -> false decides the intersect; owner true is irrelevant.
+        var (_, fcd, result) = await MeasureCheck(
+            [new RelationTuple("doc", "1", "owner", "user", "u1")],
+            [],
+            "both");
+        result.Should().BeFalse();
+        fcd.Should().BeGreaterThanOrEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Concurrency stress audit: extended `ControllablePhysicalExecutor` with fail/payload/failure release paths, added 4 specs for previously untested hazards (fail-fast + outstanding sibling, straggler failing after answer, straggler payload during drain, cancellation with outstanding op). Surfaced and fixed a real bug: the fault path threw before `OnOpCompleted`, permanently over-counting `_pendingOps` and hanging `DrainStragglersAsync` whenever a sibling was still in flight.
- M2: threaded `ChildIndex` through `Frame`/`SpawnFrame`/`Notify`/`CompleteFrame`/memo waiters so V2 emits the `ShortCircuits`/`FirstChildDecided` gate counters V1 already emits (documented divergence: V2 counts Union/Intersect expression frames only, not TTU fan-out).
- Benchmarks: added `Check_UsersetMiss` (R2 baseline) and `Check_UnionTtuDirect` (R1 baseline) against existing seeded entities, no Seeder changes.

## Test plan
- [x] `dotnet test tests/Valtuutus.Data.InMemory.Tests -f net10.0` — 396/396
- [x] `dotnet test tests/Valtuutus.Data.Postgres.Tests -f net10.0` — 308/308
- [x] `dotnet test tests/Valtuutus.Data.SqlServer.Tests -f net10.0` — 441/441
- [x] Alloc sanity: `Check_Simple` ~320-338 ns / 408 B, flat vs `342221a` baseline
- [x] Benchmark smoke: `Check_UsersetMiss`/`Check_UnionTtuDirect` non-zero, µs-range, under both V1 and V2