### PR TITLE
feat: CheckV2 R3 — plan-time TTU fast-path eligibility

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -499,9 +499,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     {
         ref var frame = ref _frames[idx];
 
-        // R3: eligibility (CheckEngine.cs:742-753's four schema-static conditions) is now
-        // precomputed by PlanCompiler.PruneAndFold. frame.Depth > 0 stays a runtime check —
-        // CheckRequest.Depth is a per-request recursion budget, not schema-derivable.
+        // Schema-static eligibility is precomputed by PlanCompiler.PruneAndFold. frame.Depth > 0
+        // stays a runtime check — CheckRequest.Depth is a per-request recursion budget, not
+        // schema-derivable.
         if (t.FastPathSubEntityType is not null && frame.Depth > 0)
         {
             frame.State = 1;

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -498,31 +498,21 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     private void StepTupleToUserSet(int idx, TupleToUserSetNode t)
     {
         ref var frame = ref _frames[idx];
-        var tuplesetRel = schema.GetRelation(frame.EntityType, t.TuplesetRelation);
 
-        // Fast path — CheckEngine.cs:742-764, condition for condition.
-        if (tuplesetRel.Entities.Count == 1
-            && tuplesetRel.Entities[0].Relation is null
-            && frame.Depth > 0
-            && !string.IsNullOrEmpty(_ctx.SubjectType))
+        // R3: eligibility (CheckEngine.cs:742-753's four schema-static conditions) is now
+        // precomputed by PlanCompiler.PruneAndFold. frame.Depth > 0 stays a runtime check —
+        // CheckRequest.Depth is a per-request recursion budget, not schema-derivable.
+        if (t.FastPathSubEntityType is not null && frame.Depth > 0)
         {
-            var subEntityType = tuplesetRel.Entities[0].Type;
-            if (schema.GetRelationType(subEntityType, t.ComputedRelation) == RelationType.DirectRelation)
+            frame.State = 1;
+            SubmitOp(new PendingOp
             {
-                var computedRel = schema.GetRelation(subEntityType, t.ComputedRelation);
-                if (!computedRel.HasSubRelationPaths && computedRel.EntityTypes.Contains(_ctx.SubjectType))
-                {
-                    frame.State = 1;
-                    SubmitOp(new PendingOp
-                    {
-                        Token = idx, Kind = OpKind.TtuFastPath,
-                        EntityType = frame.EntityType, EntityId = frame.EntityId,
-                        Relation = t.TuplesetRelation, SubEntityType = subEntityType,
-                        ComputedRelation = t.ComputedRelation
-                    });
-                    return;
-                }
-            }
+                Token = idx, Kind = OpKind.TtuFastPath,
+                EntityType = frame.EntityType, EntityId = frame.EntityId,
+                Relation = t.TuplesetRelation, SubEntityType = t.FastPathSubEntityType,
+                ComputedRelation = t.ComputedRelation
+            });
+            return;
         }
 
         frame.State = 2;

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
@@ -113,12 +113,12 @@ internal static class PlanCompiler
         }
     }
 
-    // R3: StepTupleToUserSet's runtime fast-path guard (CheckPlanExecutor.cs:504-513, mirroring
-    // CheckEngine.cs:742-753) is schema-static given (entityType, subjectType) apart from the
-    // per-request recursion budget (frame.Depth > 0, which stays a runtime check — see the R3
-    // plan's context notes for why). Decide the schema-static part once here instead of
-    // re-deriving it on every request. Also folds statically-dead TTU branches to ConstNode.False,
-    // the TTU analogue of the PlanRefNode prune case above.
+    // The TTU fast-path guard is schema-static given (entityType, subjectType) apart from the
+    // per-request recursion budget (frame.Depth > 0 in the executor, which stays a runtime
+    // check — CheckRequest.Depth is caller-supplied and outside the plan key, so it can't be
+    // decided here). Deciding the schema-static part once here avoids re-deriving it on every
+    // request. Also folds statically-dead TTU branches to ConstNode.False, the TTU analogue of
+    // the PlanRefNode prune case above.
     private static PlanNode PruneTupleToUserSet(TupleToUserSetNode t, Schema schema, string entityType,
         string? subjectType)
     {

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
@@ -95,6 +95,9 @@ internal static class PlanCompiler
                     && !schema.CanSubjectTypeReach(entityType, r.Permission, subjectType):
                 return ConstNode.False;
 
+            case TupleToUserSetNode t:
+                return PruneTupleToUserSet(t, schema, entityType, subjectType);
+
             case NegateNode n:
                 var inner = PruneAndFold(n.Child, schema, entityType, subjectType);
                 return inner is ConstNode c ? (c.Value ? ConstNode.False : ConstNode.True) : new NegateNode(inner);
@@ -108,6 +111,40 @@ internal static class PlanCompiler
             default:
                 return node;
         }
+    }
+
+    // R3: StepTupleToUserSet's runtime fast-path guard (CheckPlanExecutor.cs:504-513, mirroring
+    // CheckEngine.cs:742-753) is schema-static given (entityType, subjectType) apart from the
+    // per-request recursion budget (frame.Depth > 0, which stays a runtime check — see the R3
+    // plan's context notes for why). Decide the schema-static part once here instead of
+    // re-deriving it on every request. Also folds statically-dead TTU branches to ConstNode.False,
+    // the TTU analogue of the PlanRefNode prune case above.
+    private static PlanNode PruneTupleToUserSet(TupleToUserSetNode t, Schema schema, string entityType,
+        string? subjectType)
+    {
+        if (subjectType is null) return t; // fast path needs a known subjectType; nothing to decide yet
+
+        var tuplesetRel = schema.GetRelation(entityType, t.TuplesetRelation);
+
+        var reachable = false;
+        foreach (var e in tuplesetRel.Entities)
+        {
+            if (schema.CanSubjectTypeReach(e.Type, t.ComputedRelation, subjectType)) { reachable = true; break; }
+        }
+        if (!reachable) return ConstNode.False;
+
+        if (tuplesetRel.Entities.Count == 1 && tuplesetRel.Entities[0].Relation is null)
+        {
+            var subEntityType = tuplesetRel.Entities[0].Type;
+            if (schema.GetRelationType(subEntityType, t.ComputedRelation) == RelationType.DirectRelation)
+            {
+                var computedRel = schema.GetRelation(subEntityType, t.ComputedRelation);
+                if (!computedRel.HasSubRelationPaths && computedRel.EntityTypes.Contains(subjectType))
+                    return t with { FastPathSubEntityType = subEntityType };
+            }
+        }
+
+        return t;
     }
 
     private static PlanNode FoldChildren(ImmutableArray<PlanNode> children, Schema schema,

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
@@ -31,7 +31,7 @@ public sealed record AttributeTruthNode(string Attribute) : PlanNode;
 // In-tree leaves.
 public sealed record AttributeExprNode(PermissionNodeLeafExp Expr) : PlanNode;
 /// <summary>
-/// <paramref name="FastPathSubEntityType"/> is non-null when R3 plan-time analysis proved the
+/// <paramref name="FastPathSubEntityType"/> is non-null when plan-time analysis proved the
 /// runtime fast-path guard (single non-userset tupleset target, computed relation a direct
 /// relation with no sub-relation-paths, admits the plan key's subjectType) holds for this node
 /// — set by <see cref="PlanCompiler"/>'s PruneAndFold pass, never by CompileTree. Null means

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
@@ -30,7 +30,15 @@ public sealed record AttributeTruthNode(string Attribute) : PlanNode;
 
 // In-tree leaves.
 public sealed record AttributeExprNode(PermissionNodeLeafExp Expr) : PlanNode;
-public sealed record TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) : PlanNode;
+/// <summary>
+/// <paramref name="FastPathSubEntityType"/> is non-null when R3 plan-time analysis proved the
+/// runtime fast-path guard (single non-userset tupleset target, computed relation a direct
+/// relation with no sub-relation-paths, admits the plan key's subjectType) holds for this node
+/// — set by <see cref="PlanCompiler"/>'s PruneAndFold pass, never by CompileTree. Null means
+/// either the guard doesn't hold, or subjectType was unknown at compile time.
+/// </summary>
+public sealed record TupleToUserSetNode(
+    string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) : PlanNode;
 
 /// <summary>
 /// Re-entry into the same entity's compiled plan for the named permission, relation, or

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -340,8 +340,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -340,8 +340,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -340,8 +340,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -340,8 +340,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -339,8 +339,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -339,8 +339,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {
-        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation) { }
+        public TupleToUserSetNode(string TuplesetRelation, string ComputedRelation, string? FastPathSubEntityType = null) { }
         public string ComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public string TuplesetRelation { get; init; }
     }
     public sealed class UnionNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.UnionNode>

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
@@ -91,11 +91,117 @@ public class PlanCompilerSpecs
     }
 
     [Fact]
-    public void Ttu_leaf_compiles_to_TupleToUserSetNode()
+    public void Ttu_leaf_meeting_all_fast_path_conditions_is_annotated_with_FastPathSubEntityType()
     {
         var plan = PlanCompiler.Compile(Parse(BasicSchema), "folder", "read", "user");
         var union = plan.Root.Should().BeOfType<UnionNode>().Subject;
+        union.Children[1].Should().Be(
+            new TupleToUserSetNode("parent", "admin", FastPathSubEntityType: "organization"));
+    }
+
+    [Fact]
+    public void Ttu_leaf_with_null_subjectType_is_never_annotated()
+    {
+        var plan = PlanCompiler.Compile(Parse(BasicSchema), "folder", "read", null);
+        var union = plan.Root.Should().BeOfType<UnionNode>().Subject;
         union.Children[1].Should().Be(new TupleToUserSetNode("parent", "admin"));
+    }
+
+    [Fact]
+    public void Ttu_leaf_with_multiple_tupleset_entities_is_not_fast_path_eligible()
+    {
+        // The schema DSL requires a relation's fully-resolved final entity references to be
+        // consistent, so two *unrelated* direct entity types on one relation can't parse. To get
+        // TuplesetRelation.Entities.Count > 1 while satisfying that, one entry is direct
+        // (organization) and the other is a userset (group#member) that itself resolves down to
+        // organization — still two Entities, still not fast-path eligible.
+        const string s = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity group {
+                relation member @organization;
+            }
+            entity folder {
+                relation parent @organization @group#member;
+                permission read := parent.admin;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "read", "user");
+        plan.Root.Should().Be(new TupleToUserSetNode("parent", "admin"));
+    }
+
+    [Fact]
+    public void Ttu_leaf_with_userset_typed_tupleset_target_is_not_fast_path_eligible()
+    {
+        // The schema parser resolves a TTU's computed relation against the tupleset relation's
+        // fully-recursed final entity, which always bottoms out at a non-userset reference — so
+        // `admin` must exist there. A self-referencing `viewers @organization` keeps that bottom
+        // entity at organization (which has `admin`), while folder.parent's own (single) Entities
+        // entry is still userset-typed (Relation "viewers" is non-null), which is the condition
+        // under test.
+        const string s = """
+            entity user {}
+            entity organization {
+                relation viewers @organization;
+                relation admin @user;
+            }
+            entity folder {
+                relation parent @organization#viewers;
+                permission read := parent.admin;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "read", "user");
+        plan.Root.Should().Be(new TupleToUserSetNode("parent", "admin"));
+    }
+
+    [Fact]
+    public void Ttu_leaf_whose_computed_relation_has_sub_relation_paths_is_not_fast_path_eligible()
+    {
+        const string s = """
+            entity user {}
+            entity group {
+                relation member @user;
+            }
+            entity organization {
+                relation admin @user @group#member;
+            }
+            entity folder {
+                relation parent @organization;
+                permission read := parent.admin;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "read", "user");
+        plan.Root.Should().Be(new TupleToUserSetNode("parent", "admin"));
+    }
+
+    [Fact]
+    public void Ttu_leaf_unreachable_for_subjectType_folds_to_ConstFalse()
+    {
+        // The TTU branch must be a non-root Union child, not the whole permission: a bare
+        // `permission read := parent.admin;` root gets short-circuited to ConstNode.False by
+        // Compile's pre-existing top-level reachability guard (PlanCompiler.cs:10-12) before
+        // PruneAndFold/PruneTupleToUserSet ever run, which would test that guard instead of
+        // PruneTupleToUserSet's own `if (!reachable) return ConstNode.False;` fold. Keeping
+        // "owner" reachable for service_account keeps the top-level permission reachable, so
+        // Compile descends into PruneAndFold and PruneTupleToUserSet independently folds the
+        // dead "parent.admin" branch (organization.admin only admits user).
+        const string s = """
+            entity user {}
+            entity service_account {}
+            entity organization {
+                relation admin @user;
+                relation bot @service_account;
+            }
+            entity folder {
+                relation owner @service_account;
+                relation parent @organization;
+                permission read := owner or parent.admin;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "read", "service_account");
+        plan.Root.Should().Be(new PlanRefNode("owner"));
     }
 
     private const string PruneSchema = """


### PR DESCRIPTION
## Summary
- Move `TupleToUserSetNode`'s runtime fast-path guard (single non-userset tupleset target, computed relation a direct relation with no sub-relation-paths, subjectType admitted) from a per-request re-derivation in `CheckPlanExecutor.StepTupleToUserSet` to a one-time decision in `PlanCompiler.PruneAndFold`, recorded as a new `FastPathSubEntityType` field. `frame.Depth > 0` stays the one runtime check, since `CheckRequest.Depth` is a per-request recursion budget, not schema-derivable.
- Also folds TTU branches that can never be satisfied by the plan's subjectType to `ConstNode.False`, reusing `Schema.CanSubjectTypeReach` (the TTU analogue of the existing `PlanRefNode` prune case).
- Regenerates the 6 `Api.Tests` `ApiSpecs.ApproveCore` verified snapshots (plain + twin forms per TFM) — `TupleToUserSetNode` is a published public IR type since the seam restructure, so the new field changes its recorded public surface.

Behavior-neutral: no round-trip or allocation change, only fewer per-request schema lookups. Sets up R1 (boolean-combination fusion) to recognize plan-time-eligible TTU as a fusable leaf.

## Test plan
- [x] `dotnet build Valtuutus.slnx` — 0 errors
- [x] `dotnet test Valtuutus.slnx` — 0 failures, InMemory/Postgres/SqlServer/Lang/Api, all 4 TFMs
- [x] Benchmark sanity (`VALTUUTUS_CHECK_V2=1`, net10.0): `Check_UnionTtuDirect` 911.5ns/408B, `Check_UsersetMiss` 1632.9ns/720B — allocation byte-identical to the pre-R3 baseline, latency deltas within this repo's documented single-run noise band