### PR TITLE
feat: CheckV2 SqlServer DbBatch executor (IRelationalBatchOps)

### DIFF
--- a/src/Valtuutus.Core/Valtuutus.Core.csproj
+++ b/src/Valtuutus.Core/Valtuutus.Core.csproj
@@ -33,6 +33,10 @@
                  Valtuutus.Data.Db grant above. -->
             <_Parameter1>Valtuutus.Data.Postgres</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <!-- Same as Valtuutus.Data.Postgres above, for AddSqlServer. -->
+            <_Parameter1>Valtuutus.Data.SqlServer</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
+++ b/src/Valtuutus.Data.Db/Valtuutus.Data.Db.csproj
@@ -22,6 +22,10 @@
                  internals to Valtuutus.Data.Db itself. -->
             <_Parameter1>Valtuutus.Data.Postgres</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <!-- Same as Valtuutus.Data.Postgres above, for AddSqlServer. -->
+            <_Parameter1>Valtuutus.Data.SqlServer</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/src/Valtuutus.Data.SqlServer/DependencyInjectionExtensions.cs
+++ b/src/Valtuutus.Data.SqlServer/DependencyInjectionExtensions.cs
@@ -1,5 +1,8 @@
 using Valtuutus.Core.Data;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core.Engines.Check.V2;
+using Valtuutus.Core.Schemas;
 using Valtuutus.Data.Db;
 
 namespace Valtuutus.Data.SqlServer;
@@ -19,6 +22,11 @@ public static class DependencyInjectionExtensions
     {
         var builder = services.AddValtuutusData();
         builder.Services.AddDbSetup(factory, options ?? new ValtuutusSqlServerOptions());
+        // Harmless when CheckV2 isn't opted in (nothing resolves CheckPlanExecutorPool then).
+        // Replace (not TryAdd) so this always wins regardless of whether AddValtuutusCheckV2()
+        // ran before or after this call — same reasoning as AddPostgres's identical registration.
+        builder.Services.Replace(ServiceDescriptor.Singleton<Func<Schema, IPhysicalExecutor>>(
+            static _ => static schema => new BatchedPhysicalExecutor(schema)));
         builder.Services.AddScoped<IDataReaderProvider, SqlServerDataReaderProvider>();
         builder.Services.AddScoped<IDataWriterProvider, SqlServerDataWriterProvider>();
         builder.Services.AddScoped<IDbDataWriterProvider, SqlServerDataWriterProvider>();

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Data;
+using System.Data.Common;
 using System.Text.Json.Nodes;
 using Valtuutus.Core;
 using Valtuutus.Core.Data;
@@ -12,7 +13,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Valtuutus.Data.SqlServer;
 
-public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvider, IRelationalCheckOps
+public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvider, IRelationalCheckOps, IRelationalBatchOps
 {
     private readonly DbConnectionFactory _connectionFactory;
 
@@ -27,27 +28,27 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         _q = QueryCache.GetOrAdd(DbQueryCacheKey.From(dbOptions), static key => BuildQueries(key));
     }
 
-    private static void AddStringParameter(SqlCommand command, string name, string value, int size)
+    private static void AddStringParameter(SqlParameterCollection parameters, string name, string value, int size)
     {
-        command.Parameters.Add(new SqlParameter(name, SqlDbType.NVarChar, size) { Value = value });
+        parameters.Add(new SqlParameter(name, SqlDbType.NVarChar, size) { Value = value });
     }
 
-    private static void AddNullableStringParameter(SqlCommand command, string name, string? value, int size)
+    private static void AddNullableStringParameter(SqlParameterCollection parameters, string name, string? value, int size)
     {
-        command.Parameters.Add(new SqlParameter(name, SqlDbType.NVarChar, size)
+        parameters.Add(new SqlParameter(name, SqlDbType.NVarChar, size)
         {
             Value = string.IsNullOrWhiteSpace(value) ? DBNull.Value : value
         });
     }
 
-    private static void AddFixedCharParameter(SqlCommand command, string name, string value, int size)
+    private static void AddFixedCharParameter(SqlParameterCollection parameters, string name, string value, int size)
     {
-        command.Parameters.Add(new SqlParameter(name, SqlDbType.NChar, size) { Value = value });
+        parameters.Add(new SqlParameter(name, SqlDbType.NChar, size) { Value = value });
     }
 
-    private void AddTvpParameter(SqlCommand command, string name, IEnumerable<string> values)
+    private void AddTvpParameter(SqlParameterCollection parameters, string name, IEnumerable<string> values)
     {
-        TvpHelper.AsTvpParameter(values, _q.TvpListIdsTypeName).AddParameter(command, name);
+        TvpHelper.AsTvpParameter(values, _q.TvpListIdsTypeName).AddParameter(parameters, name);
     }
 
     // Attribute-name lists come from the schema, so counts are small and bounded: inlined
@@ -58,10 +59,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         AttributeInQueryCache.GetOrAdd((prefix, count), static key =>
             $"{key.Prefix}({string.Join(", ", Enumerable.Range(0, key.Count).Select(i => $"@Attr{i}"))})");
 
-    private static void AddAttributeInParameters(SqlCommand command, string[] attributes)
+    private static void AddAttributeInParameters(SqlParameterCollection parameters, string[] attributes)
     {
         for (var i = 0; i < attributes.Length; i++)
-            AddStringParameter(command, $"@Attr{i}", attributes[i], 64);
+            AddStringParameter(parameters, $"@Attr{i}", attributes[i], 64);
     }
 
     private static RelationTuple ReadRelationTuple(SqlDataReader reader) =>
@@ -122,7 +123,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     WHERE {snapPredicate}
                       AND entity_type = @EntityType AND entity_id = @EntityId
                       AND attribute = @Attribute AND value = 'true'
-                ) THEN 1 ELSE 0 END
+                ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
                 """,
             // Split instead of "(@EntityId IS NULL OR entity_id = @EntityId)": the catch-all
             // predicate blocks an index seek on entity_id.
@@ -199,7 +200,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     WHERE {snapPredicate}
                       AND entity_type = @EntityType AND entity_id = @EntityId AND relation = @Relation
                       AND subject_id = @SubjectId AND subject_relation = ''
-                ) THEN 1 ELSE 0 END
+                ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
                 """,
             GetIndirectRelations = $"""
                 SELECT entity_type, entity_id, relation, subject_type, subject_id, subject_relation
@@ -214,7 +215,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     WHERE {snapPredicate}
                       AND entity_type = @EntityType AND entity_id IN (SELECT id FROM @EntityIds) AND relation = @Relation
                       AND subject_id = @SubjectId AND subject_relation = ''
-                ) THEN 1 ELSE 0 END
+                ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
                 """,
             HasAnyOfDirectRelations = $"""
                 SELECT DISTINCT relation FROM {relationsTable}
@@ -318,7 +319,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                       AND r_dep.subject_type = @SubjectType
                       AND r_dep.subject_id = @SubjectId
                       AND r_dep.subject_relation = ''
-                ) THEN 1 ELSE 0 END
+                ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
                 """,
             GetRelationsWithSingleSubjectScoped = $"""
                 SELECT r_main.entity_type, r_main.entity_id, r_main.relation, r_main.subject_type, r_main.subject_id, r_main.subject_relation
@@ -493,11 +494,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             var hasEntityId = !string.IsNullOrWhiteSpace(filter.EntityId);
 
             await using var command = CreateCommand(connection, hasEntityId ? _q.GetAttributeWithEntityId : _q.GetAttribute);
-            AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-            AddStringParameter(command, "@Attribute", filter.Attribute, 64);
+            AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+            AddStringParameter(command.Parameters, "@Attribute", filter.Attribute, 64);
             if (hasEntityId)
-                AddStringParameter(command, "@EntityId", filter.EntityId!, 64);
-            AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
+                AddStringParameter(command.Parameters, "@EntityId", filter.EntityId!, 64);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleRow | CommandBehavior.SequentialAccess, cancellationToken);
             if (!await reader.ReadAsync(cancellationToken))
@@ -511,6 +512,15 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         }
     }
 
+    private static void PopulateHasTrueBoolAttributeCommand(SqlParameterCollection parameters, string entityType,
+        string entityId, string attribute, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddStringParameter(parameters, "@EntityId", entityId, 64);
+        AddStringParameter(parameters, "@Attribute", attribute, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
+    }
+
     public async Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute,
         SnapToken snapToken, CancellationToken cancellationToken)
     {
@@ -521,16 +531,22 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await using var connection = (SqlConnection)_connectionFactory();
             await connection.OpenAsync(cancellationToken);
             await using var command = CreateCommand(connection, _q.HasTrueBoolAttribute);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddStringParameter(command, "@EntityId", entityId, 64);
-            AddStringParameter(command, "@Attribute", attribute, 64);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
-            return (int)(await command.ExecuteScalarAsync(cancellationToken))! == 1;
+            PopulateHasTrueBoolAttributeCommand(command.Parameters, entityType, entityId, attribute, snapToken);
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }
         finally
         {
             Semaphore.Release();
         }
+    }
+
+    private void PopulateHasAnyOfAttributesCommand(SqlParameterCollection parameters, string entityType,
+        string entityId, string[] attributeNames, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddStringParameter(parameters, "@EntityId", entityId, 64);
+        AddTvpParameter(parameters, "@Attributes", attributeNames);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
     }
 
     public async Task<HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames,
@@ -544,10 +560,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.HasAnyOfAttributes);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddStringParameter(command, "@EntityId", entityId, 64);
-            AddTvpParameter(command, "@Attributes", attributeNames);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+            PopulateHasAnyOfAttributesCommand(command.Parameters, entityType, entityId, attributeNames, snapToken);
 
             var result = new HashSet<string>(attributeNames.Length, StringComparer.Ordinal);
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -559,6 +572,125 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         {
             Semaphore.Release();
         }
+    }
+
+    // IRelationalBatchOps: SqlServer has no NpgsqlDataSource-equivalent pooling object, so unlike
+    // Postgres, CreateBatch() cannot open a connection itself (it's a synchronous interface member
+    // with no CancellationToken). It only constructs an unopened SqlConnection + calls
+    // connection.CreateBatch() (pure object construction, no I/O — DbConnection.CreateBatch just
+    // assigns batch.Connection). All I/O (open + execute) happens in ExecuteBatchAsync, which is
+    // async and does carry a CancellationToken. CommandBehavior.CloseConnection makes the returned
+    // reader's disposal close+dispose the connection automatically — mirrors how Postgres's
+    // ephemeral per-batch connection returns to its pool when the caller disposes the reader.
+    public DbBatch CreateBatch()
+    {
+        var connection = (SqlConnection)_connectionFactory();
+        return connection.CreateBatch();
+    }
+
+    public async Task<DbDataReader> ExecuteBatchAsync(DbBatch batch, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity();
+        await EnterQuery(cancellationToken);
+        try
+        {
+            var connection = (SqlConnection)batch.Connection!;
+            try
+            {
+                await connection.OpenAsync(cancellationToken);
+                return await batch.ExecuteReaderAsync(CommandBehavior.CloseConnection, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                // CommandBehavior.CloseConnection never took effect (no reader was obtained) — the
+                // connection would otherwise leak.
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
+    // Batch siblings of the 8 methods above: same SQL text (via the same Populate<Name>Command
+    // helpers Task 3 extracted), same parameter shape, appended to a caller-supplied batch instead
+    // of dispatched as their own round trip. DbBatch.CreateBatchCommand()'s declared return type is
+    // the ADO-abstract DbBatchCommand, but every batch this provider hands out (IRelationalBatchOps
+    // .CreateBatch) is created via SqlConnection.CreateBatch(), so the object it returns at runtime
+    // is always a genuine SqlBatchCommand (Microsoft.Data.SqlClient overrides the protected factory
+    // DbBatch.CreateBatchCommand() delegates to) — verified against Microsoft.Data.SqlClient 6.0.1,
+    // the package floor pinned in Directory.Packages.props. The cast is therefore safe.
+    public void AddHasAnyOfDirectRelationsToBatch(DbBatch batch, string entityType, string entityId,
+        string[] relationNames, string subjectId, SnapToken snapToken)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasAnyOfDirectRelations;
+        PopulateHasAnyOfDirectRelationsCommand(command.Parameters, entityType, entityId, relationNames, subjectId, snapToken);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddHasAnyOfAttributesToBatch(DbBatch batch, string entityType, string entityId,
+        string[] attributeNames, SnapToken snapToken)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasAnyOfAttributes;
+        PopulateHasAnyOfAttributesCommand(command.Parameters, entityType, entityId, attributeNames, snapToken);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddHasDirectRelationToBatch(DbBatch batch, RelationTupleFilter tupleFilter, string subjectId)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasDirectRelation;
+        PopulateHasDirectRelationCommand(command.Parameters, tupleFilter, subjectId);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddHasTrueBoolAttributeToBatch(DbBatch batch, string entityType, string entityId, string attribute,
+        SnapToken snapToken)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasTrueBoolAttribute;
+        PopulateHasTrueBoolAttributeCommand(command.Parameters, entityType, entityId, attribute, snapToken);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddHasTupleToUserSetRelationToBatch(DbBatch batch, string entityType, string entityId,
+        string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId,
+        SnapToken snapToken)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasTupleToUserSetRelation;
+        PopulateHasTupleToUserSetRelationCommand(command.Parameters, entityType, entityId, tupleSetRelation,
+            subEntityType, computedRelation, subjectType, subjectId, snapToken);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,
+        string subjectId, SnapToken snapToken)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.HasAnyDirectRelation;
+        PopulateHasAnyDirectRelationCommand(command.Parameters, entityType, entityIds, relation, subjectId, snapToken);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddGetRelationsToBatch(DbBatch batch, RelationTupleFilter tupleFilter)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = PopulateGetRelationsCommand(command.Parameters, tupleFilter);
+        batch.BatchCommands.Add(command);
+    }
+
+    public void AddGetIndirectRelationsToBatch(DbBatch batch, RelationTupleFilter tupleFilter)
+    {
+        var command = (SqlBatchCommand)batch.CreateBatchCommand();
+        command.CommandText = _q.GetIndirectRelations;
+        PopulateGetIndirectRelationsCommand(command.Parameters, tupleFilter);
+        batch.BatchCommands.Add(command);
     }
 
     public async Task<List<AttributeTuple>> GetAttributes(EntityAttributeFilter filter, CancellationToken cancellationToken)
@@ -573,11 +705,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             var hasEntityId = !string.IsNullOrWhiteSpace(filter.EntityId);
             await using var command = CreateCommand(connection,
                 hasEntityId ? _q.SelectAttributesByEntityAttributeFilterWithEntityId : _q.SelectAttributesByEntityAttributeFilter);
-            AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-            AddStringParameter(command, "@Attribute", filter.Attribute, 64);
+            AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+            AddStringParameter(command.Parameters, "@Attribute", filter.Attribute, 64);
             if (hasEntityId)
-                AddStringParameter(command, "@EntityId", filter.EntityId!, 64);
-            AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
+                AddStringParameter(command.Parameters, "@EntityId", filter.EntityId!, 64);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             var rows = new List<AttributeTuple>();
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -604,12 +736,12 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             {
                 await using var command = CreateCommand(connection,
                     GetAttributeInQuery(_q.GetAttributesDictScopedPrefix, filter.Attributes.Length));
-                AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-                AddAttributeInParameters(command, filter.Attributes);
-                AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
-                AddStringParameter(command, "@ScopeRelation", s.Relation, 64);
-                AddStringParameter(command, "@ScopeSubjectType", s.SubjectType, 256);
-                AddStringParameter(command, "@ScopeSubjectId", s.SubjectId, 64);
+                AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+                AddAttributeInParameters(command.Parameters, filter.Attributes);
+                AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
+                AddStringParameter(command.Parameters, "@ScopeRelation", s.Relation, 64);
+                AddStringParameter(command.Parameters, "@ScopeSubjectType", s.SubjectType, 256);
+                AddStringParameter(command.Parameters, "@ScopeSubjectId", s.SubjectId, 64);
 
                 var dict = new Dictionary<(string AttributeName, string EntityId), AttributeTuple>();
                 await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -626,10 +758,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 hasEntityId ? _q.SelectAttributesByEntityAttributesWithEntityIdPrefix : _q.SelectAttributesByEntityAttributesPrefix,
                 filter.Attributes.Length));
             if (hasEntityId)
-                AddStringParameter(unscopedCommand, "@EntityId", filter.EntityId!, 64);
-            AddStringParameter(unscopedCommand, "@EntityType", filter.EntityType, 256);
-            AddAttributeInParameters(unscopedCommand, filter.Attributes);
-            AddFixedCharParameter(unscopedCommand, "@SnapToken", filter.SnapToken.Value, 26);
+                AddStringParameter(unscopedCommand.Parameters, "@EntityId", filter.EntityId!, 64);
+            AddStringParameter(unscopedCommand.Parameters, "@EntityType", filter.EntityType, 256);
+            AddAttributeInParameters(unscopedCommand.Parameters, filter.Attributes);
+            AddFixedCharParameter(unscopedCommand.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             var unscopedResult = new Dictionary<(string AttributeName, string EntityId), AttributeTuple>();
             await using var unscopedReader = await unscopedCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -660,10 +792,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 hasEntityId ? _q.SelectAttributesByEntityAttributesWithEntityIdPrefix : _q.SelectAttributesByEntityAttributesPrefix,
                 filter.Attributes.Length));
             if (hasEntityId)
-                AddStringParameter(command, "@EntityId", filter.EntityId!, 64);
-            AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-            AddAttributeInParameters(command, filter.Attributes);
-            AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
+                AddStringParameter(command.Parameters, "@EntityId", filter.EntityId!, 64);
+            AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+            AddAttributeInParameters(command.Parameters, filter.Attributes);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             var pooled = PooledList<AttributeTuple>.Rent();
             try
@@ -695,10 +827,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.SelectAttributesWithEntityIdsByAttributeFilter);
-            AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-            AddStringParameter(command, "@Attribute", filter.Attribute, 64);
-            AddTvpParameter(command, "@EntityIds", entitiesIds);
-            AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
+            AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+            AddStringParameter(command.Parameters, "@Attribute", filter.Attribute, 64);
+            AddTvpParameter(command.Parameters, "@EntityIds", entitiesIds);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             var rows = new List<AttributeTuple>();
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -724,10 +856,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
 
             await using var command = CreateCommand(connection,
                 GetAttributeInQuery(_q.SelectAttributesWithEntityIdsByEntityAttributesPrefix, filter.Attributes.Length));
-            AddStringParameter(command, "@EntityType", filter.EntityType, 256);
-            AddAttributeInParameters(command, filter.Attributes);
-            AddTvpParameter(command, "@EntityIds", entitiesIds);
-            AddFixedCharParameter(command, "@SnapToken", filter.SnapToken.Value, 26);
+            AddStringParameter(command.Parameters, "@EntityType", filter.EntityType, 256);
+            AddAttributeInParameters(command.Parameters, filter.Attributes);
+            AddTvpParameter(command.Parameters, "@EntityIds", entitiesIds);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", filter.SnapToken.Value, 26);
 
             var dict = new Dictionary<(string AttributeName, string EntityId), AttributeTuple>();
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -763,6 +895,26 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         }
     }
 
+    private string PopulateGetRelationsCommand(SqlParameterCollection parameters, RelationTupleFilter tupleFilter)
+    {
+        var noSubjectFilters = string.IsNullOrWhiteSpace(tupleFilter.SubjectId)
+            && string.IsNullOrWhiteSpace(tupleFilter.SubjectRelation)
+            && string.IsNullOrWhiteSpace(tupleFilter.SubjectType);
+
+        AddStringParameter(parameters, "@EntityType", tupleFilter.EntityType, 256);
+        AddStringParameter(parameters, "@EntityId", tupleFilter.EntityId, 64);
+        AddStringParameter(parameters, "@Relation", tupleFilter.Relation, 64);
+        if (!noSubjectFilters)
+        {
+            AddNullableStringParameter(parameters, "@SubjectId", tupleFilter.SubjectId, 64);
+            AddNullableStringParameter(parameters, "@SubjectRelation", tupleFilter.SubjectRelation, 64);
+            AddNullableStringParameter(parameters, "@SubjectType", tupleFilter.SubjectType, 256);
+        }
+        AddFixedCharParameter(parameters, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+
+        return noSubjectFilters ? _q.SelectRelationsByTupleFilterNoSubject : _q.SelectRelationsByTupleFilter;
+    }
+
     public async Task<PooledList<RelationTuple>> GetRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
     {
         using var activity = DefaultActivitySource.Instance.StartActivity();
@@ -772,22 +924,8 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await using var connection = (SqlConnection)_connectionFactory();
             await connection.OpenAsync(cancellationToken);
 
-            var noSubjectFilters = string.IsNullOrWhiteSpace(tupleFilter.SubjectId)
-                && string.IsNullOrWhiteSpace(tupleFilter.SubjectRelation)
-                && string.IsNullOrWhiteSpace(tupleFilter.SubjectType);
-
-            await using var command = CreateCommand(connection,
-                noSubjectFilters ? _q.SelectRelationsByTupleFilterNoSubject : _q.SelectRelationsByTupleFilter);
-            AddStringParameter(command, "@EntityType", tupleFilter.EntityType, 256);
-            AddStringParameter(command, "@EntityId", tupleFilter.EntityId, 64);
-            AddStringParameter(command, "@Relation", tupleFilter.Relation, 64);
-            if (!noSubjectFilters)
-            {
-                AddNullableStringParameter(command, "@SubjectId", tupleFilter.SubjectId, 64);
-                AddNullableStringParameter(command, "@SubjectRelation", tupleFilter.SubjectRelation, 64);
-                AddNullableStringParameter(command, "@SubjectType", tupleFilter.SubjectType, 256);
-            }
-            AddFixedCharParameter(command, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+            await using var command = CreateCommand(connection, string.Empty);
+            command.CommandText = PopulateGetRelationsCommand(command.Parameters, tupleFilter);
 
             var pooled = PooledList<RelationTuple>.Rent();
             try
@@ -809,6 +947,15 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         }
     }
 
+    private static void PopulateHasDirectRelationCommand(SqlParameterCollection parameters, RelationTupleFilter tupleFilter, string subjectId)
+    {
+        AddStringParameter(parameters, "@EntityType", tupleFilter.EntityType, 256);
+        AddStringParameter(parameters, "@EntityId", tupleFilter.EntityId, 64);
+        AddStringParameter(parameters, "@Relation", tupleFilter.Relation, 64);
+        AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+    }
+
     public async Task<bool> HasDirectRelation(RelationTupleFilter tupleFilter, string subjectId, CancellationToken cancellationToken)
     {
         using var activity = DefaultActivitySource.Instance.StartActivity();
@@ -819,13 +966,9 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.HasDirectRelation);
-            AddStringParameter(command, "@EntityType", tupleFilter.EntityType, 256);
-            AddStringParameter(command, "@EntityId", tupleFilter.EntityId, 64);
-            AddStringParameter(command, "@Relation", tupleFilter.Relation, 64);
-            AddStringParameter(command, "@SubjectId", subjectId, 64);
-            AddFixedCharParameter(command, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+            PopulateHasDirectRelationCommand(command.Parameters, tupleFilter, subjectId);
 
-            return (int)(await command.ExecuteScalarAsync(cancellationToken))! == 1;
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }
         finally
         {
@@ -843,10 +986,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.GetIndirectRelations);
-            AddStringParameter(command, "@EntityType", tupleFilter.EntityType, 256);
-            AddStringParameter(command, "@EntityId", tupleFilter.EntityId, 64);
-            AddStringParameter(command, "@Relation", tupleFilter.Relation, 64);
-            AddFixedCharParameter(command, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+            PopulateGetIndirectRelationsCommand(command.Parameters, tupleFilter);
 
             var pooled = PooledList<RelationTuple>.Rent();
             try
@@ -868,6 +1008,24 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         }
     }
 
+    private static void PopulateGetIndirectRelationsCommand(SqlParameterCollection parameters, RelationTupleFilter tupleFilter)
+    {
+        AddStringParameter(parameters, "@EntityType", tupleFilter.EntityType, 256);
+        AddStringParameter(parameters, "@EntityId", tupleFilter.EntityId, 64);
+        AddStringParameter(parameters, "@Relation", tupleFilter.Relation, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", tupleFilter.SnapToken.Value, 26);
+    }
+
+    private void PopulateHasAnyDirectRelationCommand(SqlParameterCollection parameters, string entityType,
+        string[] entityIds, string relation, string subjectId, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddTvpParameter(parameters, "@EntityIds", entityIds);
+        AddStringParameter(parameters, "@Relation", relation, 64);
+        AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
+    }
+
     public async Task<bool> HasAnyDirectRelation(string entityType, string[] entityIds, string relation,
         string subjectId, SnapToken snapToken, CancellationToken cancellationToken)
     {
@@ -879,18 +1037,24 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.HasAnyDirectRelation);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddTvpParameter(command, "@EntityIds", entityIds);
-            AddStringParameter(command, "@Relation", relation, 64);
-            AddStringParameter(command, "@SubjectId", subjectId, 64);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+            PopulateHasAnyDirectRelationCommand(command.Parameters, entityType, entityIds, relation, subjectId, snapToken);
 
-            return (int)(await command.ExecuteScalarAsync(cancellationToken))! == 1;
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }
         finally
         {
             Semaphore.Release();
         }
+    }
+
+    private void PopulateHasAnyOfDirectRelationsCommand(SqlParameterCollection parameters, string entityType,
+        string entityId, string[] relationNames, string subjectId, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddStringParameter(parameters, "@EntityId", entityId, 64);
+        AddTvpParameter(parameters, "@Relations", relationNames);
+        AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
     }
 
     public async Task<HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames,
@@ -904,11 +1068,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.HasAnyOfDirectRelations);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddStringParameter(command, "@EntityId", entityId, 64);
-            AddTvpParameter(command, "@Relations", relationNames);
-            AddStringParameter(command, "@SubjectId", subjectId, 64);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+            PopulateHasAnyOfDirectRelationsCommand(command.Parameters, entityType, entityId, relationNames, subjectId, snapToken);
 
             var result = new HashSet<string>(relationNames.Length, StringComparer.Ordinal);
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -932,12 +1092,12 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.SelectRelationsWithEntityIds);
-            AddNullableStringParameter(command, "@SubjectType", subjectType, 256);
-            AddNullableStringParameter(command, "@EntityType", entityRelationFilter.EntityType, 256);
-            AddNullableStringParameter(command, "@Relation", entityRelationFilter.Relation, 64);
-            AddTvpParameter(command, "@EntityIds", entityIds);
-            AddNullableStringParameter(command, "@SubjectRelation", subjectRelation, 64);
-            AddFixedCharParameter(command, "@SnapToken", entityRelationFilter.SnapToken.Value, 26);
+            AddNullableStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+            AddNullableStringParameter(command.Parameters, "@EntityType", entityRelationFilter.EntityType, 256);
+            AddNullableStringParameter(command.Parameters, "@Relation", entityRelationFilter.Relation, 64);
+            AddTvpParameter(command.Parameters, "@EntityIds", entityIds);
+            AddNullableStringParameter(command.Parameters, "@SubjectRelation", subjectRelation, 64);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", entityRelationFilter.SnapToken.Value, 26);
 
             var pooled = PooledList<RelationTuple>.Rent();
             try
@@ -976,14 +1136,14 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     if (scope is { } s)
                     {
                         await using var command = CreateCommand(connection, _q.GetRelationsWithSingleSubjectScoped);
-                        AddStringParameter(command, "@EntityType", entityFilter.EntityType, 256);
-                        AddStringParameter(command, "@Relation", entityFilter.Relation, 64);
-                        AddStringParameter(command, "@SubjectType", subjectType, 256);
-                        AddStringParameter(command, "@SubjectId", subjectsIds[0], 64);
-                        AddFixedCharParameter(command, "@SnapToken", entityFilter.SnapToken.Value, 26);
-                        AddStringParameter(command, "@ScopeRelation", s.Relation, 64);
-                        AddStringParameter(command, "@ScopeSubjectType", s.SubjectType, 256);
-                        AddStringParameter(command, "@ScopeSubjectId", s.SubjectId, 64);
+                        AddStringParameter(command.Parameters, "@EntityType", entityFilter.EntityType, 256);
+                        AddStringParameter(command.Parameters, "@Relation", entityFilter.Relation, 64);
+                        AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                        AddStringParameter(command.Parameters, "@SubjectId", subjectsIds[0], 64);
+                        AddFixedCharParameter(command.Parameters, "@SnapToken", entityFilter.SnapToken.Value, 26);
+                        AddStringParameter(command.Parameters, "@ScopeRelation", s.Relation, 64);
+                        AddStringParameter(command.Parameters, "@ScopeSubjectType", s.SubjectType, 256);
+                        AddStringParameter(command.Parameters, "@ScopeSubjectId", s.SubjectId, 64);
 
                         await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                         while (await reader.ReadAsync(cancellationToken))
@@ -992,11 +1152,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     else
                     {
                         await using var command = CreateCommand(connection, _q.GetRelationsWithSingleSubjectSnap);
-                        AddStringParameter(command, "@EntityType", entityFilter.EntityType, 256);
-                        AddStringParameter(command, "@Relation", entityFilter.Relation, 64);
-                        AddStringParameter(command, "@SubjectType", subjectType, 256);
-                        AddStringParameter(command, "@SubjectId", subjectsIds[0], 64);
-                        AddFixedCharParameter(command, "@SnapToken", entityFilter.SnapToken.Value, 26);
+                        AddStringParameter(command.Parameters, "@EntityType", entityFilter.EntityType, 256);
+                        AddStringParameter(command.Parameters, "@Relation", entityFilter.Relation, 64);
+                        AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                        AddStringParameter(command.Parameters, "@SubjectId", subjectsIds[0], 64);
+                        AddFixedCharParameter(command.Parameters, "@SnapToken", entityFilter.SnapToken.Value, 26);
 
                         await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                         while (await reader.ReadAsync(cancellationToken))
@@ -1017,14 +1177,14 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 if (scope is { } ms)
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsWithMultiSubjectScoped);
-                    AddStringParameter(command, "@EntityType", entityFilter.EntityType, 256);
-                    AddStringParameter(command, "@Relation", entityFilter.Relation, 64);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddTvpParameter(command, "@SubjectIds", subjectsIds);
-                    AddFixedCharParameter(command, "@SnapToken", entityFilter.SnapToken.Value, 26);
-                    AddStringParameter(command, "@ScopeRelation", ms.Relation, 64);
-                    AddStringParameter(command, "@ScopeSubjectType", ms.SubjectType, 256);
-                    AddStringParameter(command, "@ScopeSubjectId", ms.SubjectId, 64);
+                    AddStringParameter(command.Parameters, "@EntityType", entityFilter.EntityType, 256);
+                    AddStringParameter(command.Parameters, "@Relation", entityFilter.Relation, 64);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddTvpParameter(command.Parameters, "@SubjectIds", subjectsIds);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", entityFilter.SnapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@ScopeRelation", ms.Relation, 64);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectType", ms.SubjectType, 256);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectId", ms.SubjectId, 64);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1033,11 +1193,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 else
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsWithMultiSubjectSnap);
-                    AddStringParameter(command, "@EntityType", entityFilter.EntityType, 256);
-                    AddStringParameter(command, "@Relation", entityFilter.Relation, 64);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddTvpParameter(command, "@SubjectIds", subjectsIds);
-                    AddFixedCharParameter(command, "@SnapToken", entityFilter.SnapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@EntityType", entityFilter.EntityType, 256);
+                    AddStringParameter(command.Parameters, "@Relation", entityFilter.Relation, 64);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddTvpParameter(command.Parameters, "@SubjectIds", subjectsIds);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", entityFilter.SnapToken.Value, 26);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1076,14 +1236,14 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     if (scope is { } s)
                     {
                         await using var command = CreateCommand(connection, _q.GetRelationsWithSingleSubjectMultiRelationScoped);
-                        AddStringParameter(command, "@EntityType", entityType, 256);
-                        AddTvpParameter(command, "@Relations", relationNames);
-                        AddStringParameter(command, "@SubjectType", subjectType, 256);
-                        AddStringParameter(command, "@SubjectId", subjectsIds[0], 64);
-                        AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
-                        AddStringParameter(command, "@ScopeRelation", s.Relation, 64);
-                        AddStringParameter(command, "@ScopeSubjectType", s.SubjectType, 256);
-                        AddStringParameter(command, "@ScopeSubjectId", s.SubjectId, 64);
+                        AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+                        AddTvpParameter(command.Parameters, "@Relations", relationNames);
+                        AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                        AddStringParameter(command.Parameters, "@SubjectId", subjectsIds[0], 64);
+                        AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
+                        AddStringParameter(command.Parameters, "@ScopeRelation", s.Relation, 64);
+                        AddStringParameter(command.Parameters, "@ScopeSubjectType", s.SubjectType, 256);
+                        AddStringParameter(command.Parameters, "@ScopeSubjectId", s.SubjectId, 64);
 
                         await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                         while (await reader.ReadAsync(cancellationToken))
@@ -1092,11 +1252,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                     else
                     {
                         await using var command = CreateCommand(connection, _q.GetRelationsWithSingleSubjectMultiRelationSnap);
-                        AddStringParameter(command, "@EntityType", entityType, 256);
-                        AddTvpParameter(command, "@Relations", relationNames);
-                        AddStringParameter(command, "@SubjectType", subjectType, 256);
-                        AddStringParameter(command, "@SubjectId", subjectsIds[0], 64);
-                        AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+                        AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+                        AddTvpParameter(command.Parameters, "@Relations", relationNames);
+                        AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                        AddStringParameter(command.Parameters, "@SubjectId", subjectsIds[0], 64);
+                        AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
 
                         await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                         while (await reader.ReadAsync(cancellationToken))
@@ -1117,14 +1277,14 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 if (scope is { } ms)
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsWithMultiSubjectMultiRelationScoped);
-                    AddStringParameter(command, "@EntityType", entityType, 256);
-                    AddTvpParameter(command, "@Relations", relationNames);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddTvpParameter(command, "@SubjectIds", subjectsIds);
-                    AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
-                    AddStringParameter(command, "@ScopeRelation", ms.Relation, 64);
-                    AddStringParameter(command, "@ScopeSubjectType", ms.SubjectType, 256);
-                    AddStringParameter(command, "@ScopeSubjectId", ms.SubjectId, 64);
+                    AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+                    AddTvpParameter(command.Parameters, "@Relations", relationNames);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddTvpParameter(command.Parameters, "@SubjectIds", subjectsIds);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@ScopeRelation", ms.Relation, 64);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectType", ms.SubjectType, 256);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectId", ms.SubjectId, 64);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1133,11 +1293,11 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 else
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsWithMultiSubjectMultiRelationSnap);
-                    AddStringParameter(command, "@EntityType", entityType, 256);
-                    AddTvpParameter(command, "@Relations", relationNames);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddTvpParameter(command, "@SubjectIds", subjectsIds);
-                    AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+                    AddTvpParameter(command.Parameters, "@Relations", relationNames);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddTvpParameter(command.Parameters, "@SubjectIds", subjectsIds);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1169,12 +1329,12 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.GetRelationsWithEntityIdsMultiRelationSnap);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddTvpParameter(command, "@Relations", relationNames);
-            AddStringParameter(command, "@SubjectType", subjectType, 256);
-            AddTvpParameter(command, "@EntityIds", entityIds);
-            AddNullableStringParameter(command, "@SubjectRelation", subjectRelation, 64);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+            AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+            AddTvpParameter(command.Parameters, "@Relations", relationNames);
+            AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+            AddTvpParameter(command.Parameters, "@EntityIds", entityIds);
+            AddNullableStringParameter(command.Parameters, "@SubjectRelation", subjectRelation, 64);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
 
             var pooled = PooledList<RelationTuple>.Rent();
             try
@@ -1213,16 +1373,16 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 if (scope is { } s)
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsJoinedScoped);
-                    AddStringParameter(command, "@EntityType", mainFilter.EntityType, 256);
-                    AddStringParameter(command, "@Relation", mainFilter.Relation, 64);
-                    AddStringParameter(command, "@SubEntityType", subEntityType, 256);
-                    AddStringParameter(command, "@SubRelation", subRelation, 64);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddStringParameter(command, "@SubjectId", subjectId, 64);
-                    AddFixedCharParameter(command, "@SnapToken", mainFilter.SnapToken.Value, 26);
-                    AddStringParameter(command, "@ScopeRelation", s.Relation, 64);
-                    AddStringParameter(command, "@ScopeSubjectType", s.SubjectType, 256);
-                    AddStringParameter(command, "@ScopeSubjectId", s.SubjectId, 64);
+                    AddStringParameter(command.Parameters, "@EntityType", mainFilter.EntityType, 256);
+                    AddStringParameter(command.Parameters, "@Relation", mainFilter.Relation, 64);
+                    AddStringParameter(command.Parameters, "@SubEntityType", subEntityType, 256);
+                    AddStringParameter(command.Parameters, "@SubRelation", subRelation, 64);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddStringParameter(command.Parameters, "@SubjectId", subjectId, 64);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", mainFilter.SnapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@ScopeRelation", s.Relation, 64);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectType", s.SubjectType, 256);
+                    AddStringParameter(command.Parameters, "@ScopeSubjectId", s.SubjectId, 64);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1231,13 +1391,13 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                 else
                 {
                     await using var command = CreateCommand(connection, _q.GetRelationsJoined);
-                    AddStringParameter(command, "@EntityType", mainFilter.EntityType, 256);
-                    AddStringParameter(command, "@Relation", mainFilter.Relation, 64);
-                    AddStringParameter(command, "@SubEntityType", subEntityType, 256);
-                    AddStringParameter(command, "@SubRelation", subRelation, 64);
-                    AddStringParameter(command, "@SubjectType", subjectType, 256);
-                    AddStringParameter(command, "@SubjectId", subjectId, 64);
-                    AddFixedCharParameter(command, "@SnapToken", mainFilter.SnapToken.Value, 26);
+                    AddStringParameter(command.Parameters, "@EntityType", mainFilter.EntityType, 256);
+                    AddStringParameter(command.Parameters, "@Relation", mainFilter.Relation, 64);
+                    AddStringParameter(command.Parameters, "@SubEntityType", subEntityType, 256);
+                    AddStringParameter(command.Parameters, "@SubRelation", subRelation, 64);
+                    AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+                    AddStringParameter(command.Parameters, "@SubjectId", subjectId, 64);
+                    AddFixedCharParameter(command.Parameters, "@SnapToken", mainFilter.SnapToken.Value, 26);
 
                     await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                     while (await reader.ReadAsync(cancellationToken))
@@ -1272,12 +1432,12 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             try
             {
                 await using var command = CreateCommand(connection, _q.GetRelationsJoinedByEntityIds);
-                AddStringParameter(command, "@EntityType", mainFilter.EntityType, 256);
-                AddStringParameter(command, "@Relation", mainFilter.Relation, 64);
-                AddTvpParameter(command, "@EntityIds", entityIds);
-                AddStringParameter(command, "@SubEntityType", subEntityType, 256);
-                AddStringParameter(command, "@SubRelation", subRelation, 64);
-                AddFixedCharParameter(command, "@SnapToken", mainFilter.SnapToken.Value, 26);
+                AddStringParameter(command.Parameters, "@EntityType", mainFilter.EntityType, 256);
+                AddStringParameter(command.Parameters, "@Relation", mainFilter.Relation, 64);
+                AddTvpParameter(command.Parameters, "@EntityIds", entityIds);
+                AddStringParameter(command.Parameters, "@SubEntityType", subEntityType, 256);
+                AddStringParameter(command.Parameters, "@SubRelation", subRelation, 64);
+                AddFixedCharParameter(command.Parameters, "@SnapToken", mainFilter.SnapToken.Value, 26);
 
                 await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
@@ -1296,6 +1456,19 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         }
     }
 
+    private static void PopulateHasTupleToUserSetRelationCommand(SqlParameterCollection parameters,
+        string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation,
+        string subjectType, string subjectId, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddStringParameter(parameters, "@EntityId", entityId, 64);
+        AddStringParameter(parameters, "@TupleSetRelation", tupleSetRelation, 64);
+        AddStringParameter(parameters, "@ComputedRelation", computedRelation, 64);
+        AddStringParameter(parameters, "@SubjectType", subjectType, 256);
+        AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
+    }
+
     public async Task<bool> HasTupleToUserSetRelation(
         string entityType, string entityId, string tupleSetRelation,
         string subEntityType, string computedRelation,
@@ -1309,16 +1482,10 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.HasTupleToUserSetRelation);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddStringParameter(command, "@EntityId", entityId, 64);
-            AddStringParameter(command, "@TupleSetRelation", tupleSetRelation, 64);
-            AddStringParameter(command, "@ComputedRelation", computedRelation, 64);
-            AddStringParameter(command, "@SubjectType", subjectType, 256);
-            AddStringParameter(command, "@SubjectId", subjectId, 64);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
+            PopulateHasTupleToUserSetRelationCommand(command.Parameters, entityType, entityId, tupleSetRelation,
+                subEntityType, computedRelation, subjectType, subjectId, snapToken);
 
-            var result = (int)(await command.ExecuteScalarAsync(cancellationToken))!;
-            return result == 1;
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }
         finally
         {
@@ -1336,9 +1503,9 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.GetEntityIdsExcluding);
-            AddStringParameter(command, "@EntityType", entityType, 256);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
-            AddTvpParameter(command, "@ExcludeIds", excludeIds);
+            AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
+            AddTvpParameter(command.Parameters, "@ExcludeIds", excludeIds);
 
             var result = new List<string>();
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
@@ -1362,9 +1529,9 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await connection.OpenAsync(cancellationToken);
 
             await using var command = CreateCommand(connection, _q.GetSubjectIdsExcluding);
-            AddStringParameter(command, "@SubjectType", subjectType, 256);
-            AddFixedCharParameter(command, "@SnapToken", snapToken.Value, 26);
-            AddTvpParameter(command, "@ExcludeIds", excludeIds);
+            AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
+            AddTvpParameter(command.Parameters, "@ExcludeIds", excludeIds);
 
             var result = new List<string>();
             await using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);

--- a/src/Valtuutus.Data.SqlServer/Utils/TvpHelper.cs
+++ b/src/Valtuutus.Data.SqlServer/Utils/TvpHelper.cs
@@ -20,9 +20,9 @@ internal static class TvpHelper
     {
         private static readonly SqlMetaData[] _meta = [new("id", SqlDbType.NVarChar, 256)];
 
-        public void AddParameter(SqlCommand command, string name)
+        public void AddParameter(SqlParameterCollection parameters, string name)
         {
-            var param = command.Parameters.Add(name, SqlDbType.Structured);
+            var param = parameters.Add(name, SqlDbType.Structured);
             param.TypeName = typeName;
             param.Value = this;
         }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
@@ -8,9 +8,19 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalBatchOps, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public void AddGetIndirectRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddGetRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddHasAnyDirectRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public System.Data.Common.DbBatch CreateBatch() { }
+        public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
@@ -8,9 +8,19 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalBatchOps, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public void AddGetIndirectRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddGetRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddHasAnyDirectRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public System.Data.Common.DbBatch CreateBatch() { }
+        public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
@@ -7,9 +7,19 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalBatchOps, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public void AddGetIndirectRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddGetRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddHasAnyDirectRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public System.Data.Common.DbBatch CreateBatch() { }
+        public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
@@ -7,9 +7,19 @@ namespace Valtuutus.Data.SqlServer
     {
         public static Valtuutus.Data.IValtuutusDataBuilder AddSqlServer(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.SqlServer.ValtuutusSqlServerOptions? options = null) { }
     }
-    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalCheckOps
+    public class SqlServerDataReaderProvider : Valtuutus.Data.RateLimiterExecuter, Valtuutus.Core.Data.IDataReaderProvider, Valtuutus.Data.Db.IRelationalBatchOps, Valtuutus.Data.Db.IRelationalCheckOps
     {
         public SqlServerDataReaderProvider(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public void AddGetIndirectRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddGetRelationsToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter) { }
+        public void AddHasAnyDirectRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string[] entityIds, string relation, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public System.Data.Common.DbBatch CreateBatch() { }
+        public System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<Valtuutus.Core.AttributeTuple?> GetAttribute(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Valtuutus.Core.AttributeTuple>> GetAttributes(Valtuutus.Core.Data.EntityAttributeFilter filter, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/tests/Valtuutus.Data.SqlServer.Tests/BatchedExecutorRoundTripSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/BatchedExecutorRoundTripSpecs.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+/// <summary>
+/// SqlServer counterpart of Valtuutus.Data.Postgres.Tests.BatchedExecutorRoundTripSpecs — the one
+/// claim only a real SqlServer can prove: BatchedPhysicalExecutor genuinely collapses a wave's
+/// several batchable ops into fewer physical round trips than running them individually, and
+/// produces the identical answer either way. Same schema/scenario/technique as the Postgres
+/// version — see that file's doc comment for full rationale (three different op kinds in one
+/// Union, so neither GroupSiblingDirectRelations nor GroupSiblingAttributeTruth fuses it away at
+/// plan-compile time; toggling IRelationalBatchOps presence via a counting decorator instead of
+/// touching DefaultPhysicalExecutor directly, since that type is internal to Valtuutus.Core with
+/// no InternalsVisibleTo grant to this test assembly).
+/// </summary>
+[Collection("SqlServerSpec")]
+public sealed class BatchedExecutorRoundTripSpecs : IAsyncLifetime
+{
+    private const string Schema = """
+        entity user {}
+        entity team {
+            relation member @user;
+        }
+        entity doc {
+            relation owner @user;
+            relation team_link @team;
+            attribute public bool;
+            permission view := owner or team_link.member or public;
+        }
+        """;
+
+    public BatchedExecutorRoundTripSpecs(SqlServerFixture fixture, Xunit.Abstractions.ITestOutputHelper output)
+    {
+        Fixture = fixture;
+        Output = output;
+    }
+
+    private SqlServerFixture Fixture { get; }
+    private Xunit.Abstractions.ITestOutputHelper Output { get; }
+
+    public Task InitializeAsync() => Fixture.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task BatchedExecutor_UsesFewerRoundTrips_ThanIndividualExecution_ForSameWave()
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+
+        SnapToken snapToken;
+        {
+            var seedServices = new ServiceCollection().AddValtuutusCore(Schema);
+            seedServices.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+            await using var seedProvider = seedServices.BuildServiceProvider();
+            await using var seedScope = seedProvider.CreateAsyncScope();
+            var writer = seedScope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(
+                [new RelationTuple("doc", "d1", "owner", "user", "alice")],
+                [],
+                default);
+        }
+
+        var request = new CheckRequest("doc", "d1", "view", "user", "alice", snapToken: snapToken);
+
+        var (batchedResult, batchedRoundTrips) = await RunCheck(dbFactory, request, batching: true);
+        var (individualResult, individualRoundTrips) = await RunCheck(dbFactory, request, batching: false);
+
+        Output.WriteLine($"batched={batchedRoundTrips}, individual={individualRoundTrips}");
+
+        batchedResult.Should().BeTrue();
+        individualResult.Should().Be(batchedResult);
+
+        batchedRoundTrips.Should().BeLessThan(individualRoundTrips,
+            $"batched={batchedRoundTrips}, individual={individualRoundTrips}");
+    }
+
+    private static async Task<(bool Result, int RoundTrips)> RunCheck(DbConnectionFactory dbFactory, CheckRequest request, bool batching)
+    {
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+        services.Replace(ServiceDescriptor.Scoped<IDataReaderProvider>(sp =>
+        {
+            var real = ActivatorUtilities.CreateInstance<SqlServerDataReaderProvider>(sp);
+            return batching
+                ? new BatchingCountingReader(real)
+                : (IDataReaderProvider)new NonBatchingCountingReader(real);
+        }));
+
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+        var result = await engine.Check(request, default);
+        var counting = (RoundTripCountingReaderBase)scope.ServiceProvider.GetRequiredService<IDataReaderProvider>();
+        return (result, counting.RoundTripCount);
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
@@ -1,0 +1,244 @@
+using System.Data.Common;
+using Valtuutus.Core;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.LookupEntity;
+using Valtuutus.Core.Pools;
+using Valtuutus.Data.Db;
+using Valtuutus.Data.SqlServer;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+/// <summary>
+/// Wraps a real <see cref="SqlServerDataReaderProvider"/> and counts physical round trips for the
+/// round-trip-reduction proof, mirroring <c>Valtuutus.Data.Postgres.Tests.RoundTripCountingReaderProvider</c>
+/// (same technique, same reasoning — see that file's doc comment for the full rationale).
+/// </summary>
+internal abstract class RoundTripCountingReaderBase(SqlServerDataReaderProvider inner) : IDataReaderProvider, IRelationalCheckOps
+{
+    private int _roundTrips;
+
+    public int RoundTripCount => Volatile.Read(ref _roundTrips);
+
+    protected SqlServerDataReaderProvider Inner { get; } = inner;
+
+    protected void CountRoundTrip() => Interlocked.Increment(ref _roundTrips);
+
+    public async Task<SnapToken?> GetLatestSnapToken(CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetLatestSnapToken(cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelations(tupleFilter, cancellationToken);
+    }
+
+    public async Task<bool> HasDirectRelation(RelationTupleFilter tupleFilter, string subjectId, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasDirectRelation(tupleFilter, subjectId, cancellationToken);
+    }
+
+    public async Task<bool> HasAnyDirectRelation(string entityType, string[] entityIds, string relation, string subjectId,
+        SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasAnyDirectRelation(entityType, entityIds, relation, subjectId, snapToken, cancellationToken);
+    }
+
+    public async Task<HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames,
+        string subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasAnyOfDirectRelations(entityType, entityId, relationNames, subjectId, snapToken, cancellationToken);
+    }
+
+    public async Task<HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames,
+        SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasAnyOfAttributes(entityType, entityId, attributeNames, snapToken, cancellationToken);
+    }
+
+    public async Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken,
+        CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasTupleToUserSetRelation(entityType, entityId, tupleSetRelation, subEntityType,
+            computedRelation, subjectType, subjectId, snapToken, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetIndirectRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetIndirectRelations(tupleFilter, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsWithEntityIds(EntityRelationFilter entityRelationFilter,
+        string subjectType, IEnumerable<string> entityIds, string? subjectRelation, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsWithEntityIds(entityRelationFilter, subjectType, entityIds, subjectRelation, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsWithSubjectsIds(EntityRelationFilter entityFilter,
+        string[] subjectsIds, string subjectType, EntityScope? scope, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsWithSubjectsIds(entityFilter, subjectsIds, subjectType, scope, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsWithSubjectsIdsMultiRelation(string entityType,
+        string[] relationNames, string[] subjectsIds, string subjectType, SnapToken snapToken, EntityScope? scope,
+        CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsWithSubjectsIdsMultiRelation(entityType, relationNames, subjectsIds, subjectType,
+            snapToken, scope, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsWithEntityIdsMultiRelation(string entityType,
+        string[] relationNames, string subjectType, IEnumerable<string> entityIds, string? subjectRelation,
+        SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsWithEntityIdsMultiRelation(entityType, relationNames, subjectType, entityIds,
+            subjectRelation, snapToken, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsJoined(EntityRelationFilter mainFilter, string subEntityType,
+        string subRelation, string subjectType, string subjectId, EntityScope? scope, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsJoined(mainFilter, subEntityType, subRelation, subjectType, subjectId, scope, cancellationToken);
+    }
+
+    public async Task<PooledList<RelationTuple>> GetRelationsJoinedByEntityIds(EntityRelationFilter mainFilter,
+        IEnumerable<string> entityIds, string subEntityType, string subRelation, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetRelationsJoinedByEntityIds(mainFilter, entityIds, subEntityType, subRelation, cancellationToken);
+    }
+
+    public async Task<AttributeTuple?> GetAttribute(EntityAttributeFilter filter, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttribute(filter, cancellationToken);
+    }
+
+    public async Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, SnapToken snapToken,
+        CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.HasTrueBoolAttribute(entityType, entityId, attribute, snapToken, cancellationToken);
+    }
+
+    public async Task<List<AttributeTuple>> GetAttributes(EntityAttributeFilter filter, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttributes(filter, cancellationToken);
+    }
+
+    public async Task<Dictionary<(string AttributeName, string EntityId), AttributeTuple>> GetAttributes(
+        EntityAttributesFilter filter, EntityScope? scope, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttributes(filter, scope, cancellationToken);
+    }
+
+    public async Task<List<AttributeTuple>> GetAttributesWithEntityIds(AttributeFilter filter, IEnumerable<string> entitiesIds,
+        CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttributesWithEntityIds(filter, entitiesIds, cancellationToken);
+    }
+
+    public async Task<Dictionary<(string AttributeName, string EntityId), AttributeTuple>> GetAttributesWithEntityIds(
+        EntityAttributesFilter filter, IEnumerable<string> entitiesIds, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttributesWithEntityIds(filter, entitiesIds, cancellationToken);
+    }
+
+    public async Task<PooledList<AttributeTuple>> GetAttributesSingleEntity(EntityAttributesFilter filter, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetAttributesSingleEntity(filter, cancellationToken);
+    }
+
+    public async Task<List<string>> GetEntityIdsExcluding(string entityType, IReadOnlyCollection<string> excludeIds,
+        SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetEntityIdsExcluding(entityType, excludeIds, snapToken, cancellationToken);
+    }
+
+    public async Task<List<string>> GetSubjectIdsExcluding(string subjectType, IReadOnlyCollection<string> excludeIds,
+        SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        CountRoundTrip();
+        return await Inner.GetSubjectIdsExcluding(subjectType, excludeIds, snapToken, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Implements <see cref="IRelationalBatchOps"/> so <c>BatchedPhysicalExecutor</c>'s `Reader is
+/// IRelationalBatchOps` check succeeds and a wave's batchable ops are packed into one
+/// ExecuteBatchAsync round trip — the "batched" side of the comparison.
+/// </summary>
+internal sealed class BatchingCountingReader(SqlServerDataReaderProvider inner)
+    : RoundTripCountingReaderBase(inner), IRelationalBatchOps
+{
+    // CreateBatch/AddXToBatch never touch the network — not counted, same reasoning as the
+    // Postgres version.
+    public DbBatch CreateBatch() => Inner.CreateBatch();
+
+    public void AddHasAnyOfDirectRelationsToBatch(DbBatch batch, string entityType, string entityId,
+        string[] relationNames, string subjectId, SnapToken snapToken)
+        => Inner.AddHasAnyOfDirectRelationsToBatch(batch, entityType, entityId, relationNames, subjectId, snapToken);
+
+    public void AddHasAnyOfAttributesToBatch(DbBatch batch, string entityType, string entityId,
+        string[] attributeNames, SnapToken snapToken)
+        => Inner.AddHasAnyOfAttributesToBatch(batch, entityType, entityId, attributeNames, snapToken);
+
+    public void AddHasDirectRelationToBatch(DbBatch batch, RelationTupleFilter tupleFilter, string subjectId)
+        => Inner.AddHasDirectRelationToBatch(batch, tupleFilter, subjectId);
+
+    public void AddHasTrueBoolAttributeToBatch(DbBatch batch, string entityType, string entityId, string attribute,
+        SnapToken snapToken)
+        => Inner.AddHasTrueBoolAttributeToBatch(batch, entityType, entityId, attribute, snapToken);
+
+    public void AddHasTupleToUserSetRelationToBatch(DbBatch batch, string entityType, string entityId,
+        string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId,
+        SnapToken snapToken)
+        => Inner.AddHasTupleToUserSetRelationToBatch(batch, entityType, entityId, tupleSetRelation, subEntityType,
+            computedRelation, subjectType, subjectId, snapToken);
+
+    public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,
+        string subjectId, SnapToken snapToken)
+        => Inner.AddHasAnyDirectRelationToBatch(batch, entityType, entityIds, relation, subjectId, snapToken);
+
+    public void AddGetRelationsToBatch(DbBatch batch, RelationTupleFilter tupleFilter)
+        => Inner.AddGetRelationsToBatch(batch, tupleFilter);
+
+    public void AddGetIndirectRelationsToBatch(DbBatch batch, RelationTupleFilter tupleFilter)
+        => Inner.AddGetIndirectRelationsToBatch(batch, tupleFilter);
+
+    public async Task<DbDataReader> ExecuteBatchAsync(DbBatch batch, CancellationToken cancellationToken)
+    {
+        // One physical round trip regardless of how many commands `batch` carries.
+        CountRoundTrip();
+        return await Inner.ExecuteBatchAsync(batch, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Deliberately does NOT implement <see cref="IRelationalBatchOps"/>: BatchedPhysicalExecutor's
+/// `Reader is not IRelationalBatchOps` check fails for this type, so it falls back to
+/// SubmitAllIndividually — the "individual round trip per op" side of the comparison.
+/// </summary>
+internal sealed class NonBatchingCountingReader(SqlServerDataReaderProvider inner)
+    : RoundTripCountingReaderBase(inner);


### PR DESCRIPTION
## Summary
- Ports `BatchedPhysicalExecutor`'s wave-batching (shipped Postgres-only in #265) to SqlServer: `SqlServerDataReaderProvider` now implements `IRelationalBatchOps`, and `AddSqlServer` wires `BatchedPhysicalExecutor` in the same way `AddPostgres` does.
- Two SqlServer-specific fixes beyond a straight port:
  - The four boolean-scalar queries (`HasDirectRelation`/`HasTrueBoolAttribute`/`HasAnyDirectRelation`/`HasTupleToUserSetRelation`) moved from T-SQL's implicit `int` (`CASE...THEN 1 ELSE 0 END`) to explicit `CAST(...AS BIT)`, since the shared `BatchedPhysicalExecutor.ReadResult` reads these via `reader.GetBoolean(0)`, which throws against an `int` column.
  - SqlServer has no `NpgsqlDataSource`-equivalent connection pool, so unlike Postgres's one-line `CreateBatch()`, SqlServer's `CreateBatch()` only constructs an unopened `SqlConnection`+`SqlBatch` (the interface member is synchronous, no `CancellationToken`) and defers `OpenAsync` + `CommandBehavior.CloseConnection` to the async `ExecuteBatchAsync`.
- Retyped the file's parameter-adding helpers from `SqlCommand` to `SqlParameterCollection` and extracted `Populate<Name>Command` helpers for the 8 batchable ops, so batch and non-batch paths share identical SQL/parameter logic (mirrors the equivalent Postgres refactor).
- Added `InternalsVisibleTo` grants for `Valtuutus.Data.SqlServer` on `Valtuutus.Core` and `Valtuutus.Data.Db` (`BatchedPhysicalExecutor`/`IPhysicalExecutor` are internal), matching the existing Postgres grants.
- Round-trip proof (new `BatchedExecutorRoundTripSpecs`): a 3-op-kind Union wave costs 1 round trip batched vs 3 individual, real SqlServer.

## Benchmarks (SqlServer `Check_*`, short job, local Testcontainers, origin/dev baseline vs this branch)
| Category | Latency Δ | Alloc Δ |
|---|---|---|
| Check_Simple | -13.1% | -0.1% |
| Check_UnionTtuDirect | -13.0% | -0.2% |
| Check_Complex | -8.6% | -0.1% |
| Check_Prune | +4.9% | -0.1% |
| Check_UsersetMiss | +3.6% | +1.2% |
| Check_Diamond | -56.7%* | -1.6% |

\* Check_Diamond's baseline had high variance (StdDev ~50µs on a 574µs mean, 3-iteration ShortRun) — not trustworthy as a real number, flagged rather than claimed.

Same qualitative shape as the Postgres version of this comparison: single-op-wave scenarios win, multi-op-wave scenarios flat-to-noisy locally (near-zero Testcontainers network RTT hides round-trip savings) — expected to favor batching more clearly once real per-round-trip latency is ~1ms+.

## Test plan
- [x] `dotnet build Valtuutus.slnx` — 0 errors, whole solution
- [x] `dotnet test Valtuutus.slnx -f net10.0` — InMemory 403, Postgres 314, SqlServer 442, Data.Db.Tests 21, Api.Tests 6, Lang.Tests 65, all green
- [x] New `BatchedExecutorRoundTripSpecs` proves fewer round trips against real SqlServer (Testcontainers)
- [x] Final full-diff code review (connection lifecycle, BIT fix, helper reuse, InternalsVisibleTo scoping) — no issues found