### PR TITLE
fix: work around SqlBatch connection leak from broken CommandBehavior.CloseConnection

### DIFF
--- a/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
@@ -50,9 +50,11 @@ public sealed class SqlServerBatchOps : RelationalBatchProviderBase, IDisposable
     // Same body SqlServerDataReaderProvider.ExecuteBatchAsync had before the batch ops moved here,
     // including the slot semantics IRelationalBatchOps.ExecuteBatchAsync documents: the rate-limit
     // slot is released as soon as the reader is obtained, NOT after the caller drains it.
-    // CommandBehavior.CloseConnection makes the returned reader's disposal close+dispose the
-    // connection automatically — mirrors how Postgres's ephemeral per-batch connection returns to
-    // its pool when the caller disposes the reader.
+    //
+    // Does NOT use CommandBehavior.CloseConnection to return the connection — see
+    // CommandBehaviorCloseConnectionWorkaroundReader's doc comment for why: it's a WORKAROUND for
+    // a Microsoft.Data.SqlClient bug (CommandBehavior.CloseConnection not honored for SqlBatch),
+    // not this design's first choice.
     public override async Task<DbDataReader> ExecuteBatchAsync(DbBatch batch, CancellationToken cancellationToken)
     {
         using var activity = DefaultActivitySource.Instance.StartActivity();
@@ -63,13 +65,15 @@ public sealed class SqlServerBatchOps : RelationalBatchProviderBase, IDisposable
             try
             {
                 await connection.OpenAsync(cancellationToken);
-                return await batch.ExecuteReaderAsync(CommandBehavior.CloseConnection, cancellationToken)
+                var reader = await batch.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken)
                     .ConfigureAwait(false);
+                return new CommandBehaviorCloseConnectionWorkaroundReader(reader, connection);
             }
             catch
             {
-                // CommandBehavior.CloseConnection never took effect (no reader was obtained) — the
-                // connection would otherwise leak.
+                // No reader was obtained, so nothing downstream will ever dispose the connection —
+                // the workaround reader above only exists once ExecuteReaderAsync has already
+                // succeeded.
                 await connection.DisposeAsync();
                 throw;
             }

--- a/src/Valtuutus.Data.SqlServer/Utils/CommandBehaviorCloseConnectionWorkaroundReader.cs
+++ b/src/Valtuutus.Data.SqlServer/Utils/CommandBehaviorCloseConnectionWorkaroundReader.cs
@@ -1,0 +1,75 @@
+using System.Collections;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+
+namespace Valtuutus.Data.SqlServer.Utils;
+
+/// <summary>
+/// WORKAROUND, not a design choice — delete once the pinned Microsoft.Data.SqlClient version
+/// fixes <c>CommandBehavior.CloseConnection</c> for <see cref="SqlBatch"/>.
+///
+/// Confirmed with a Valtuutus-free raw ADO.NET repro (open connection, run
+/// <c>SqlBatch.ExecuteReaderAsync(CommandBehavior.CloseConnection)</c>, dispose the reader, check
+/// <c>connection.State</c>): the connection stays <c>Open</c> on Microsoft.Data.SqlClient 6.0.1
+/// and 6.1.6 (the latest 6.x as of this writing) — <c>CommandBehavior.CloseConnection</c> is
+/// simply not honored for <see cref="SqlBatch"/>, unlike <see cref="SqlCommand"/>, where it
+/// reliably works. Same repro against <c>7.1.0-preview2.26190.5</c> shows it fixed there, but
+/// that's a prerelease with no GA yet, so it's not something to depend on for this fix.
+///
+/// Every batched query call otherwise leaked one physical connection permanently (never returned
+/// to the pool), eventually exhausting it under sustained load.
+///
+/// This wraps the raw reader so the connection's disposal is tied explicitly to the reader's
+/// lifetime instead — exactly what <c>CommandBehavior.CloseConnection</c> was supposed to do.
+/// </summary>
+internal sealed class CommandBehaviorCloseConnectionWorkaroundReader(DbDataReader inner, SqlConnection connection)
+    : DbDataReader
+{
+    public override async ValueTask DisposeAsync()
+    {
+        await inner.DisposeAsync().ConfigureAwait(false);
+        await connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        inner.Dispose();
+        if (disposing) connection.Dispose();
+    }
+
+    public override bool Read() => inner.Read();
+    public override Task<bool> ReadAsync(CancellationToken cancellationToken) => inner.ReadAsync(cancellationToken);
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken) => inner.NextResultAsync(cancellationToken);
+    public override bool NextResult() => inner.NextResult();
+    public override int FieldCount => inner.FieldCount;
+    public override bool HasRows => inner.HasRows;
+    public override bool IsClosed => inner.IsClosed;
+    public override int Depth => inner.Depth;
+    public override int RecordsAffected => inner.RecordsAffected;
+    public override object this[int ordinal] => inner[ordinal];
+    public override object this[string name] => inner[name];
+    public override bool GetBoolean(int ordinal) => inner.GetBoolean(ordinal);
+    public override byte GetByte(int ordinal) => inner.GetByte(ordinal);
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) =>
+        inner.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+    public override char GetChar(int ordinal) => inner.GetChar(ordinal);
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) =>
+        inner.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+    public override string GetDataTypeName(int ordinal) => inner.GetDataTypeName(ordinal);
+    public override DateTime GetDateTime(int ordinal) => inner.GetDateTime(ordinal);
+    public override decimal GetDecimal(int ordinal) => inner.GetDecimal(ordinal);
+    public override double GetDouble(int ordinal) => inner.GetDouble(ordinal);
+    public override Type GetFieldType(int ordinal) => inner.GetFieldType(ordinal);
+    public override float GetFloat(int ordinal) => inner.GetFloat(ordinal);
+    public override Guid GetGuid(int ordinal) => inner.GetGuid(ordinal);
+    public override short GetInt16(int ordinal) => inner.GetInt16(ordinal);
+    public override int GetInt32(int ordinal) => inner.GetInt32(ordinal);
+    public override long GetInt64(int ordinal) => inner.GetInt64(ordinal);
+    public override string GetName(int ordinal) => inner.GetName(ordinal);
+    public override int GetOrdinal(string name) => inner.GetOrdinal(name);
+    public override string GetString(int ordinal) => inner.GetString(ordinal);
+    public override object GetValue(int ordinal) => inner.GetValue(ordinal);
+    public override int GetValues(object[] values) => inner.GetValues(values);
+    public override bool IsDBNull(int ordinal) => inner.IsDBNull(ordinal);
+    public override IEnumerator GetEnumerator() => inner.GetEnumerator();
+}


### PR DESCRIPTION
## Summary

Investigation into the pre-existing SqlServer benchmark timeout (surfaced by CheckV2 R2's batching, but predates it).

- Root cause: `SqlBatch.ExecuteReaderAsync(CommandBehavior.CloseConnection)` does not honor `CloseConnection` in Microsoft.Data.SqlClient — confirmed with a Valtuutus-free raw ADO.NET repro (open a connection, run a `SqlBatch` with `CommandBehavior.CloseConnection`, dispose the reader, check `connection.State`) on both `6.0.1` (repo's pinned floor) and `6.1.6` (latest 6.x). Fixed in `7.1.0-preview2.26190.5`, but that's a prerelease with no GA — not something to depend on yet.
- Every batched SqlServer query (`SqlServerBatchOps.ExecuteBatchAsync`) leaked one physical connection permanently, never returned to the pool. Reproduced as an exact 1:1 linear growth in `sys.dm_exec_sessions` per sequential `Check()` call, under strictly sequential (non-concurrent) load — ruling out pool contention, confirming a genuine leak.
- Fix: `CommandBehaviorCloseConnectionWorkaroundReader` (new file) wraps the reader returned from `ExecuteBatchAsync` and explicitly disposes the connection when the reader is disposed, since `SqlServerBatchOps` already owns that connection (created it in `CreateBatch`). Named and documented explicitly as a workaround for an external library bug, not a design choice, so it's obvious to remove once the repo depends on a SqlClient version with the real fix.

## Test plan

- [x] Raw ADO.NET repro (no Valtuutus code) confirms the underlying `SqlClient` bug on 6.0.1/6.1.6, and confirms the workaround genuinely closes the connection (`connection.State == Closed` after reader disposal, 30/30 runs).
- [x] Real `CheckEngineV2` sequential loop (150 calls) against a real SqlServer Testcontainer: `sys.dm_exec_sessions` stays flat throughout with the fix, vs. exact 1:1 growth before it.
- [x] The original BenchmarkDotNet reproduction (`SqlServerBenchmarks.Check_UsersetMiss`, default job with pilot-stage invocation ramp) that previously timed out on connection-pool exhaustion now completes cleanly — and the number itself improved (~158µs/20.2KB vs. numbers measured around the leak's connection-pool contention).
- [x] Full solution test suite (`dotnet test Valtuutus.slnx`, all 4 TFMs): 0 failures, including all 447 SqlServer tests per TFM (batch/round-trip paths exercised).