### PR TITLE
feat: CheckV2 M1 wave-shaped driver loop + drain-time drop + M3 wave telemetry

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -1,6 +1,4 @@
 using System.Buffers;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Observability;
 using Valtuutus.Core.Pools;
@@ -36,6 +34,14 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // Intrusive LIFO over Frame.NextReady — avoids a per-call Stack<int> + its backing-array
     // allocation by reusing storage already rented via ArrayPool<Frame>. -1 = empty.
     private int _readyHead = -1;
+
+    // Ops that became ready during the current DrainReady pass, accumulated here instead of
+    // being submitted one at a time — flushed as a single Physical.Submit call by FlushWave()
+    // once the pass reaches quiescence (M1: wave-shaped driver loop). Same ArrayPool lifecycle
+    // and lifetime rules as _frames (rent in ExecuteAsync's prologue, grow by doubling, return
+    // only once _pendingOps reaches 0 — see ExecuteAsync/DrainStragglersAsync).
+    private PendingOp[] _waveBuffer = [];
+    private int _waveCount;
 
     private bool[] _results = [];
     private int _rootsPending;
@@ -111,6 +117,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         _frames = ArrayPool<Frame>.Shared.Rent(16);
         _frameCount = 0;
         _readyHead = -1;
+        _waveBuffer = ArrayPool<PendingOp>.Shared.Rent(8);
+        _waveCount = 0;
         _memoIndex?.Clear();
         _memoEntries.Clear();
         _results = new bool[roots.Length];
@@ -148,11 +156,16 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         {
             // If stragglers are still outstanding (short-circuited Union/Intersect), _frames
             // must stay alive — OnOpCompleted needs to read it to recognize each straggler as
-            // stale. DrainStragglersAsync returns it once they've all landed.
+            // stale. DrainStragglersAsync returns it (and the wave buffer) once they've all
+            // landed. The wave buffer follows the same rule even though nothing reads it during
+            // drain (FlushWave already reset it to empty) — DrainStragglersAsync's own DrainReady
+            // calls can still append new ops to it (e.g. a TTU fan-out discovered while draining).
             if (_pendingOps == 0)
             {
                 ArrayPool<Frame>.Shared.Return(_frames, clearArray: true);
                 _frames = [];
+                ArrayPool<PendingOp>.Shared.Return(_waveBuffer, clearArray: true);
+                _waveBuffer = [];
             }
         }
     }
@@ -186,6 +199,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         }
         ArrayPool<Frame>.Shared.Return(_frames, clearArray: true);
         _frames = [];
+        ArrayPool<PendingOp>.Shared.Return(_waveBuffer, clearArray: true);
+        _waveBuffer = [];
     }
 
     // ── IOpCompletionSink (called from provider threads) ────────────────────
@@ -205,6 +220,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             _readyHead = _frames[idx].NextReady;
             StepFrame(idx);
         }
+        // M1: every leaf op that became ready during this pass (including ones surfaced by
+        // frames spawned mid-pass, e.g. a PlanRef re-entry) flushes as a single wave here.
+        FlushWave();
     }
 
     private int SpawnFrame(PlanNode node, string entityType, string entityId, string? subjectRelation,
@@ -602,14 +620,63 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 slots: slots, childIndex: i);
     }
 
-    // Avoids a heap-allocated PendingOp[1] for the collection-expression `[op]` (PendingOp has
-    // reference-type fields, so the compiler can't stackalloc it). Safe because Submit is
-    // synchronous within this call — DefaultPhysicalExecutor copies each op by value into
-    // RunAsync's own parameter before any suspension, so nothing retains this span past return.
+    // Appends to the current wave instead of submitting immediately (M1) — FlushWave() (called
+    // once per DrainReady pass, see below) is the only place that actually calls Physical.Submit.
     private void SubmitOp(in PendingOp op)
     {
         _pendingOps++;
-        Physical.Submit(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in op), 1), _ctx, this, _ct);
+        if (_waveCount == _waveBuffer.Length)
+        {
+            var bigger = ArrayPool<PendingOp>.Shared.Rent(_waveBuffer.Length * 2);
+            Array.Copy(_waveBuffer, bigger, _waveCount);
+            ArrayPool<PendingOp>.Shared.Return(_waveBuffer, clearArray: true);
+            _waveBuffer = bigger;
+        }
+        _waveBuffer[_waveCount++] = op;
+    }
+
+    // Submits everything accumulated by SubmitOp since the last flush, then resets for the next
+    // wave. Called once per DrainReady pass — see DrainReady below. A no-op when nothing became
+    // ready as a leaf op this pass (e.g. a pass that only resolved memo hits or PlanRef re-entries).
+    private void FlushWave()
+    {
+        if (_waveCount == 0) return;
+
+        // Once every root already has its final answer (_rootsPending == 0 — true for the tail
+        // of the main loop once the last root decides, and always true throughout
+        // DrainStragglersAsync), anything still sitting in the wave buffer is work discovered
+        // after the caller already has _results back. Drop it instead of submitting it: nobody
+        // will ever read the answer, so the real provider round trip is pure waste. _pendingOps
+        // is repaid here exactly as OnOpCompleted would repay it on a real completion, so
+        // DrainStragglersAsync's `while (_pendingOps > 0)` still terminates correctly — usually
+        // faster, since a dropped op never needs an async round trip through the mailbox at all.
+        //
+        // Scope note: this only catches the case where EVERY root already decided. A multi-root
+        // SubjectPermission call where one root short-circuits while others are still pending
+        // does not get this benefit for that root's own stale descendants yet (_rootsPending
+        // isn't 0 until every root is done) — that needs per-branch ancestor tracking, a larger
+        // separate change. A cancelled or faulted request also never hits this path
+        // (cancellation/fault propagate via the mailbox, not via Notify, so they never force
+        // _rootsPending to 0) — CheckEngineV2 abandons those executors instead of pooling them
+        // regardless, so optimizing their drain has little value.
+        if (_rootsPending == 0)
+        {
+            _pendingOps -= _waveCount;
+            _waveCount = 0;
+            return;
+        }
+
+        ValtuutusMetrics.WaveOps.Record(_waveCount);
+
+        // M3: how many ops in this wave share an OpKind with at least one sibling — stackalloc,
+        // never heap-allocated, since this runs on every wave flush.
+        Span<int> kindCounts = stackalloc int[OpKindMeta.OpKindCount];
+        for (var i = 0; i < _waveCount; i++) kindCounts[(byte)_waveBuffer[i].Kind]++;
+        for (var i = 0; i < _waveCount; i++)
+            if (kindCounts[(byte)_waveBuffer[i].Kind] >= 2) ValtuutusMetrics.WaveSameKindOps.Add(1);
+
+        Physical.Submit(_waveBuffer.AsSpan(0, _waveCount), _ctx, this, _ct);
+        _waveCount = 0;
     }
 
     // ── op completion routing ───────────────────────────────────────────────

--- a/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
@@ -16,6 +16,14 @@ internal enum OpKind : byte
     CheckOp,                // Op = rewriter-installed ICheckOp; executor is opaque to its contents
 }
 
+internal static class OpKindMeta
+{
+    // Self-adjusting for the common case (appending a member after CheckOp) instead of a
+    // hand-maintained magic number — sizes a stackalloc same-kind tally in
+    // CheckPlanExecutor.FlushWave (M3 telemetry) so it never heap-allocates on the hot path.
+    internal const int OpKindCount = (int)OpKind.CheckOp + 1;
+}
+
 internal readonly struct PendingOp
 {
     public required int Token { get; init; }

--- a/src/Valtuutus.Core/Observability/ValtuutusMetrics.cs
+++ b/src/Valtuutus.Core/Observability/ValtuutusMetrics.cs
@@ -37,6 +37,20 @@ public static class ValtuutusMetrics
     internal static readonly Counter<long> MemoHits =
         Meter.CreateCounter<long>("valtuutus.check.memo_hits");
 
+    /// <summary>Ops submitted per DrainReady wave (one Physical.Submit call). V2 only — V1 has
+    /// no wave concept. M3 telemetry: the ops-per-Submit half of the true batching-headroom
+    /// signal (design doc "M3 — wave-shaped telemetry").</summary>
+    internal static readonly Histogram<long> WaveOps =
+        Meter.CreateHistogram<long>("valtuutus.check.wave_ops");
+
+    /// <summary>Ops within a wave that share their OpKind with at least one sibling in the same
+    /// wave — i.e., ops a same-shape coalescer could merge. V2 only. M3 telemetry: the
+    /// same-OpKind-per-wave half of the batching-headroom signal; divide by the sum of
+    /// <c>valtuutus.check.wave_ops</c> for the ratio the frontier-batching gate's decision rule
+    /// wants (design doc "Reading the frontier-batching gate").</summary>
+    internal static readonly Counter<long> WaveSameKindOps =
+        Meter.CreateCounter<long>("valtuutus.check.wave_same_kind_ops");
+
     /// <summary>Provider-level DB/store queries issued (all read methods).</summary>
     public static readonly Counter<long> DbQueries =
         Meter.CreateCounter<long>("valtuutus.db.queries");

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
@@ -34,14 +34,20 @@ public class CheckPlanExecutorSpecs
     }
 
     // Records every submitted op, then forwards to the real executor — lets a test assert on
-    // query SHAPE (one batched op vs N singles) while the check still runs for real.
+    // query SHAPE (one batched op vs N singles) while the check still runs for real. Submitted
+    // is a flattened view across every Submit call; SubmitCalls preserves per-call boundaries so
+    // a test can additionally assert on wave SIZE (how many ops one Submit call carried).
     internal sealed class RecordingPhysicalExecutor(IPhysicalExecutor inner) : IPhysicalExecutor
     {
         public readonly List<PendingOp> Submitted = [];
+        public readonly List<PendingOp[]> SubmitCalls = [];
         public void Submit(ReadOnlySpan<PendingOp> ops, CheckRequestContext ctx, IOpCompletionSink sink, CancellationToken ct)
         {
             lock (Submitted)
+            {
                 foreach (var op in ops) Submitted.Add(op);
+                SubmitCalls.Add(ops.ToArray());
+            }
             inner.Submit(ops, ctx, sink, ct);
         }
     }
@@ -615,6 +621,86 @@ public class CheckPlanExecutorSpecs
         recording.Submitted[0].Relations.Should().Equal("owner", "admin", "member");
     }
 
+    private const string WaveSchema = """
+        entity user {}
+        entity doc {
+            relation owner @user;
+            attribute published bool;
+            permission view := owner or published;
+        }
+        """;
+
+    [Fact]
+    public async Task Different_kind_siblings_ready_in_the_same_pass_submit_in_one_wave()
+    {
+        // M1: DrainReady accumulates every leaf op that becomes ready in one synchronous pass
+        // and flushes them via a single Physical.Submit call, instead of one Submit per op.
+        // owner (HasDirectRelation) and published (HasTrueBoolAttribute) are different OpKinds,
+        // so GroupSiblingDirectRelations cannot fuse them at compile time — this schema isolates
+        // wave batching (a runtime driver-loop behavior) from sibling-relation batching (a
+        // compile-time pass), proving the two are independent mechanisms.
+        var (_, schema, reader) = await Arrange(WaveSchema,
+            [new RelationTuple("doc", "1", "owner", "user", "u1")]);
+        var snap = await Valtuutus.Core.Engines.SnapTokenUtils.ResolveLatest(reader, null, default);
+        var ctx = new CheckRequestContext
+            { SubjectType = "user", SubjectId = "u1", SnapToken = snap, Context = new Dictionary<string, object>() };
+        var recording = new RecordingPhysicalExecutor(new DefaultPhysicalExecutor(schema) { Reader = reader });
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+
+        results[0].Should().BeTrue("owner is granted");
+        recording.SubmitCalls.Should().ContainSingle(
+            "both leaf ops become ready in the same DrainReady pass and must flush as one wave");
+        // Set membership, not positional order: DrainReady drains its intrusive LIFO ready-stack
+        // (see _readyHead), so union children surface in reverse-of-spawn order — a pre-existing,
+        // deliberate characteristic of the scheduler (Union is commutative; order was never
+        // observable before wave batching existed). BeEquivalentTo would enforce byte-for-byte
+        // positional equality here regardless of source order since OpKind is byte-backed and
+        // FluentAssertions special-cases byte-sized collections like raw byte arrays — Contain +
+        // HaveCount checks the same two distinct kinds are present without asserting an order the
+        // wave never promised.
+        var kinds = recording.SubmitCalls[0].Select(o => o.Kind).ToArray();
+        kinds.Should().HaveCount(2);
+        kinds.Should().Contain([OpKind.HasDirectRelation, OpKind.HasTrueBoolAttribute]);
+    }
+
+    [Fact]
+    public async Task Wave_buffer_growth_does_not_corrupt_submitted_ops()
+    {
+        // Regression test mirroring Wide_union_forces_frame_array_growth_without_corruption,
+        // but for the wave buffer: ArrayPool<T>.Shared.Rent(8) actually rounds up to a 16-element
+        // array (bucket rounding), so branchCount must exceed 16 -- not just 8 -- to force a real
+        // grow. GroupSiblingDirectRelations doesn't fuse attribute nodes (only direct relations),
+        // so all branches submit individually and must all land in one wave after at least one grow.
+        const int branchCount = 20;
+        var attrDecls = string.Join("\n", Enumerable.Range(0, branchCount).Select(i => $"    attribute a{i} bool;"));
+        var unionExpr = string.Join(" or ", Enumerable.Range(0, branchCount).Select(i => $"a{i}"));
+        var schemaText = $$"""
+            entity user {}
+            entity doc {
+            {{attrDecls}}
+                permission view := {{unionExpr}};
+            }
+            """;
+        var (_, schema, reader) = await Arrange(schemaText, [],
+            [new AttributeTuple("doc", "1", $"a{branchCount - 1}", System.Text.Json.Nodes.JsonValue.Create(true))]);
+        var snap = await Valtuutus.Core.Engines.SnapTokenUtils.ResolveLatest(reader, null, default);
+        var ctx = new CheckRequestContext
+            { SubjectType = "user", SubjectId = "u1", SnapToken = snap, Context = new Dictionary<string, object>() };
+        var recording = new RecordingPhysicalExecutor(new DefaultPhysicalExecutor(schema) { Reader = reader });
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+
+        results[0].Should().BeTrue();
+        recording.SubmitCalls.Should().ContainSingle();
+        recording.SubmitCalls[0].Should().HaveCount(branchCount);
+        recording.SubmitCalls[0].Select(o => o.Kind).Should().AllBeEquivalentTo(OpKind.HasTrueBoolAttribute);
+    }
+
     private const string StragglerSchema = """
         entity user {}
         entity doc {
@@ -720,6 +806,47 @@ public class CheckPlanExecutorSpecs
         var again = await executor.ExecuteAsync(
             [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
         again[0].Should().BeTrue("the drained straggler expansion must not leak into this call");
+    }
+
+    [Fact]
+    public async Task Drain_time_descendants_after_the_answer_are_dropped_not_submitted()
+    {
+        // Once every root already has its final answer (_rootsPending == 0 — true throughout
+        // DrainStragglersAsync), FlushWave drops the wave instead of submitting it: nobody will
+        // ever read an answer for work discovered after the caller already has _results back.
+        // r0 short-circuits the union immediately; shared's TTU op is held. Its late payload
+        // (delivered during drain) fans out to 2 member-relation checks against g1/g2 — those
+        // must never reach Physical.Submit.
+        const string s = """
+            entity user {}
+            entity group { relation member @user; }
+            entity doc {
+                relation r0 @user;
+                relation shared @group;
+                permission view := r0 or shared.member;
+            }
+            """;
+        var (_, schema, _) = await Arrange(s, []);
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema));
+        var controllable = new ControllablePhysicalExecutor { ImmediateResult = true };
+        controllable.HeldRelations.Add("shared");
+        var recording = new RecordingPhysicalExecutor(controllable);
+        executor.Physical = recording;
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+        results[0].Should().BeTrue("r0 short-circuits the union");
+        var submittedBeforeDrain = recording.Submitted.Count;
+
+        var drainTask = executor.DrainStragglersAsync();
+        var payload = Valtuutus.Core.Pools.PooledList<RelationTuple>.Rent();
+        payload.Add(new RelationTuple("doc", "1", "shared", "group", "g1"));
+        payload.Add(new RelationTuple("doc", "1", "shared", "group", "g2"));
+        controllable.ReleaseWithPayload("shared", payload);
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        recording.Submitted.Count.Should().Be(submittedBeforeDrain,
+            "member-relation fan-out ops discovered after the answer must be dropped, not submitted");
     }
 
     [Fact]

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/V2WaveMetricsSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/V2WaveMetricsSpecs.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Valtuutus.Core;
+using Valtuutus.Core.Engines.Check.V2;
+
+namespace Valtuutus.Data.InMemory.Tests.V2;
+
+public class V2WaveMetricsSpecs
+{
+    // Counters/histograms are process-global statics and other tests run in parallel, so
+    // assertions here check for a specific recorded value or a ">=" delta, never an exact count.
+    private static async Task<(List<long> WaveOps, long SameKindOps, bool Result)> MeasureCheck(
+        string schemaText, RelationTuple[] tuples, AttributeTuple[]? attributes, string permission)
+    {
+        var waveOps = new List<long>();
+        long sameKindOps = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (inst, l) =>
+        {
+            if (inst.Meter.Name == "Valtuutus" &&
+                inst.Name is "valtuutus.check.wave_ops" or "valtuutus.check.wave_same_kind_ops")
+                l.EnableMeasurementEvents(inst);
+        };
+        listener.SetMeasurementEventCallback<long>((inst, value, _, _) =>
+        {
+            if (inst.Name == "valtuutus.check.wave_ops") lock (waveOps) waveOps.Add(value);
+            else Interlocked.Add(ref sameKindOps, value);
+        });
+        listener.Start();
+
+        var result = await CheckPlanExecutorSpecs.RunCheck(schemaText, tuples, attributes, "doc", "1", permission);
+        return (waveOps, Interlocked.Read(ref sameKindOps), result);
+    }
+
+    private const string DifferentKindSchema = """
+        entity user {}
+        entity doc {
+            relation owner @user;
+            attribute published bool;
+            permission view := owner or published;
+        }
+        """;
+
+    [Fact]
+    public async Task Wave_of_different_kind_ops_records_the_wave_size()
+    {
+        // owner (HasDirectRelation) and published (HasTrueBoolAttribute) become ready in the
+        // same DrainReady pass -> one wave of size 2, but they don't share an OpKind.
+        var (waveOps, _, result) = await MeasureCheck(DifferentKindSchema,
+            [new RelationTuple("doc", "1", "owner", "user", "u1")], [], "view");
+
+        result.Should().BeTrue();
+        waveOps.Should().Contain(2, "owner and published become ready in the same wave");
+    }
+
+    private const string SameKindSchema = """
+        entity user {}
+        entity doc {
+            attribute a0 bool;
+            attribute a1 bool;
+            permission view := a0 or a1;
+        }
+        """;
+
+    [Fact]
+    public async Task Wave_of_same_kind_ops_credits_both_as_coalescable()
+    {
+        // a0 and a1 are both HasTrueBoolAttribute ops ready in the same wave -> both count
+        // toward WaveSameKindOps (what a same-shape coalescer could merge).
+        var (waveOps, sameKindOps, result) = await MeasureCheck(SameKindSchema,
+            [], [new AttributeTuple("doc", "1", "a1", System.Text.Json.Nodes.JsonValue.Create(true))], "view");
+
+        result.Should().BeTrue();
+        waveOps.Should().Contain(2);
+        sameKindOps.Should().BeGreaterThanOrEqualTo(2,
+            "both a0 and a1 share OpKind.HasTrueBoolAttribute within the same wave");
+    }
+}


### PR DESCRIPTION
## Summary
- Wave-shaped driver loop: `DrainReady` accumulates every leaf op ready in one synchronous pass into a pooled wave buffer, flushing via a single `Physical.Submit` call per pass instead of one call per op (same ArrayPool lifecycle as the existing `Frame[]` pool).
- Drain-time drop: `FlushWave` drops (never submits) a wave once every root already has its final answer (`_rootsPending == 0`) — the provably-safe case where late TTU fan-out discovered during `DrainStragglersAsync` is guaranteed unreachable, saving the real provider query.
- M3 wave telemetry: `valtuutus.check.wave_ops` (histogram) and `valtuutus.check.wave_same_kind_ops` (counter), the concrete instruments the frontier-batching gate's decision rule needs.

## Test plan
- [x] `dotnet test tests/Valtuutus.Data.InMemory.Tests -f net10.0` — 401/401
- [x] `dotnet test tests/Valtuutus.Data.Postgres.Tests -f net10.0` — 308/308
- [x] `dotnet test tests/Valtuutus.Data.SqlServer.Tests -f net10.0` — 441/441
- [x] InMemory `Check_*` alloc/latency: flat vs pre-work baseline, byte-identical allocations (expected — `DefaultPhysicalExecutor` still issues one query per op regardless of wave size; round-trip reduction needs a `RelationalPhysicalExecutor`, a separate future step)