### PR TITLE
feat: CheckV2 R2 — userset 2-hop join fast path

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
@@ -98,6 +98,9 @@ internal static class PlanCompiler
             case TupleToUserSetNode t:
                 return PruneTupleToUserSet(t, schema, entityType, subjectType);
 
+            case DirectRelationNode d:
+                return PruneDirectRelationUserSet(d, schema, entityType, subjectType);
+
             case NegateNode n:
                 var inner = PruneAndFold(n.Child, schema, entityType, subjectType);
                 return inner is ConstNode c ? (c.Value ? ConstNode.False : ConstNode.True) : new NegateNode(inner);
@@ -145,6 +148,39 @@ internal static class PlanCompiler
         }
 
         return t;
+    }
+
+    // The userset-join fast-path guard: DirectRelationNode always compiles as the sole
+    // root of its own plan (PlanValidator enforces this), so — unlike PruneTupleToUserSet,
+    // which is nested inside a larger tree and needs its own per-branch reachability fold —
+    // this node's overall reachability is already covered by Compile()'s top-level
+    // CanSubjectTypeReach guard before PruneAndFold ever runs. This only decides whether the
+    // userset portion of the relation's targets qualifies for a single 2-hop join instead of
+    // the runtime HasDirectRelation-then-GetIndirectRelations-fan-out sequence.
+    private static PlanNode PruneDirectRelationUserSet(DirectRelationNode d, Schema schema, string entityType,
+        string? subjectType)
+    {
+        if (subjectType is null || !d.HasSubRelationPaths) return d;
+
+        var rel = schema.GetRelation(entityType, d.Relation);
+        RelationEntity? usersetTarget = null;
+        foreach (var e in rel.Entities)
+        {
+            if (e.Relation is null) continue;
+            if (usersetTarget is not null) return d; // MVP: exactly one userset target type
+            usersetTarget = e;
+        }
+        if (usersetTarget is null) return d; // defensive: HasSubRelationPaths implies one exists
+
+        var subEntityType = usersetTarget.Type;
+        var computedRelation = usersetTarget.Relation!;
+        if (!schema.CanSubjectTypeReach(subEntityType, computedRelation, subjectType)) return d;
+        if (schema.GetRelationType(subEntityType, computedRelation) != RelationType.DirectRelation) return d;
+
+        var computedRel = schema.GetRelation(subEntityType, computedRelation);
+        if (computedRel.HasSubRelationPaths || !computedRel.EntityTypes.Contains(subjectType)) return d;
+
+        return d with { FastPathSubEntityType = subEntityType, FastPathComputedRelation = computedRelation };
     }
 
     private static PlanNode FoldChildren(ImmutableArray<PlanNode> children, Schema schema,

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanNode.cs
@@ -18,9 +18,17 @@ public sealed record ConstNode(bool Value) : PlanNode
 
 /// <summary>
 /// Appears as a plan ROOT only (a bare relation name compiled as its own plan), never as an
-/// interior node.
+/// interior node. <paramref name="FastPathSubEntityType"/>/<paramref name="FastPathComputedRelation"/>
+/// are non-null when plan-time analysis proved this relation's userset target admits a single
+/// 2-hop join instead of runtime GetIndirectRelations expansion (exactly one userset-typed
+/// target, whose computed relation is itself a direct relation with no further sub-relation
+/// paths, that admits the plan key's subjectType) — set by <see cref="PlanCompiler"/>'s
+/// PruneAndFold pass, never by CompileRoot. Null means either the guard doesn't hold, this
+/// relation has no userset target at all, or subjectType was unknown at compile time.
 /// </summary>
-public sealed record DirectRelationNode(string Relation, bool HasSubRelationPaths) : PlanNode;
+public sealed record DirectRelationNode(
+    string Relation, bool HasSubRelationPaths,
+    string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) : PlanNode;
 
 /// <summary>
 /// Appears as a plan ROOT only (a bare attribute name compiled as its own plan), never as an

--- a/src/Valtuutus.Data.Db/CheckOps.cs
+++ b/src/Valtuutus.Data.Db/CheckOps.cs
@@ -78,3 +78,38 @@ internal sealed class HasAnyOfAttributesOp(string[] attributes, bool requireAll)
         sink.Complete(token, requireAll ? matched.Count == attributes.Length : matched.Count > 0);
     }
 }
+
+// Physical op for the userset 2-hop join fast path — one round trip replaces the runtime
+// HasDirectRelation-then-GetIndirectRelations-fan-out sequence CheckPlanExecutor otherwise
+// runs for a DirectRelationNode with a userset target. RelationalPlanRewriter installs this
+// only when PlanCompiler's PruneAndFold already proved the guard holds for the plan key's
+// subjectType, so no eligibility re-checking happens here.
+internal sealed class UsersetJoinOp(string relation, string subEntityType, string computedRelation)
+    : ICheckOp, IBatchableCheckOp
+{
+    public async ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+        string entityType, string entityId, CancellationToken ct)
+    {
+        if (reader is not IRelationalCheckOps ops)
+            throw new InvalidOperationException(
+                $"RelationalPlanRewriter installed a relational op, but the registered " +
+                $"IDataReaderProvider ({reader.GetType().Name}) does not implement " +
+                $"{nameof(IRelationalCheckOps)}. Readers used with AddDbSetup must implement it.");
+
+        return await ops.HasUsersetJoinRelation(entityType, entityId, relation, subEntityType, computedRelation,
+            ctx.SubjectType!, ctx.SubjectId!, ctx.SnapToken, ct).ConfigureAwait(false);
+    }
+
+    public string Describe() => $"UsersetJoin({relation} -> {subEntityType}#{computedRelation})";
+
+    public void AddToBatch(DbBatch batch, IRelationalBatchOps ops, CheckRequestContext ctx,
+        string entityType, string entityId)
+        => ops.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
+            computedRelation, ctx.SubjectType!, ctx.SubjectId!, ctx.SnapToken);
+
+    public async Task ReadResultAsync(DbDataReader reader, int token, IOpCompletionSink sink, CancellationToken ct)
+    {
+        var result = await reader.ReadAsync(ct).ConfigureAwait(false) && reader.GetBoolean(0);
+        sink.Complete(token, result);
+    }
+}

--- a/src/Valtuutus.Data.Db/IRelationalBatchOps.cs
+++ b/src/Valtuutus.Data.Db/IRelationalBatchOps.cs
@@ -81,6 +81,14 @@ public interface IRelationalBatchOps
         string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken);
 
     /// <summary>
+    /// Adds a command answering <see cref="IRelationalCheckOps.HasUsersetJoinRelation"/>'s
+    /// question to <paramref name="batch"/> — the batched sibling of that method, same SQL
+    /// text/params.
+    /// </summary>
+    void AddHasUsersetJoinRelationToBatch(DbBatch batch, string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken);
+
+    /// <summary>
     /// Adds a command answering <see cref="IDataReaderProvider.HasAnyDirectRelation"/>'s question to
     /// <paramref name="batch"/> — the batched sibling of that method, same SQL text/params.
     /// </summary>

--- a/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
+++ b/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
@@ -20,4 +20,17 @@ public interface IRelationalCheckOps
     /// <inheritdoc cref="IDataReaderProvider.HasAnyOfAttributes"/>
     Task<HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames,
         SnapToken snapToken, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The userset 2-hop join fast path: true iff <paramref name="subjectId"/> either holds
+    /// <paramref name="relation"/> directly on (<paramref name="entityType"/>,
+    /// <paramref name="entityId"/>), or holds <paramref name="computedRelation"/> on
+    /// (<paramref name="subEntityType"/>, X) for some X that (<paramref name="entityType"/>,
+    /// <paramref name="entityId"/>) references via <paramref name="relation"/> as a userset
+    /// (<c>@subEntityType#computedRelation</c>). One round trip instead of
+    /// HasDirectRelation-then-GetIndirectRelations-fan-out.
+    /// </summary>
+    Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId,
+        SnapToken snapToken, CancellationToken cancellationToken);
 }

--- a/src/Valtuutus.Data.Db/RelationalBatchProviderBase.cs
+++ b/src/Valtuutus.Data.Db/RelationalBatchProviderBase.cs
@@ -128,6 +128,21 @@ public abstract class RelationalBatchProviderBase : IRelationalBatchOps
     }
 
     /// <inheritdoc />
+    public virtual void AddHasUsersetJoinRelationToBatch(DbBatch batch, string entityType, string entityId,
+        string relation, string subEntityType, string computedRelation, string subjectType, string subjectId,
+        SnapToken snapToken)
+    {
+        var cmd = NewCommand(batch, GetSql(RelationalBatchQuery.HasUsersetJoinRelation));
+        WriteSnapTokenParam(cmd, "snap_token", snapToken);
+        WriteStringParam(cmd, "entity_type", entityType, 256);
+        WriteStringParam(cmd, "entity_id", entityId, 64);
+        WriteStringParam(cmd, "relation", relation, 64);
+        WriteStringParam(cmd, "computed_relation", computedRelation, 64);
+        WriteStringParam(cmd, "subject_type", subjectType, 256);
+        WriteStringParam(cmd, "subject_id", subjectId, 64);
+    }
+
+    /// <inheritdoc />
     public virtual void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds,
         string relation, string subjectId, SnapToken snapToken)
     {

--- a/src/Valtuutus.Data.Db/RelationalBatchQuery.cs
+++ b/src/Valtuutus.Data.Db/RelationalBatchQuery.cs
@@ -21,6 +21,12 @@ public enum RelationalBatchQuery
     HasTupleToUserSetRelation,
 
     /// <summary>
+    /// Batched sibling of <see cref="IRelationalCheckOps.HasUsersetJoinRelation"/>: the userset
+    /// 2-hop join fast path (SELECT direct-membership-EXISTS OR 2-hop-join-EXISTS).
+    /// </summary>
+    HasUsersetJoinRelation,
+
+    /// <summary>
     /// Batched sibling of <see cref="Valtuutus.Core.Data.IDataReaderProvider.HasAnyDirectRelation"/>.
     /// <c>{0}</c> = entity-id array.
     /// </summary>

--- a/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
+++ b/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
@@ -23,6 +23,15 @@ namespace Valtuutus.Data.Db;
 // Attribute sibling fusion: symmetric for >= 2 sibling same-entity bool-attribute refs —
 // HasAnyOfAttributesOp. No subjectType gate: attributes don't depend on subject at all.
 //
+// Userset 2-hop join: a DirectRelationNode whose PlanCompiler.PruneAndFold pass already
+// proved eligible (FastPathSubEntityType/FastPathComputedRelation both set) becomes one
+// PhysicalCheckNode(UsersetJoinOp) — a single round trip replacing the runtime
+// HasDirectRelation-then-GetIndirectRelations-fan-out sequence. Unlike the two fusion passes
+// above, this recognizes a plan ROOT directly in Walk, not a Union/Intersect child in
+// GroupChildren — DirectRelationNode never appears nested (PlanValidator enforces this), and
+// IsBatchableDirectRef above already excludes HasSubRelationPaths relations, so the two passes
+// never compete for the same node.
+//
 // Both passes rely on hash-consing having already run: a shared ref is MemoNode-wrapped by
 // then and fails the PlanRefNode type test below — that non-match IS the fusion barrier (a
 // MemoNode's child is shared by multiple parents, so fusing it into one duplicates the work
@@ -61,6 +70,10 @@ internal sealed class RelationalPlanRewriter : IPlanRewriter
                     result = ReferenceEquals(child, m.Child) ? m : new MemoNode(m.SlotId, child);
                     break;
                 }
+                case DirectRelationNode { FastPathSubEntityType: not null } d:
+                    result = new PhysicalCheckNode(
+                        new UsersetJoinOp(d.Relation, d.FastPathSubEntityType, d.FastPathComputedRelation!));
+                    break;
                 default: result = node; break;
             }
             _visited[node] = result;

--- a/src/Valtuutus.Data.Postgres/PostgresBatchOps.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresBatchOps.cs
@@ -61,6 +61,7 @@ public sealed class PostgresBatchOps : RelationalBatchProviderBase, IDisposable
         RelationalBatchQuery.HasDirectRelation => _q.HasDirectRelation,
         RelationalBatchQuery.HasTrueBoolAttribute => _q.HasTrueBoolAttribute,
         RelationalBatchQuery.HasTupleToUserSetRelation => _q.HasTupleToUserSetRelation,
+        RelationalBatchQuery.HasUsersetJoinRelation => _q.HasUsersetJoinRelation,
         RelationalBatchQuery.HasAnyDirectRelation => _q.HasAnyDirectRelationBatchTemplate,
         RelationalBatchQuery.HasAnyOfDirectRelations => _q.HasAnyOfDirectRelationsBatchTemplate,
         RelationalBatchQuery.HasAnyOfAttributes => _q.HasAnyOfAttributesBatchTemplate,

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -63,6 +63,7 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
         public required string GetRelationsJoined { get; init; }
         public required string GetRelationsJoinedByEntityIds { get; init; }
         public required string HasTupleToUserSetRelation { get; init; }
+        public required string HasUsersetJoinRelation { get; init; }
         public required string GetAttribute { get; init; }
         public required string GetAttributeWithEntityId { get; init; }
         public required string HasTrueBoolAttribute { get; init; }
@@ -273,6 +274,34 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                       AND r_dep.subject_type = @subject_type
                       AND r_dep.subject_id = @subject_id
                       AND r_dep.subject_relation = ''
+                )
+                """,
+            HasUsersetJoinRelation = $"""
+                SELECT (
+                    EXISTS(
+                        SELECT 1 FROM {relationsTable}
+                        WHERE {SnapTokenPredicate}
+                          AND entity_type = @entity_type
+                          AND entity_id = @entity_id
+                          AND relation = @relation
+                          AND subject_id = @subject_id
+                          AND subject_relation = ''
+                    )
+                    OR EXISTS(
+                        SELECT 1 FROM {relationsTable} r_main
+                        INNER JOIN {relationsTable} r_dep
+                            ON r_dep.entity_type = r_main.subject_type AND r_dep.entity_id = r_main.subject_id
+                        WHERE r_main.created_tx_id <= @snap_token AND (r_main.deleted_tx_id IS NULL OR r_main.deleted_tx_id > @snap_token)
+                          AND r_main.entity_type = @entity_type
+                          AND r_main.entity_id = @entity_id
+                          AND r_main.relation = @relation
+                          AND r_main.subject_relation = @computed_relation
+                          AND r_dep.created_tx_id <= @snap_token AND (r_dep.deleted_tx_id IS NULL OR r_dep.deleted_tx_id > @snap_token)
+                          AND r_dep.relation = @computed_relation
+                          AND r_dep.subject_type = @subject_type
+                          AND r_dep.subject_id = @subject_id
+                          AND r_dep.subject_relation = ''
+                    )
                 )
                 """,
             GetAttribute =
@@ -1088,6 +1117,44 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
             command.CommandText = _q.HasTupleToUserSetRelation;
             PopulateHasTupleToUserSetRelationCommand(command.Parameters, entityType, entityId, tupleSetRelation,
                 subEntityType, computedRelation, subjectType, subjectId, snapToken);
+
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
+    private void PopulateHasUsersetJoinRelationCommand(NpgsqlParameterCollection parameters,
+        string entityType, string entityId, string relation, string computedRelation,
+        string subjectType, string subjectId, SnapToken snapToken)
+    {
+        AddFixedCharParameter(parameters, "snap_token", snapToken.Value, 26);
+        AddStringParameter(parameters, "entity_type", entityType, 256);
+        AddStringParameter(parameters, "entity_id", entityId, 64);
+        AddStringParameter(parameters, "relation", relation, 64);
+        AddStringParameter(parameters, "computed_relation", computedRelation, 64);
+        AddStringParameter(parameters, "subject_type", subjectType, 256);
+        AddStringParameter(parameters, "subject_id", subjectId, 64);
+    }
+
+    // subEntityType is accepted for interface-signature symmetry with HasTupleToUserSetRelation
+    // but isn't a runtime filter here — it's what proved the join eligible at compile time; the
+    // query only needs relation/computedRelation/subjectType/subjectId.
+    public async Task<bool> HasUsersetJoinRelation(
+        string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation,
+        string subjectType, string subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        await EnterQuery(cancellationToken);
+        try
+        {
+            await using var command = _hotPathDataSource.CreateCommand();
+            command.CommandText = _q.HasUsersetJoinRelation;
+            PopulateHasUsersetJoinRelationCommand(command.Parameters, entityType, entityId, relation,
+                computedRelation, subjectType, subjectId, snapToken);
 
             return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }

--- a/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
@@ -89,6 +89,7 @@ public sealed class SqlServerBatchOps : RelationalBatchProviderBase, IDisposable
         RelationalBatchQuery.HasDirectRelation => _q.HasDirectRelation,
         RelationalBatchQuery.HasTrueBoolAttribute => _q.HasTrueBoolAttribute,
         RelationalBatchQuery.HasTupleToUserSetRelation => _q.HasTupleToUserSetRelation,
+        RelationalBatchQuery.HasUsersetJoinRelation => _q.HasUsersetJoinRelation,
         RelationalBatchQuery.HasAnyDirectRelation => _q.HasAnyDirectRelation,
         RelationalBatchQuery.HasAnyOfDirectRelations => _q.HasAnyOfDirectRelations,
         RelationalBatchQuery.HasAnyOfAttributes => _q.HasAnyOfAttributes,

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -328,6 +328,34 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
                       AND r_dep.subject_relation = ''
                 ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
                 """,
+            HasUsersetJoinRelation = $"""
+                SELECT CASE WHEN (
+                    EXISTS(
+                        SELECT 1 FROM {relationsTable}
+                        WHERE created_tx_id <= @SnapToken AND (deleted_tx_id IS NULL OR deleted_tx_id > @SnapToken)
+                          AND entity_type = @EntityType
+                          AND entity_id = @EntityId
+                          AND relation = @Relation
+                          AND subject_id = @SubjectId
+                          AND subject_relation = ''
+                    )
+                    OR EXISTS(
+                        SELECT 1 FROM {relationsTable} r_main
+                        INNER JOIN {relationsTable} r_dep
+                            ON r_dep.entity_type = r_main.subject_type AND r_dep.entity_id = r_main.subject_id
+                        WHERE r_main.created_tx_id <= @SnapToken AND (r_main.deleted_tx_id IS NULL OR r_main.deleted_tx_id > @SnapToken)
+                          AND r_main.entity_type = @EntityType
+                          AND r_main.entity_id = @EntityId
+                          AND r_main.relation = @Relation
+                          AND r_main.subject_relation = @ComputedRelation
+                          AND r_dep.created_tx_id <= @SnapToken AND (r_dep.deleted_tx_id IS NULL OR r_dep.deleted_tx_id > @SnapToken)
+                          AND r_dep.relation = @ComputedRelation
+                          AND r_dep.subject_type = @SubjectType
+                          AND r_dep.subject_id = @SubjectId
+                          AND r_dep.subject_relation = ''
+                    )
+                ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+                """,
             GetRelationsWithSingleSubjectScoped = $"""
                 SELECT r_main.entity_type, r_main.entity_id, r_main.relation, r_main.subject_type, r_main.subject_id, r_main.subject_relation
                 FROM {relationsTable} r_main
@@ -483,6 +511,7 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
         public required string GetRelationsJoined { get; init; }
         public required string GetRelationsJoinedByEntityIds { get; init; }
         public required string HasTupleToUserSetRelation { get; init; }
+        public required string HasUsersetJoinRelation { get; init; }
         public required string GetRelationsWithSingleSubjectScoped { get; init; }
         public required string GetRelationsWithMultiSubjectScoped { get; init; }
         public required string GetRelationsWithSingleSubjectMultiRelationScoped { get; init; }
@@ -1375,6 +1404,43 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await using var command = CreateCommand(connection, _q.HasTupleToUserSetRelation);
             PopulateHasTupleToUserSetRelationCommand(command.Parameters, entityType, entityId, tupleSetRelation,
                 subEntityType, computedRelation, subjectType, subjectId, snapToken);
+
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
+    private static void PopulateHasUsersetJoinRelationCommand(SqlParameterCollection parameters,
+        string entityType, string entityId, string relation, string computedRelation,
+        string subjectType, string subjectId, SnapToken snapToken)
+    {
+        AddStringParameter(parameters, "@EntityType", entityType, 256);
+        AddStringParameter(parameters, "@EntityId", entityId, 64);
+        AddStringParameter(parameters, "@Relation", relation, 64);
+        AddStringParameter(parameters, "@ComputedRelation", computedRelation, 64);
+        AddStringParameter(parameters, "@SubjectType", subjectType, 256);
+        AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
+    }
+
+    public async Task<bool> HasUsersetJoinRelation(
+        string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation,
+        string subjectType, string subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity();
+        await EnterQuery(cancellationToken);
+        try
+        {
+            await using var connection = (SqlConnection)_connectionFactory();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = CreateCommand(connection, _q.HasUsersetJoinRelation);
+            PopulateHasUsersetJoinRelationCommand(command.Parameters, entityType, entityId, relation,
+                computedRelation, subjectType, subjectId, snapToken);
 
             return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -252,7 +252,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -252,7 +252,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -252,7 +252,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -252,7 +252,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -251,7 +251,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -251,7 +251,9 @@ namespace Valtuutus.Core.Engines.Check.V2
     }
     public sealed class DirectRelationNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.DirectRelationNode>
     {
-        public DirectRelationNode(string Relation, bool HasSubRelationPaths) { }
+        public DirectRelationNode(string Relation, bool HasSubRelationPaths, string? FastPathSubEntityType = null, string? FastPathComputedRelation = null) { }
+        public string? FastPathComputedRelation { get; init; }
+        public string? FastPathSubEntityType { get; init; }
         public bool HasSubRelationPaths { get; init; }
         public string Relation { get; init; }
     }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
@@ -56,6 +56,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -63,6 +64,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -82,6 +84,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -97,11 +100,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
@@ -56,6 +56,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -63,6 +64,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -82,6 +84,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -97,11 +100,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
@@ -56,6 +56,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -63,6 +64,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -82,6 +84,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -97,11 +100,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -56,6 +56,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -63,6 +64,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -82,6 +84,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -97,11 +100,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
@@ -55,6 +55,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -62,6 +63,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -81,6 +83,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -96,11 +99,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
@@ -55,6 +55,7 @@ namespace Valtuutus.Data.Db
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
+        void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         System.Data.Common.DbBatch CreateBatch();
         System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
     }
@@ -62,6 +63,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
     {
@@ -81,6 +83,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
+        public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public abstract System.Data.Common.DbBatch CreateBatch();
         public abstract System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken);
         protected abstract string GetSql(Valtuutus.Data.Db.RelationalBatchQuery query);
@@ -96,11 +99,12 @@ namespace Valtuutus.Data.Db
         HasDirectRelation = 0,
         HasTrueBoolAttribute = 1,
         HasTupleToUserSetRelation = 2,
-        HasAnyDirectRelation = 3,
-        HasAnyOfDirectRelations = 4,
-        HasAnyOfAttributes = 5,
-        GetRelations = 6,
-        GetRelationsWithSubjectFilters = 7,
-        GetIndirectRelations = 8,
+        HasUsersetJoinRelation = 3,
+        HasAnyDirectRelation = 4,
+        HasAnyOfDirectRelations = 5,
+        HasAnyOfAttributes = 6,
+        GetRelations = 7,
+        GetRelationsWithSubjectFilters = 8,
+        GetIndirectRelations = 9,
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
@@ -51,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
@@ -51,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PostgresDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
@@ -52,6 +52,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
@@ -51,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
@@ -51,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SqlServerDataWriterProvider : Valtuutus.Core.Data.IDataWriterProvider, Valtuutus.Data.Db.IDbDataWriterProvider
     {

--- a/tests/Valtuutus.Data.Db.Tests/FakeBoolResultReader.cs
+++ b/tests/Valtuutus.Data.Db.Tests/FakeBoolResultReader.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Data.Common;
+
+namespace Valtuutus.Data.Db.Tests;
+
+// Minimal single-bool-column, 0-or-1-row DbDataReader test double — just enough surface to
+// exercise UsersetJoinOp.ReadResultAsync, which only ever calls ReadAsync + GetBoolean(0)
+// against the result set a batched HasUsersetJoinRelation command produces (one scalar row, or
+// none if unmatched). `value: null` means the result set has zero rows.
+internal sealed class FakeBoolResultReader(bool? value) : DbDataReader
+{
+    private bool _consumed;
+
+    public override bool Read()
+    {
+        if (value is null || _consumed) return false;
+        _consumed = true;
+        return true;
+    }
+
+    public override bool GetBoolean(int ordinal) =>
+        ordinal == 0 ? value!.Value : throw new IndexOutOfRangeException(ordinal.ToString());
+
+    public override int FieldCount => 1;
+    public override bool HasRows => value is not null;
+    public override bool IsClosed => false;
+    public override int Depth => 0;
+    public override int RecordsAffected => -1;
+    public override string GetName(int ordinal) => ordinal == 0 ? "value" : throw new IndexOutOfRangeException();
+    public override int GetOrdinal(string name) => 0;
+    public override Type GetFieldType(int ordinal) => typeof(bool);
+    public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();
+    public override bool IsDBNull(int ordinal) => false;
+    public override object GetValue(int ordinal) => GetBoolean(ordinal);
+    public override bool NextResult() => throw new NotSupportedException();
+    public override int GetValues(object[] values) => throw new NotSupportedException();
+    public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+    public override string GetString(int ordinal) => throw new NotSupportedException();
+    public override byte GetByte(int ordinal) => throw new NotSupportedException();
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override char GetChar(int ordinal) => throw new NotSupportedException();
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+    public override DateTime GetDateTime(int ordinal) => throw new NotSupportedException();
+    public override decimal GetDecimal(int ordinal) => throw new NotSupportedException();
+    public override double GetDouble(int ordinal) => throw new NotSupportedException();
+    public override float GetFloat(int ordinal) => throw new NotSupportedException();
+    public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+    public override short GetInt16(int ordinal) => throw new NotSupportedException();
+    public override int GetInt32(int ordinal) => throw new NotSupportedException();
+    public override long GetInt64(int ordinal) => throw new NotSupportedException();
+    public override object this[int ordinal] => throw new NotSupportedException();
+    public override object this[string name] => throw new NotSupportedException();
+}

--- a/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
@@ -259,4 +259,42 @@ public class RelationalPlanRewriterSpecs
         negate.Child.Should().BeSameAs(memo);
         memo.Child.Should().Be(new PlanRefNode("owner"));
     }
+
+    private const string UsersetJoinSchema = """
+        entity user {}
+        entity group { relation member @user; }
+        entity folder {
+            relation owner @user @group#member;
+        }
+        """;
+
+    [Fact]
+    public void Eligible_direct_relation_userset_target_rewrites_to_physical_userset_join()
+    {
+        var rewritten = Rewrite(Parse(UsersetJoinSchema), "folder", "owner", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("UsersetJoin(owner -> group#member)");
+    }
+
+    [Fact]
+    public void Direct_relation_without_userset_target_passes_through_unchanged()
+    {
+        const string s = """
+            entity user {}
+            entity folder { relation owner @user; }
+            """;
+        var rewritten = Rewrite(Parse(s), "folder", "owner", "user", out var compiledRoot);
+        rewritten.Should().BeSameAs(compiledRoot);
+        rewritten.Should().BeOfType<DirectRelationNode>();
+    }
+
+    [Fact]
+    public void Direct_relation_userset_target_stays_unfused_when_subject_type_unknown()
+    {
+        // PruneDirectRelationUserSet needs a known subjectType — without one,
+        // FastPathSubEntityType is never set, so the rewriter has nothing to recognize.
+        var rewritten = Rewrite(Parse(UsersetJoinSchema), "folder", "owner", null, out var compiledRoot);
+        rewritten.Should().BeSameAs(compiledRoot);
+        rewritten.Should().BeOfType<DirectRelationNode>();
+    }
 }

--- a/tests/Valtuutus.Data.Db.Tests/UsersetJoinOpBatchSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/UsersetJoinOpBatchSpecs.cs
@@ -1,0 +1,49 @@
+using System.Data.Common;
+using FluentAssertions;
+using NSubstitute;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+// Covers UsersetJoinOp's IBatchableCheckOp side (AddToBatch / ReadResultAsync) — the
+// Execute-based ICheckOp path is already covered by UsersetJoinOpSpecs.
+public class UsersetJoinOpBatchSpecs
+{
+    private static CheckRequestContext Ctx() => new()
+    {
+        SubjectType = "user", SubjectId = "u1",
+        SnapToken = new SnapToken("00000000000000000000000001"),
+        Context = new Dictionary<string, object>()
+    };
+
+    [Fact]
+    public void AddToBatch_delegates_to_the_matching_IRelationalBatchOps_method_with_its_own_arguments()
+    {
+        var op = new UsersetJoinOp("owner", "group", "member");
+        var ops = Substitute.For<IRelationalBatchOps>();
+        var batch = Substitute.For<DbBatch>();
+        var ctx = Ctx();
+
+        op.AddToBatch(batch, ops, ctx, "folder", "1");
+
+        ops.Received(1).AddHasUsersetJoinRelationToBatch(
+            batch, "folder", "1", "owner", "group", "member", "user", "u1", ctx.SnapToken);
+    }
+
+    [Fact]
+    public async Task ReadResultAsync_reports_true_only_when_a_row_comes_back_true()
+    {
+        var op = new UsersetJoinOp("owner", "group", "member");
+        var sink = new RecordingSink();
+
+        await op.ReadResultAsync(new FakeBoolResultReader(true), token: 7, sink, default);
+        await op.ReadResultAsync(new FakeBoolResultReader(false), token: 9, sink, default);
+        await op.ReadResultAsync(new FakeBoolResultReader(null), token: 11, sink, default); // no rows
+
+        sink.Completed.Should().ContainSingle(c => c.Token == 7 && c.Result);
+        sink.Completed.Should().ContainSingle(c => c.Token == 9 && !c.Result);
+        sink.Completed.Should().ContainSingle(c => c.Token == 11 && !c.Result);
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/UsersetJoinOpSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/UsersetJoinOpSpecs.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NSubstitute;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+public class UsersetJoinOpSpecs
+{
+    private static CheckRequestContext Ctx() => new()
+    {
+        SubjectType = "user", SubjectId = "u1",
+        SnapToken = new SnapToken("00000000000000000000000001"),
+        Context = new Dictionary<string, object>()
+    };
+
+    private static IDataReaderProvider RelationalReader(bool result)
+    {
+        var reader = Substitute.For<IDataReaderProvider, IRelationalCheckOps>();
+        ((IRelationalCheckOps)reader).HasUsersetJoinRelation(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SnapToken>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+        return reader;
+    }
+
+    [Fact]
+    public async Task Execute_returns_the_relational_reader_result_unchanged()
+    {
+        var op = new UsersetJoinOp("owner", "group", "member");
+        (await op.Execute(RelationalReader(true), Ctx(), "folder", "1", default)).Should().BeTrue();
+        (await op.Execute(RelationalReader(false), Ctx(), "folder", "1", default)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Execute_passes_constructor_args_and_context_through()
+    {
+        var op = new UsersetJoinOp("owner", "group", "member");
+        var reader = RelationalReader(true);
+        var ctx = Ctx();
+
+        await op.Execute(reader, ctx, "folder", "1", default);
+
+        ((IRelationalCheckOps)reader).Received(1).HasUsersetJoinRelation(
+            "folder", "1", "owner", "group", "member", "user", "u1", ctx.SnapToken, default);
+    }
+
+    [Fact]
+    public async Task Non_relational_reader_fails_with_a_pointed_message()
+    {
+        var op = new UsersetJoinOp("owner", "group", "member");
+        var reader = Substitute.For<IDataReaderProvider>(); // no IRelationalCheckOps
+        var act = () => op.Execute(reader, Ctx(), "folder", "1", default).AsTask();
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*IRelationalCheckOps*");
+    }
+}

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
@@ -204,6 +204,98 @@ public class PlanCompilerSpecs
         plan.Root.Should().Be(new PlanRefNode("owner"));
     }
 
+    private const string EligibleSchema = """
+        entity user {}
+        entity group { relation member @user; }
+        entity folder {
+            relation owner @user @group#member;
+        }
+        """;
+
+    [Fact]
+    public void DirectRelation_userset_target_meeting_all_fast_path_conditions_is_annotated()
+    {
+        var plan = PlanCompiler.Compile(Parse(EligibleSchema), "folder", "owner", "user");
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: true,
+            FastPathSubEntityType: "group", FastPathComputedRelation: "member"));
+    }
+
+    [Fact]
+    public void DirectRelation_without_userset_target_is_never_annotated()
+    {
+        const string s = """
+            entity user {}
+            entity folder {
+                relation owner @user;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "owner", "user");
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: false));
+    }
+
+    [Fact]
+    public void DirectRelation_with_null_subjectType_is_never_annotated()
+    {
+        var plan = PlanCompiler.Compile(Parse(EligibleSchema), "folder", "owner", null);
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: true));
+    }
+
+    [Fact]
+    public void DirectRelation_with_two_userset_target_types_is_not_fast_path_eligible()
+    {
+        const string s = """
+            entity user {}
+            entity group { relation member @user; }
+            entity team { relation lead @user; }
+            entity folder {
+                relation owner @user @group#member @team#lead;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "owner", "user");
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: true));
+    }
+
+    [Fact]
+    public void DirectRelation_whose_computed_relation_has_sub_relation_paths_is_not_fast_path_eligible()
+    {
+        const string s = """
+            entity user {}
+            entity org { relation employee @user; }
+            entity group { relation member @user @org#employee; }
+            entity folder {
+                relation owner @user @group#member;
+            }
+            """;
+        var plan = PlanCompiler.Compile(Parse(s), "folder", "owner", "user");
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: true));
+    }
+
+    [Fact]
+    public void DirectRelation_whose_computed_relation_does_not_admit_subjectType_is_not_fast_path_eligible()
+    {
+        // Compile()'s top-level guard already passed (the @user direct target makes folder/"owner"
+        // reachable for "user"), so PruneAndFold runs — but the userset half alone doesn't reach
+        // "user" (group.member only admits service_account), so it must stay ineligible. This
+        // exercises PruneDirectRelationUserSet's own CanSubjectTypeReach check specifically.
+        //
+        // Built via SchemaBuilder directly rather than Parse(): the DSL parser requires a
+        // relation's direct and userset legs to bottom out at the same final entity type, so this
+        // exact shape (owner's direct leg reaching only "user", its userset leg only
+        // "service_account") can't be expressed as schema text. Schema.CanSubjectTypeReach carries
+        // no such restriction — it just unions admissible subject types across a relation's legs —
+        // so building the Relation objects directly still exercises the real runtime guard.
+        var builder = new SchemaBuilder();
+        builder.WithEntity("user");
+        builder.WithEntity("service_account");
+        builder.WithEntity("group").WithRelation("member", r => r.WithEntityType("service_account"));
+        builder.WithEntity("folder").WithRelation("owner",
+            r => r.WithEntityType("user").WithEntityType("group", "member"));
+        var schema = builder.Build();
+
+        var plan = PlanCompiler.Compile(schema, "folder", "owner", "user");
+        plan.Root.Should().Be(new DirectRelationNode("owner", HasSubRelationPaths: true));
+    }
+
     private const string PruneSchema = """
         entity user {}
         entity service_account {}

--- a/tests/Valtuutus.Data.Postgres.Tests/RoundTripCountingReaderProvider.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/RoundTripCountingReaderProvider.cs
@@ -85,6 +85,15 @@ internal sealed class CountingReaderProvider(PostgresDataReaderProvider inner, R
             computedRelation, subjectType, subjectId, snapToken, cancellationToken);
     }
 
+    public async Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken,
+        CancellationToken cancellationToken)
+    {
+        counter.Increment();
+        return await inner.HasUsersetJoinRelation(entityType, entityId, relation, subEntityType, computedRelation,
+            subjectType, subjectId, snapToken, cancellationToken);
+    }
+
     public async Task<PooledList<RelationTuple>> GetIndirectRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
     {
         counter.Increment();
@@ -227,6 +236,11 @@ internal sealed class CountingBatchOps(IRelationalBatchOps inner, RoundTripCount
         string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId,
         SnapToken snapToken)
         => inner.AddHasTupleToUserSetRelationToBatch(batch, entityType, entityId, tupleSetRelation, subEntityType,
+            computedRelation, subjectType, subjectId, snapToken);
+
+    public void AddHasUsersetJoinRelationToBatch(DbBatch batch, string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken)
+        => inner.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
             computedRelation, subjectType, subjectId, snapToken);
 
     public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,

--- a/tests/Valtuutus.Data.Postgres.Tests/UsersetJoinRelationSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/UsersetJoinRelationSpecs.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+using Valtuutus.Data.Postgres;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.Postgres.Tests;
+
+/// <summary>
+/// End-to-end correctness + round-trip proof for the userset 2-hop join fast path: a
+/// DirectRelationNode with a userset target answered by one UsersetJoinOp round trip instead of
+/// HasDirectRelation-then-GetIndirectRelations-fan-out.
+/// </summary>
+[Collection("PostgreSqlSpec")]
+public sealed class UsersetJoinRelationSpecs : IAsyncLifetime
+{
+    private const string Schema = """
+        entity user {}
+        entity group {
+            relation member @user;
+        }
+        entity folder {
+            relation owner @user @group#member;
+        }
+        """;
+
+    public UsersetJoinRelationSpecs(PostgresFixture fixture) => Fixture = fixture;
+
+    private PostgresFixture Fixture { get; }
+
+    public Task InitializeAsync() => Fixture.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData("f1", "direct-hit", true)]   // folder:f1#owner@user:direct-hit — direct membership
+    [InlineData("f2", "join-hit", true)]     // folder:f2#owner@group:g1#member, group:g1#member@user:join-hit
+    [InlineData("f2", "someone-else", false)] // present group, subject not a member of it
+    [InlineData("f3", "anyone", false)]      // folder:f3 has no owner tuples at all
+    public async Task Check_matches_expected_result(string entityId, string subjectId, bool expected)
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+        SnapToken snapToken;
+        {
+            var seedServices = new ServiceCollection().AddValtuutusCore(Schema);
+            seedServices.AddPostgres(_ => dbFactory).AddConcurrentQueryLimit(3);
+            await using var seedProvider = seedServices.BuildServiceProvider();
+            await using var seedScope = seedProvider.CreateAsyncScope();
+            var writer = seedScope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(
+                [
+                    new RelationTuple("folder", "f1", "owner", "user", "direct-hit"),
+                    new RelationTuple("folder", "f2", "owner", "group", "g1", "member"),
+                    new RelationTuple("group", "g1", "member", "user", "join-hit"),
+                ],
+                [],
+                default);
+        }
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddPostgres(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+
+        var result = await engine.Check(
+            new CheckRequest("folder", entityId, "owner", "user", subjectId, snapToken: snapToken), default);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Userset_join_hit_costs_exactly_one_round_trip()
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+        SnapToken snapToken;
+        {
+            var seedServices = new ServiceCollection().AddValtuutusCore(Schema);
+            seedServices.AddPostgres(_ => dbFactory).AddConcurrentQueryLimit(3);
+            await using var seedProvider = seedServices.BuildServiceProvider();
+            await using var seedScope = seedProvider.CreateAsyncScope();
+            var writer = seedScope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(
+                [
+                    new RelationTuple("folder", "f2", "owner", "group", "g1", "member"),
+                    new RelationTuple("group", "g1", "member", "user", "join-hit"),
+                ],
+                [],
+                default);
+        }
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddPostgres(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+
+        var counter = new RoundTripCounter();
+        services.AddSingleton(counter);
+        services.Replace(ServiceDescriptor.Scoped<IDataReaderProvider>(sp =>
+        {
+            var real = ActivatorUtilities.CreateInstance<PostgresDataReaderProvider>(sp);
+            return new CountingReaderProvider(real, sp.GetRequiredService<RoundTripCounter>());
+        }));
+
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+
+        var result = await engine.Check(
+            new CheckRequest("folder", "f2", "owner", "user", "join-hit", snapToken: snapToken), default);
+
+        result.Should().BeTrue();
+        // Without this fast path, this shape costs at least 2 round trips (HasDirectRelation,
+        // then GetIndirectRelations plus one recursive fan-out check per matched group). The
+        // userset join collapses it to exactly 1 (UsersetJoinOp's single combined query) — no
+        // GetLatestSnapToken round trip either, since the request supplies its own snapToken.
+        counter.Count.Should().Be(1);
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
@@ -85,6 +85,15 @@ internal sealed class CountingReaderProvider(SqlServerDataReaderProvider inner, 
             computedRelation, subjectType, subjectId, snapToken, cancellationToken);
     }
 
+    public async Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken,
+        CancellationToken cancellationToken)
+    {
+        counter.Increment();
+        return await inner.HasUsersetJoinRelation(entityType, entityId, relation, subEntityType, computedRelation,
+            subjectType, subjectId, snapToken, cancellationToken);
+    }
+
     public async Task<PooledList<RelationTuple>> GetIndirectRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
     {
         counter.Increment();
@@ -227,6 +236,11 @@ internal sealed class CountingBatchOps(IRelationalBatchOps inner, RoundTripCount
         string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId,
         SnapToken snapToken)
         => inner.AddHasTupleToUserSetRelationToBatch(batch, entityType, entityId, tupleSetRelation, subEntityType,
+            computedRelation, subjectType, subjectId, snapToken);
+
+    public void AddHasUsersetJoinRelationToBatch(DbBatch batch, string entityType, string entityId, string relation,
+        string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken)
+        => inner.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
             computedRelation, subjectType, subjectId, snapToken);
 
     public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,

--- a/tests/Valtuutus.Data.SqlServer.Tests/UsersetJoinRelationSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/UsersetJoinRelationSpecs.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+using Valtuutus.Data.SqlServer;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+/// <summary>
+/// End-to-end correctness + round-trip proof for the userset 2-hop join fast path: a
+/// DirectRelationNode with a userset target answered by one UsersetJoinOp round trip instead of
+/// HasDirectRelation-then-GetIndirectRelations-fan-out.
+/// </summary>
+[Collection("SqlServerSpec")]
+public sealed class UsersetJoinRelationSpecs : IAsyncLifetime
+{
+    private const string Schema = """
+        entity user {}
+        entity group {
+            relation member @user;
+        }
+        entity folder {
+            relation owner @user @group#member;
+        }
+        """;
+
+    public UsersetJoinRelationSpecs(SqlServerFixture fixture) => Fixture = fixture;
+
+    private SqlServerFixture Fixture { get; }
+
+    public Task InitializeAsync() => Fixture.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData("f1", "direct-hit", true)]   // folder:f1#owner@user:direct-hit — direct membership
+    [InlineData("f2", "join-hit", true)]     // folder:f2#owner@group:g1#member, group:g1#member@user:join-hit
+    [InlineData("f2", "someone-else", false)] // present group, subject not a member of it
+    [InlineData("f3", "anyone", false)]      // folder:f3 has no owner tuples at all
+    public async Task Check_matches_expected_result(string entityId, string subjectId, bool expected)
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+        SnapToken snapToken;
+        {
+            var seedServices = new ServiceCollection().AddValtuutusCore(Schema);
+            seedServices.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+            await using var seedProvider = seedServices.BuildServiceProvider();
+            await using var seedScope = seedProvider.CreateAsyncScope();
+            var writer = seedScope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(
+                [
+                    new RelationTuple("folder", "f1", "owner", "user", "direct-hit"),
+                    new RelationTuple("folder", "f2", "owner", "group", "g1", "member"),
+                    new RelationTuple("group", "g1", "member", "user", "join-hit"),
+                ],
+                [],
+                default);
+        }
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+
+        var result = await engine.Check(
+            new CheckRequest("folder", entityId, "owner", "user", subjectId, snapToken: snapToken), default);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Userset_join_hit_costs_exactly_one_round_trip()
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+        SnapToken snapToken;
+        {
+            var seedServices = new ServiceCollection().AddValtuutusCore(Schema);
+            seedServices.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+            await using var seedProvider = seedServices.BuildServiceProvider();
+            await using var seedScope = seedProvider.CreateAsyncScope();
+            var writer = seedScope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(
+                [
+                    new RelationTuple("folder", "f2", "owner", "group", "g1", "member"),
+                    new RelationTuple("group", "g1", "member", "user", "join-hit"),
+                ],
+                [],
+                default);
+        }
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+
+        var counter = new RoundTripCounter();
+        services.AddSingleton(counter);
+        services.Replace(ServiceDescriptor.Scoped<IDataReaderProvider>(sp =>
+        {
+            var real = ActivatorUtilities.CreateInstance<SqlServerDataReaderProvider>(sp);
+            return new CountingReaderProvider(real, sp.GetRequiredService<RoundTripCounter>());
+        }));
+
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+
+        var result = await engine.Check(
+            new CheckRequest("folder", "f2", "owner", "user", "join-hit", snapToken: snapToken), default);
+
+        result.Should().BeTrue();
+        // Without this fast path, this shape costs at least 2 round trips (HasDirectRelation,
+        // then GetIndirectRelations plus one recursive fan-out check per matched group). The
+        // userset join collapses it to exactly 1 (UsersetJoinOp's single combined query) — no
+        // GetLatestSnapToken round trip either, since the request supplies its own snapToken.
+        counter.Count.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the runtime `HasDirectRelation`-then-`GetIndirectRelations`-fan-out sequence for a `DirectRelationNode` with a single userset target with one 2-hop `EXISTS` join, when `PlanCompiler.PruneAndFold` proves it schema-statically safe for the plan key's subjectType.
- Data.Db-only (new `IRelationalCheckOps`/`IRelationalBatchOps` member + `UsersetJoinOp`), following the seam-restructure pattern R1 established — InMemory keeps today's runtime expansion, unchanged. V1 has no equivalent fast path, so this is V2's first strictly-better-than-V1 behavior.
- Both Postgres and SqlServer implement the new 2-hop join query, wired through `RelationalPlanRewriter` and the existing `BatchedPhysicalExecutor` DbBatch path.

## Benchmark (`Check_UsersetMiss`, V1 vs V2)

| Provider | Latency | Allocation |
|---|---|---|
| InMemory | unaffected (no rewriter registered) | unaffected |
| Postgres | ~-30% | ~-44% |
| SqlServer | ~-20% | ~-63% |

Note: getting stable SqlServer numbers required pinning `--invocationCount`/`--unrollFactor` instead of BenchmarkDotNet's default pilot ramp — the default ramp hits a connection-pool-exhaustion timeout in `GetLatestSnapToken` under load. Confirmed via a scratch worktree that this reproduces identically on `dev` before this branch's changes, so it's a pre-existing SqlServer-benchmark issue (also seen in CI), not something this PR introduces. Follow-up tracked separately.

## Test plan

- [x] Full solution build/test (`dotnet build`/`dotnet test Valtuutus.slnx`, all 4 TFMs) — 0 failures.
- [x] New `PlanCompiler.PruneDirectRelationUserSet` eligibility unit tests (6 cases, InMemory.Tests).
- [x] New `RelationalPlanRewriter` rewrite-recognition tests (3 cases).
- [x] New `UsersetJoinOp` unit tests (`ICheckOp` + `IBatchableCheckOp` sides, with a new `FakeBoolResultReader` test double).
- [x] New Postgres + SqlServer Testcontainers integration tests: end-to-end correctness (direct hit / join hit / group-present-but-not-member miss / no-tuples miss) and a round-trip-count proof (1 round trip vs the old ≥2).
- [x] `ApiSpecs` public-API-approval snapshots updated for `Valtuutus.Core`, `Valtuutus.Data.Db`, `Valtuutus.Data.Postgres`, `Valtuutus.Data.SqlServer` (all 4 TFMs, plain + twin net10/net11 forms kept in lockstep).