### PR TITLE
feat: CheckV2 R1 — boolean-combination fusion

### DIFF
--- a/src/Valtuutus.Data.Db/CheckOps.cs
+++ b/src/Valtuutus.Data.Db/CheckOps.cs
@@ -9,6 +9,9 @@ namespace Valtuutus.Data.Db;
 // check-then-batch: one round trip answers what would otherwise be N sibling children.
 internal sealed class HasAnyOfDirectRelationsOp(string[] relations, bool requireAll) : ICheckOp, IBatchableCheckOp
 {
+    internal string[] Relations => relations;
+    internal bool RequireAll => requireAll;
+
     public async ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
         string entityType, string entityId, CancellationToken ct)
     {
@@ -49,6 +52,9 @@ internal sealed class HasAnyOfDirectRelationsOp(string[] relations, bool require
 // batch (see RelationalPlanRewriter's attribute sibling fusion pass).
 internal sealed class HasAnyOfAttributesOp(string[] attributes, bool requireAll) : ICheckOp, IBatchableCheckOp
 {
+    internal string[] Attributes => attributes;
+    internal bool RequireAll => requireAll;
+
     public async ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
         string entityType, string entityId, CancellationToken ct)
     {
@@ -106,6 +112,55 @@ internal sealed class UsersetJoinOp(string relation, string subEntityType, strin
         string entityType, string entityId)
         => ops.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
             computedRelation, ctx.SubjectType!, ctx.SubjectId!, ctx.SnapToken);
+
+    public async Task ReadResultAsync(DbDataReader reader, int token, IOpCompletionSink sink, CancellationToken ct)
+    {
+        var result = await reader.ReadAsync(ct).ConfigureAwait(false) && reader.GetBoolean(0);
+        sink.Complete(token, result);
+    }
+}
+
+// Physical op for the boolean-combination fusion fast path: one round trip answers a whole
+// Union/Intersect whose every child was a recognizable relational leaf (see
+// RelationalPlanRewriter's GroupChildren), instead of one round trip per leaf (or one DbBatch
+// packing N statements — this is exactly one statement).
+internal sealed class FusedExpressionOp(IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll)
+    : ICheckOp, IBatchableCheckOp
+{
+    internal IReadOnlyList<FusedCheckLeaf> Leaves => leaves;
+    internal bool RequireAll => requireAll;
+
+    public async ValueTask<bool> Execute(IDataReaderProvider reader, CheckRequestContext ctx,
+        string entityType, string entityId, CancellationToken ct)
+    {
+        if (reader is not IRelationalCheckOps ops)
+            throw new InvalidOperationException(
+                $"RelationalPlanRewriter installed a relational op, but the registered " +
+                $"IDataReaderProvider ({reader.GetType().Name}) does not implement " +
+                $"{nameof(IRelationalCheckOps)}. Readers used with AddDbSetup must implement it.");
+
+        return await ops.HasFusedExpression(entityType, entityId, leaves, requireAll,
+            ctx.SubjectType, ctx.SubjectId, ctx.SnapToken, ct).ConfigureAwait(false);
+    }
+
+    public string Describe()
+    {
+        var parts = leaves.Select(l => (l.Negate ? "not " : "") + l.Kind switch
+        {
+            FusedLeafKind.Direct => $"Direct({l.Names[0]})",
+            FusedLeafKind.MultiDirect => $"MultiDirect([{string.Join(", ", l.Names)}], {(l.RequireAll ? "all" : "any")})",
+            FusedLeafKind.Attribute => $"Attribute({l.Names[0]})",
+            FusedLeafKind.MultiAttribute => $"MultiAttribute([{string.Join(", ", l.Names)}], {(l.RequireAll ? "all" : "any")})",
+            FusedLeafKind.TupleToUserSet => $"Ttu({l.Names[0]} -> {l.TtuSubEntityType}#{l.TtuComputedRelation})",
+            _ => throw new ArgumentOutOfRangeException(nameof(l.Kind), l.Kind, null),
+        });
+        return $"FusedExpression([{string.Join(", ", parts)}], {(requireAll ? "all" : "any")})";
+    }
+
+    public void AddToBatch(DbBatch batch, IRelationalBatchOps ops, CheckRequestContext ctx,
+        string entityType, string entityId)
+        => ops.AddHasFusedExpressionToBatch(batch, entityType, entityId, leaves, requireAll,
+            ctx.SubjectType, ctx.SubjectId, ctx.SnapToken);
 
     public async Task ReadResultAsync(DbDataReader reader, int token, IOpCompletionSink sink, CancellationToken ct)
     {

--- a/src/Valtuutus.Data.Db/FusedCheckLeaf.cs
+++ b/src/Valtuutus.Data.Db/FusedCheckLeaf.cs
@@ -1,0 +1,45 @@
+namespace Valtuutus.Data.Db;
+
+/// <summary>
+/// One relational-leaf shape a fused boolean expression (see <c>IRelationalCheckOps.HasFusedExpression</c>)
+/// can compose. Built exclusively by <c>RelationalPlanRewriter</c> from a compiled plan's Union/Intersect
+/// children — never constructed by a provider.
+/// </summary>
+public enum FusedLeafKind
+{
+    /// <summary>A single plain direct-relation reference. <see cref="FusedCheckLeaf.Names"/> has 1 element.</summary>
+    Direct,
+
+    /// <summary>An already-grouped sibling direct-relation set (&gt;= 2 relations, one query answers all of them). <see cref="FusedCheckLeaf.Names"/> has &gt;= 2 elements.</summary>
+    MultiDirect,
+
+    /// <summary>A single bool-attribute reference. <see cref="FusedCheckLeaf.Names"/> has 1 element.</summary>
+    Attribute,
+
+    /// <summary>An already-grouped sibling bool-attribute set. <see cref="FusedCheckLeaf.Names"/> has &gt;= 2 elements.</summary>
+    MultiAttribute,
+
+    /// <summary>
+    /// A tuple-to-userset node whose plan-time analysis already proved the 2-hop-join fast path
+    /// eligible: <see cref="FusedCheckLeaf.Names"/>[0] is the tupleset relation,
+    /// <see cref="FusedCheckLeaf.TtuSubEntityType"/>/<see cref="FusedCheckLeaf.TtuComputedRelation"/>
+    /// are the 2-hop join target.
+    /// </summary>
+    TupleToUserSet,
+}
+
+/// <summary>
+/// One leaf of a fused boolean expression. <see cref="Names"/>' meaning depends on <see cref="Kind"/> — see
+/// each <see cref="FusedLeafKind"/> member's doc. <see cref="RequireAll"/> only applies to
+/// <see cref="FusedLeafKind.MultiDirect"/>/<see cref="FusedLeafKind.MultiAttribute"/> (true: every name must
+/// match; false: any one match suffices) — it is this leaf's OWN combinator, independent of the fused
+/// expression's outer <c>requireAll</c> (e.g. <c>org.admin and (owner or member)</c> fuses to an outer
+/// AND of [TupleToUserSet, MultiDirect(RequireAll: false)]).
+/// </summary>
+public sealed record FusedCheckLeaf(
+    FusedLeafKind Kind,
+    bool Negate,
+    string[] Names,
+    bool RequireAll = false,
+    string? TtuSubEntityType = null,
+    string? TtuComputedRelation = null);

--- a/src/Valtuutus.Data.Db/FusedExpressionSqlBuilder.cs
+++ b/src/Valtuutus.Data.Db/FusedExpressionSqlBuilder.cs
@@ -1,0 +1,24 @@
+namespace Valtuutus.Data.Db;
+
+/// <summary>
+/// Joins per-leaf SQL fragments into one boolean expression — the provider-agnostic half of
+/// building a fused expression's SQL text. A provider supplies <c>fragment</c>, returning an
+/// EXISTS(...)-or-count-comparison fragment for leaf <c>i</c> already using index-suffixed
+/// parameter names (<c>@relation_{i}</c>, ...) so leaves of the same kind never collide. This
+/// class only decides join order/combinator/negation wrapping — it never touches parameters.
+/// </summary>
+public static class FusedExpressionSqlBuilder
+{
+    public static string BuildBooleanExpression(IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll,
+        Func<FusedCheckLeaf, int, string> fragment)
+    {
+        var combinator = requireAll ? " AND " : " OR ";
+        var parts = new string[leaves.Count];
+        for (var i = 0; i < leaves.Count; i++)
+        {
+            var frag = fragment(leaves[i], i);
+            parts[i] = leaves[i].Negate ? $"NOT {frag}" : frag;
+        }
+        return $"({string.Join(combinator, parts)})";
+    }
+}

--- a/src/Valtuutus.Data.Db/IRelationalBatchOps.cs
+++ b/src/Valtuutus.Data.Db/IRelationalBatchOps.cs
@@ -108,4 +108,17 @@ public interface IRelationalBatchOps
     /// <paramref name="batch"/> — the batched sibling of that method, same SQL text/params.
     /// </summary>
     void AddGetIndirectRelationsToBatch(DbBatch batch, RelationTupleFilter tupleFilter);
+
+    /// <summary>
+    /// Adds a command answering <see cref="IRelationalCheckOps.HasFusedExpression"/>'s question to
+    /// <paramref name="batch"/> — the batched sibling of that method. Unlike every other Add* member
+    /// on this interface, there is no shared fixed SQL text this mirrors byte-for-byte: the compound
+    /// expression's shape varies per call (leaf count/kind/negation), so each provider composes its
+    /// own text per call via <see cref="RelationalBatchProviderBase.AddHasFusedExpressionToBatch"/>
+    /// (declared abstract there, alongside <see cref="RelationalBatchProviderBase.CreateBatch"/> —
+    /// the class's other genuinely dialect-specific hooks).
+    /// </summary>
+    void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId,
+        SnapToken snapToken);
 }

--- a/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
+++ b/src/Valtuutus.Data.Db/IRelationalCheckOps.cs
@@ -33,4 +33,22 @@ public interface IRelationalCheckOps
     Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation,
         string subEntityType, string computedRelation, string subjectType, string subjectId,
         SnapToken snapToken, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The boolean-combination fusion fast path: true iff the leaves in
+    /// <paramref name="leaves"/> combine — per-leaf <see cref="FusedCheckLeaf.Negate"/>, joined by
+    /// <paramref name="requireAll"/> (AND) or its negation (OR) — to true for
+    /// (<paramref name="entityType"/>, <paramref name="entityId"/>) against
+    /// (<paramref name="subjectType"/>, <paramref name="subjectId"/>). One round trip instead of
+    /// one per leaf (even batched, that's N statements in one DbBatch — this is exactly one
+    /// statement). <paramref name="subjectType"/>/<paramref name="subjectId"/> are null only when
+    /// every leaf is <see cref="FusedLeafKind.Attribute"/>/<see cref="FusedLeafKind.MultiAttribute"/>
+    /// (attributes have no subject dependency); any <see cref="FusedLeafKind.Direct"/>/
+    /// <see cref="FusedLeafKind.MultiDirect"/>/<see cref="FusedLeafKind.TupleToUserSet"/> leaf
+    /// requires both non-null (the rewriter only recognizes those leaf kinds when subjectType is
+    /// known, so this holds by construction).
+    /// </summary>
+    Task<bool> HasFusedExpression(string entityType, string entityId, IReadOnlyList<FusedCheckLeaf> leaves,
+        bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken,
+        CancellationToken cancellationToken);
 }

--- a/src/Valtuutus.Data.Db/RelationalBatchProviderBase.cs
+++ b/src/Valtuutus.Data.Db/RelationalBatchProviderBase.cs
@@ -43,6 +43,18 @@ public abstract class RelationalBatchProviderBase : IRelationalBatchOps
     protected abstract string WriteNameArrayParam(DbBatchCommand cmd, string baseName, string[] values);
 
     /// <summary>
+    /// Composes and adds the fused-expression command — unlike every other Add* member below, this
+    /// one cannot be implemented generically here: the SQL shape varies per call (leaf
+    /// count/kind/negation), so there is no single <see cref="RelationalBatchQuery"/> catalog entry
+    /// to key off. Each provider builds its own text per call via
+    /// <see cref="FusedExpressionSqlBuilder.BuildBooleanExpression"/> plus its own leaf-fragment
+    /// templates and parameter writing (see <c>PostgresBatchOps</c>/<c>SqlServerBatchOps</c>).
+    /// </summary>
+    public abstract void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId,
+        SnapToken snapToken);
+
+    /// <summary>
     /// Generic parameter append: <see cref="DbBatchCommand.CreateParameter"/> (net8+), name+value,
     /// add. The default implementation the Write*Param hooks fall back to when a provider doesn't
     /// need provider-typed parameters.

--- a/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
+++ b/src/Valtuutus.Data.Db/RelationalPlanRewriter.cs
@@ -50,6 +50,11 @@ internal sealed class RelationalPlanRewriter : IPlanRewriter
         // preserving the DAG interchange form instead of silently duplicating shared subtrees.
         private readonly Dictionary<PlanNode, PlanNode> _visited = new(ReferenceEqualityComparer.Instance);
 
+        // subjectType is fixed for a Walker's whole lifetime (one Walker per Rewrite call), so
+        // this gate is computed once and shared by GroupChildren and TryRecognizeSingleLeaf
+        // rather than recomputed as a per-call local.
+        private readonly bool directGate = !string.IsNullOrEmpty(subjectType);
+
         public PlanNode Walk(PlanNode node)
         {
             if (_visited.TryGetValue(node, out var done)) return done;
@@ -83,19 +88,71 @@ internal sealed class RelationalPlanRewriter : IPlanRewriter
         private PlanNode GroupChildren(PlanNode original, ImmutableArray<PlanNode> children, bool isUnion)
         {
             // A ref can't be both (GetRelationType resolves a name to exactly one kind), so the
-            // two collections are disjoint by construction.
-            var directGate = !string.IsNullOrEmpty(subjectType);
+            // two collections are disjoint by construction. Every child is walked FIRST (not the
+            // raw child) before classification: a nested Union/Intersect child (e.g. the
+            // "(owner or member)" in "org.admin and (owner or member)") only becomes recognizable
+            // once its own sibling-group fusion has already turned it into a
+            // PhysicalCheckNode(HasAnyOfDirectRelationsOp) — that happens inside Walk, so
+            // classification must happen after. Walk is memoized (_visited), so walking every
+            // child up front costs nothing extra when the partial-fusion path below walks
+            // survivors again.
             List<string>? relations = null;
             List<string>? attributes = null;
+            List<FusedCheckLeaf>? singleLeaves = null;
+            var fullyRecognized = true;
             foreach (var child in children)
             {
-                if (directGate && IsBatchableDirectRef(child, out var relation))
+                var walked = Walk(child);
+                if (directGate && IsBatchableDirectRef(walked, out var relation))
                     (relations ??= []).Add(relation);
-                else if (IsBatchableAttributeRef(child, out var attribute))
+                else if (IsBatchableAttributeRef(walked, out var attribute))
                     (attributes ??= []).Add(attribute);
+                // A nested FusedExpressionOp holds its own ImmutableArray<FusedCheckLeaf> rather
+                // than a single Names/RequireAll pair, so it can't go through
+                // TryRecognizeSingleLeaf's single-leaf-out contract — it contributes MANY leaves,
+                // handled here directly. Flattening is only safe when the nested op's own
+                // combinator agrees with what this outer level needs (f.RequireAll == !isUnion):
+                // an inner OR's leaves flattened into an outer AND (or vice versa) would silently
+                // change the boolean semantics. On a mismatch this child is left unrecognized —
+                // it survives as an ordinary sibling via the partial-fusion path below, still a
+                // single round trip for itself, just not folded into the outer one.
+                else if (walked is PhysicalCheckNode { Op: FusedExpressionOp f } && f.RequireAll == !isUnion)
+                    (singleLeaves ??= []).AddRange(f.Leaves);
+                else if (TryRecognizeSingleLeaf(walked, out var leaf))
+                    (singleLeaves ??= []).Add(leaf);
+                else
+                    fullyRecognized = false;
             }
 
-            // A group only fires with >= 2 members — one batchable child alone saves nothing.
+            // Full fusion: every child accounted for, and collapsing groups still leaves >= 2
+            // distinct leaves — a single already-optimal group (e.g. 3 plain direct-relation
+            // siblings, nothing else) is left to the single-group path below unchanged; wrapping
+            // it in FusedExpressionOp would gain nothing and would silently change its SQL text.
+            if (fullyRecognized)
+            {
+                var fused = ImmutableArray.CreateBuilder<FusedCheckLeaf>();
+                if (attributes is { Count: >= 2 })
+                    fused.Add(new FusedCheckLeaf(FusedLeafKind.MultiAttribute, false, attributes.ToArray(), !isUnion));
+                else if (attributes is { Count: 1 })
+                    fused.Add(new FusedCheckLeaf(FusedLeafKind.Attribute, false, [attributes[0]]));
+                if (relations is { Count: >= 2 })
+                    fused.Add(new FusedCheckLeaf(FusedLeafKind.MultiDirect, false, relations.ToArray(), !isUnion));
+                else if (relations is { Count: 1 })
+                    fused.Add(new FusedCheckLeaf(FusedLeafKind.Direct, false, [relations[0]]));
+                if (singleLeaves is not null) fused.AddRange(singleLeaves);
+
+                if (fused.Count >= 2)
+                    return new PhysicalCheckNode(new FusedExpressionOp(fused.ToImmutable(), requireAll: !isUnion));
+            }
+
+            // Partial fusion (unchanged pre-existing behavior): only the direct-relation and/or
+            // attribute sibling groups fuse (each needs >= 2 members — one batchable child alone
+            // saves nothing); everything else, including TTU/negated/nested leaves recognized
+            // above, survives as its own walked child. Note this rebuild loop still checks
+            // IsBatchableDirectRef/IsBatchableAttributeRef against the RAW child (not `walked`) —
+            // identical result for the cases that matter here (a raw direct/attribute PlanRefNode
+            // walks to itself), and Walk(child) below is a memoized re-fetch of what the
+            // classification loop above already computed, not new work.
             var fuseRelations = relations is { Count: >= 2 };
             var fuseAttributes = attributes is { Count: >= 2 };
             if (!fuseRelations && !fuseAttributes)
@@ -122,6 +179,56 @@ internal sealed class RelationalPlanRewriter : IPlanRewriter
             if (kept.Count == 1) return kept[0]; // single-survivor collapse: everything fused
             var keptArr = kept.MoveToImmutable();
             return isUnion ? new UnionNode(keptArr) : new IntersectNode(keptArr);
+        }
+
+        // Recognizes a single (non-grouped) leaf the full-fusion path above can use directly: a
+        // plan-time TTU fast-path node (eligibility already proved by PlanCompiler.PruneAndFold),
+        // an already-fused HasAnyOfDirectRelationsOp/HasAnyOfAttributesOp sibling group nested one
+        // level down (walked before this is called, so a former Union/Intersect child arrives
+        // here as a PhysicalCheckNode if its own children partially fused), or a Negate over any
+        // of those / a direct-relation ref / an attribute ref. Non-negated direct-relation/
+        // attribute refs are handled by IsBatchableDirectRef/IsBatchableAttributeRef above (they
+        // feed the sibling-group lists, not this method) — this method only covers what those two
+        // do not. A nested PhysicalCheckNode { Op: FusedExpressionOp } is NOT handled here:
+        // it needs to contribute MULTIPLE leaves to the outer fusion (not one opaque leaf), which
+        // this method's single-leaf-out signature can't express — GroupChildren's classification
+        // loop checks for and flattens that case itself, before ever calling this method.
+        private bool TryRecognizeSingleLeaf(PlanNode node, out FusedCheckLeaf leaf)
+        {
+            switch (node)
+            {
+                case TupleToUserSetNode { FastPathSubEntityType: not null } t:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, false,
+                        [t.TuplesetRelation], TtuSubEntityType: t.FastPathSubEntityType, TtuComputedRelation: t.ComputedRelation);
+                    return true;
+                case PhysicalCheckNode { Op: HasAnyOfDirectRelationsOp d }:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.MultiDirect, false, d.Relations, d.RequireAll);
+                    return true;
+                case PhysicalCheckNode { Op: HasAnyOfAttributesOp a }:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.MultiAttribute, false, a.Attributes, a.RequireAll);
+                    return true;
+                case NegateNode { Child: PlanRefNode p } when directGate
+                        && schema.GetRelationType(entityType, p.Permission) == RelationType.DirectRelation
+                        && !schema.GetRelation(entityType, p.Permission).HasSubRelationPaths:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.Direct, true, [p.Permission]);
+                    return true;
+                case NegateNode { Child: PlanRefNode p2 } when schema.GetRelationType(entityType, p2.Permission) == RelationType.Attribute:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.Attribute, true, [p2.Permission]);
+                    return true;
+                case NegateNode { Child: TupleToUserSetNode { FastPathSubEntityType: not null } t2 }:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, true,
+                        [t2.TuplesetRelation], TtuSubEntityType: t2.FastPathSubEntityType, TtuComputedRelation: t2.ComputedRelation);
+                    return true;
+                case NegateNode { Child: PhysicalCheckNode { Op: HasAnyOfDirectRelationsOp d2 } }:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.MultiDirect, true, d2.Relations, d2.RequireAll);
+                    return true;
+                case NegateNode { Child: PhysicalCheckNode { Op: HasAnyOfAttributesOp a2 } }:
+                    leaf = new FusedCheckLeaf(FusedLeafKind.MultiAttribute, true, a2.Attributes, a2.RequireAll);
+                    return true;
+                default:
+                    leaf = null!;
+                    return false;
+            }
         }
 
         private PlanNode RebuildIfChanged(PlanNode original, ImmutableArray<PlanNode> children, bool isUnion)

--- a/src/Valtuutus.Data.Postgres/FusedExpressionSql.cs
+++ b/src/Valtuutus.Data.Postgres/FusedExpressionSql.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using Npgsql;
+using NpgsqlTypes;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Postgres;
+
+// Shared by PostgresDataReaderProvider.HasFusedExpression and
+// PostgresBatchOps.AddHasFusedExpressionToBatch: both paths build the per-leaf fragment and
+// parameters from here, so they can never drift apart.
+internal static class FusedExpressionSql
+{
+    // Keyed by the leaves list's own reference identity — stable for a FusedExpressionOp's whole
+    // lifetime (constructed once per compiled plan, reused across every Check against that plan) —
+    // so the full command text is built once per distinct fused shape instead of being
+    // re-interpolated from scratch on every request. ConditionalWeakTable ties each cached entry's
+    // lifetime to the leaves list's own (no manual eviction needed when a plan is GC'd).
+    private static readonly ConditionalWeakTable<IReadOnlyList<FusedCheckLeaf>, string> CommandSqlCache = new();
+
+    internal static string BuildCommandSql(IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll,
+        string relationsTable, string attributesTable)
+    {
+        if (CommandSqlCache.TryGetValue(leaves, out var cached)) return cached;
+        var expr = FusedExpressionSqlBuilder.BuildBooleanExpression(leaves, requireAll,
+            (leaf, i) => LeafFragment(leaf, i, relationsTable, attributesTable));
+        var sql = $"SELECT {expr}";
+        CommandSqlCache.AddOrUpdate(leaves, sql);
+        return sql;
+    }
+
+    internal static string LeafFragment(FusedCheckLeaf leaf, int i, string relationsTable, string attributesTable) => leaf.Kind switch
+    {
+        FusedLeafKind.Direct =>
+            $"EXISTS(SELECT 1 FROM {relationsTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND relation = @relation_{i} AND subject_id = @subject_id AND subject_relation = '')",
+        FusedLeafKind.MultiDirect when !leaf.RequireAll =>
+            $"EXISTS(SELECT 1 FROM {relationsTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND relation = ANY(@relations_{i}) AND subject_id = @subject_id AND subject_relation = '')",
+        FusedLeafKind.MultiDirect =>
+            $"(SELECT COUNT(DISTINCT relation) FROM {relationsTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND relation = ANY(@relations_{i}) AND subject_id = @subject_id AND subject_relation = '') = {leaf.Names.Length}",
+        FusedLeafKind.Attribute =>
+            $"EXISTS(SELECT 1 FROM {attributesTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND attribute = @attribute_{i} AND value = 'true'::jsonb)",
+        FusedLeafKind.MultiAttribute when !leaf.RequireAll =>
+            $"EXISTS(SELECT 1 FROM {attributesTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND attribute = ANY(@attributes_{i}) AND value = 'true'::jsonb)",
+        FusedLeafKind.MultiAttribute =>
+            $"(SELECT COUNT(DISTINCT attribute) FROM {attributesTable} WHERE {PostgresDataReaderProvider.SnapTokenPredicate} AND entity_type = @entity_type AND entity_id = @entity_id AND attribute = ANY(@attributes_{i}) AND value = 'true'::jsonb) = {leaf.Names.Length}",
+        FusedLeafKind.TupleToUserSet => $"""
+            EXISTS(
+                SELECT 1 FROM {relationsTable} r_main_{i}
+                INNER JOIN {relationsTable} r_dep_{i}
+                    ON r_dep_{i}.entity_type = r_main_{i}.subject_type AND r_dep_{i}.entity_id = r_main_{i}.subject_id
+                WHERE r_main_{i}.created_tx_id <= @snap_token AND (r_main_{i}.deleted_tx_id IS NULL OR r_main_{i}.deleted_tx_id > @snap_token)
+                  AND r_main_{i}.entity_type = @entity_type
+                  AND r_main_{i}.entity_id = @entity_id
+                  AND r_main_{i}.relation = @tuple_set_relation_{i}
+                  AND r_main_{i}.subject_relation = ''
+                  AND r_dep_{i}.created_tx_id <= @snap_token AND (r_dep_{i}.deleted_tx_id IS NULL OR r_dep_{i}.deleted_tx_id > @snap_token)
+                  AND r_dep_{i}.relation = @computed_relation_{i}
+                  AND r_dep_{i}.subject_type = @subject_type
+                  AND r_dep_{i}.subject_id = @subject_id
+                  AND r_dep_{i}.subject_relation = ''
+            )
+            """,
+        _ => throw new ArgumentOutOfRangeException(nameof(leaf.Kind), leaf.Kind, null),
+    };
+
+    internal static void WriteLeafParameters(NpgsqlParameterCollection parameters, FusedCheckLeaf leaf, int i)
+    {
+        switch (leaf.Kind)
+        {
+            case FusedLeafKind.Direct:
+                PostgresDataReaderProvider.AddStringParameter(parameters, $"relation_{i}", leaf.Names[0], 64);
+                break;
+            case FusedLeafKind.MultiDirect:
+                parameters.Add(new NpgsqlParameter<string[]>($"relations_{i}", NpgsqlDbType.Array | NpgsqlDbType.Varchar) { TypedValue = leaf.Names });
+                break;
+            case FusedLeafKind.Attribute:
+                PostgresDataReaderProvider.AddStringParameter(parameters, $"attribute_{i}", leaf.Names[0], 64);
+                break;
+            case FusedLeafKind.MultiAttribute:
+                parameters.Add(new NpgsqlParameter<string[]>($"attributes_{i}", NpgsqlDbType.Array | NpgsqlDbType.Varchar) { TypedValue = leaf.Names });
+                break;
+            case FusedLeafKind.TupleToUserSet:
+                PostgresDataReaderProvider.AddStringParameter(parameters, $"tuple_set_relation_{i}", leaf.Names[0], 64);
+                PostgresDataReaderProvider.AddStringParameter(parameters, $"computed_relation_{i}", leaf.TtuComputedRelation!, 64);
+                break;
+        }
+    }
+}

--- a/src/Valtuutus.Data.Postgres/PostgresBatchOps.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresBatchOps.cs
@@ -91,6 +91,22 @@ public sealed class PostgresBatchOps : RelationalBatchProviderBase, IDisposable
     protected override void WriteSnapTokenParam(DbBatchCommand cmd, string name, SnapToken snapToken)
         => PostgresDataReaderProvider.AddFixedCharParameter(Parameters(cmd), name, snapToken.Value, 26);
 
+    /// <inheritdoc />
+    public override void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken)
+    {
+        var sql = FusedExpressionSql.BuildCommandSql(leaves, requireAll, _q.RelationsTable, _q.AttributesTable);
+        var cmd = NewCommand(batch, sql);
+        var parameters = Parameters(cmd);
+        PostgresDataReaderProvider.AddStringParameter(parameters, "entity_type", entityType, 256);
+        PostgresDataReaderProvider.AddStringParameter(parameters, "entity_id", entityId, 64);
+        if (subjectType is not null) PostgresDataReaderProvider.AddStringParameter(parameters, "subject_type", subjectType, 256);
+        if (subjectId is not null) PostgresDataReaderProvider.AddStringParameter(parameters, "subject_id", subjectId, 64);
+        PostgresDataReaderProvider.AddFixedCharParameter(parameters, "snap_token", snapToken.Value, 26);
+        for (var i = 0; i < leaves.Count; i++)
+            FusedExpressionSql.WriteLeafParameters(parameters, leaves[i], i);
+    }
+
     // DbBatchCommand's declared type is the ADO-abstract one, but every batch this class hands out
     // (CreateBatch) comes from NpgsqlDataSource.CreateBatch(), so the command the base class
     // creates from it is always a genuine NpgsqlBatchCommand (Npgsql overrides the protected

--- a/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
+++ b/src/Valtuutus.Data.Postgres/PostgresDataReaderProvider.cs
@@ -31,13 +31,18 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                 FROM {0}.{1} /**where**/";
 
     private const string UnformattedExistsRelation = "SELECT EXISTS(SELECT 1 FROM {0}.{1} /**where**/)";
-    private const string SnapTokenPredicate = "created_tx_id <= @snap_token AND (deleted_tx_id IS NULL OR deleted_tx_id > @snap_token)";
+    // Internal (not private): FusedExpressionSql builds fused-expression fragments for both this
+    // class's HasFusedExpression and PostgresBatchOps.AddHasFusedExpressionToBatch, and needs the
+    // exact same snap-token predicate text those queries use.
+    internal const string SnapTokenPredicate = "created_tx_id <= @snap_token AND (deleted_tx_id IS NULL OR deleted_tx_id > @snap_token)";
 
     // Internal (not private): PostgresBatchOps' dialect catalog serves the exact same SQL text as
     // these single-op queries — one definition, shared through GetQueries, so the two paths can
     // never drift apart (and the server's prepared-statement cache sees one statement, not two).
     internal sealed record ReaderQueries
     {
+        public required string RelationsTable { get; init; }
+        public required string AttributesTable { get; init; }
         public required string SelectAttributes { get; init; }
         public required string SelectRelations { get; init; }
         public required string GetLatestSnapToken { get; init; }
@@ -195,6 +200,8 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
 
         return new ReaderQueries
         {
+            RelationsTable = relationsTable,
+            AttributesTable = attributesTable,
             SelectAttributes = selectAttributes,
             SelectRelations = selectRelations,
             GetLatestSnapToken = $"SELECT id FROM {key.Schema}.{key.TransactionsTable} ORDER BY id DESC LIMIT 1",
@@ -1157,6 +1164,32 @@ public class PostgresDataReaderProvider : RateLimiterExecuter, IDataReaderProvid
                 computedRelation, subjectType, subjectId, snapToken);
 
             return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
+    public async Task<bool> HasFusedExpression(string entityType, string entityId, IReadOnlyList<FusedCheckLeaf> leaves,
+        bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.InternalSourceInstance.StartActivity();
+        await EnterQuery(cancellationToken);
+        try
+        {
+            var sql = FusedExpressionSql.BuildCommandSql(leaves, requireAll, _q.RelationsTable, _q.AttributesTable);
+            await using var command = _hotPathDataSource.CreateCommand(sql);
+            AddStringParameter(command.Parameters, "entity_type", entityType, 256);
+            AddStringParameter(command.Parameters, "entity_id", entityId, 64);
+            if (subjectType is not null) AddStringParameter(command.Parameters, "subject_type", subjectType, 256);
+            if (subjectId is not null) AddStringParameter(command.Parameters, "subject_id", subjectId, 64);
+            AddFixedCharParameter(command.Parameters, "snap_token", snapToken.Value, 26);
+            for (var i = 0; i < leaves.Count; i++)
+                FusedExpressionSql.WriteLeafParameters(command.Parameters, leaves[i], i);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            return await reader.ReadAsync(cancellationToken) && reader.GetBoolean(0);
         }
         finally
         {

--- a/src/Valtuutus.Data.SqlServer/FusedExpressionSql.cs
+++ b/src/Valtuutus.Data.SqlServer/FusedExpressionSql.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Data.SqlClient;
+using Valtuutus.Data.Db;
+using Valtuutus.Data.SqlServer.Utils;
+
+namespace Valtuutus.Data.SqlServer;
+
+// Shared by SqlServerDataReaderProvider.HasFusedExpression and
+// SqlServerBatchOps.AddHasFusedExpressionToBatch: both paths build the per-leaf fragment and
+// parameters from here, so they can never drift apart.
+internal static class FusedExpressionSql
+{
+    // Keyed by the leaves list's own reference identity — stable for a FusedExpressionOp's whole
+    // lifetime (constructed once per compiled plan, reused across every Check against that plan) —
+    // so the full command text is built once per distinct fused shape instead of being
+    // re-interpolated from scratch on every request. ConditionalWeakTable ties each cached entry's
+    // lifetime to the leaves list's own (no manual eviction needed when a plan is GC'd).
+    private static readonly ConditionalWeakTable<IReadOnlyList<FusedCheckLeaf>, string> CommandSqlCache = new();
+
+    internal static string BuildCommandSql(IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll,
+        string relationsTable, string attributesTable)
+    {
+        if (CommandSqlCache.TryGetValue(leaves, out var cached)) return cached;
+        var expr = FusedExpressionSqlBuilder.BuildBooleanExpression(leaves, requireAll,
+            (leaf, i) => LeafFragment(leaf, i, relationsTable, attributesTable));
+        var sql = $"SELECT CASE WHEN {expr} THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END";
+        CommandSqlCache.AddOrUpdate(leaves, sql);
+        return sql;
+    }
+
+    internal static string LeafFragment(FusedCheckLeaf leaf, int i, string relationsTable, string attributesTable) => leaf.Kind switch
+    {
+        FusedLeafKind.Direct =>
+            $"EXISTS(SELECT 1 FROM {relationsTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND relation = @Relation_{i} AND subject_id = @SubjectId AND subject_relation = '')",
+        FusedLeafKind.MultiDirect when !leaf.RequireAll =>
+            $"EXISTS(SELECT 1 FROM {relationsTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND relation IN (SELECT id FROM @Relations_{i}) AND subject_id = @SubjectId AND subject_relation = '')",
+        FusedLeafKind.MultiDirect =>
+            $"(SELECT COUNT(DISTINCT relation) FROM {relationsTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND relation IN (SELECT id FROM @Relations_{i}) AND subject_id = @SubjectId AND subject_relation = '') = {leaf.Names.Length}",
+        FusedLeafKind.Attribute =>
+            $"EXISTS(SELECT 1 FROM {attributesTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND attribute = @Attribute_{i} AND value = 'true')",
+        FusedLeafKind.MultiAttribute when !leaf.RequireAll =>
+            $"EXISTS(SELECT 1 FROM {attributesTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND attribute IN (SELECT id FROM @Attributes_{i}) AND value = 'true')",
+        FusedLeafKind.MultiAttribute =>
+            $"(SELECT COUNT(DISTINCT attribute) FROM {attributesTable} WHERE {SqlServerDataReaderProvider.SnapPredicate} AND entity_type = @EntityType AND entity_id = @EntityId AND attribute IN (SELECT id FROM @Attributes_{i}) AND value = 'true') = {leaf.Names.Length}",
+        FusedLeafKind.TupleToUserSet => $"""
+            EXISTS(
+                SELECT 1 FROM {relationsTable} r_main_{i}
+                INNER JOIN {relationsTable} r_dep_{i}
+                    ON r_dep_{i}.entity_type = r_main_{i}.subject_type AND r_dep_{i}.entity_id = r_main_{i}.subject_id
+                WHERE r_main_{i}.created_tx_id <= @SnapToken AND (r_main_{i}.deleted_tx_id IS NULL OR r_main_{i}.deleted_tx_id > @SnapToken)
+                  AND r_main_{i}.entity_type = @EntityType
+                  AND r_main_{i}.entity_id = @EntityId
+                  AND r_main_{i}.relation = @TupleSetRelation_{i}
+                  AND r_main_{i}.subject_relation = ''
+                  AND r_dep_{i}.created_tx_id <= @SnapToken AND (r_dep_{i}.deleted_tx_id IS NULL OR r_dep_{i}.deleted_tx_id > @SnapToken)
+                  AND r_dep_{i}.relation = @ComputedRelation_{i}
+                  AND r_dep_{i}.subject_type = @SubjectType
+                  AND r_dep_{i}.subject_id = @SubjectId
+                  AND r_dep_{i}.subject_relation = ''
+            )
+            """,
+        _ => throw new ArgumentOutOfRangeException(nameof(leaf.Kind), leaf.Kind, null),
+    };
+
+    internal static void WriteLeafParameters(SqlParameterCollection parameters, FusedCheckLeaf leaf, int i, string tvpListIdsTypeName)
+    {
+        switch (leaf.Kind)
+        {
+            case FusedLeafKind.Direct:
+                SqlServerDataReaderProvider.AddStringParameter(parameters, $"@Relation_{i}", leaf.Names[0], 64);
+                break;
+            case FusedLeafKind.MultiDirect:
+                TvpHelper.AsTvpParameter(leaf.Names, tvpListIdsTypeName).AddParameter(parameters, $"@Relations_{i}");
+                break;
+            case FusedLeafKind.Attribute:
+                SqlServerDataReaderProvider.AddStringParameter(parameters, $"@Attribute_{i}", leaf.Names[0], 64);
+                break;
+            case FusedLeafKind.MultiAttribute:
+                TvpHelper.AsTvpParameter(leaf.Names, tvpListIdsTypeName).AddParameter(parameters, $"@Attributes_{i}");
+                break;
+            case FusedLeafKind.TupleToUserSet:
+                SqlServerDataReaderProvider.AddStringParameter(parameters, $"@TupleSetRelation_{i}", leaf.Names[0], 64);
+                SqlServerDataReaderProvider.AddStringParameter(parameters, $"@ComputedRelation_{i}", leaf.TtuComputedRelation!, 64);
+                break;
+        }
+    }
+}

--- a/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerBatchOps.cs
@@ -149,6 +149,22 @@ public sealed class SqlServerBatchOps : RelationalBatchProviderBase, IDisposable
         _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unmapped batch parameter name."),
     };
 
+    /// <inheritdoc />
+    public override void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken)
+    {
+        var sql = FusedExpressionSql.BuildCommandSql(leaves, requireAll, _q.RelationsTable, _q.AttributesTable);
+        var cmd = NewCommand(batch, sql);
+        var parameters = Parameters(cmd);
+        SqlServerDataReaderProvider.AddStringParameter(parameters, "@EntityType", entityType, 256);
+        SqlServerDataReaderProvider.AddStringParameter(parameters, "@EntityId", entityId, 64);
+        if (subjectType is not null) SqlServerDataReaderProvider.AddStringParameter(parameters, "@SubjectType", subjectType, 256);
+        if (subjectId is not null) SqlServerDataReaderProvider.AddStringParameter(parameters, "@SubjectId", subjectId, 64);
+        SqlServerDataReaderProvider.AddFixedCharParameter(parameters, "@SnapToken", snapToken.Value, 26);
+        for (var i = 0; i < leaves.Count; i++)
+            FusedExpressionSql.WriteLeafParameters(parameters, leaves[i], i, _q.TvpListIdsTypeName);
+    }
+
     // DbBatchCommand's declared type is the ADO-abstract one, but every batch this class hands out
     // (CreateBatch) comes from SqlConnection.CreateBatch(), so the command the base class creates
     // from it is always a genuine SqlBatchCommand (Microsoft.Data.SqlClient overrides the

--- a/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
+++ b/src/Valtuutus.Data.SqlServer/SqlServerDataReaderProvider.cs
@@ -14,6 +14,11 @@ namespace Valtuutus.Data.SqlServer;
 
 public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvider, IRelationalCheckOps
 {
+    // Internal (not private): FusedExpressionSql builds fused-expression fragments for both this
+    // class's HasFusedExpression and SqlServerBatchOps.AddHasFusedExpressionToBatch, and needs the
+    // exact same snap-token predicate text those queries use.
+    internal const string SnapPredicate = "created_tx_id <= @SnapToken AND (deleted_tx_id IS NULL OR deleted_tx_id > @SnapToken)";
+
     private readonly DbConnectionFactory _connectionFactory;
 
     private static readonly ConcurrentDictionary<DbQueryCacheKey, ReaderQueries> QueryCache = new();
@@ -102,10 +107,12 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
     {
         var relationsTable = $"[{key.Schema}].[{key.RelationsTable}]";
         var attributesTable = $"[{key.Schema}].[{key.AttributesTable}]";
-        const string snapPredicate = "created_tx_id <= @SnapToken AND (deleted_tx_id IS NULL OR deleted_tx_id > @SnapToken)";
+        var snapPredicate = SnapPredicate;
 
         return new ReaderQueries
         {
+            RelationsTable = relationsTable,
+            AttributesTable = attributesTable,
             TvpListIdsTypeName = SqlBuilderExtensions.FormatTvpListIdsName(key.Schema),
             GetLatestSnapToken = string.Format(
                 "SELECT TOP 1 id FROM [{0}].[{1}] ORDER BY id DESC", key.Schema, key.TransactionsTable),
@@ -484,6 +491,8 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
     // can never drift apart.
     internal sealed record ReaderQueries
     {
+        public required string RelationsTable { get; init; }
+        public required string AttributesTable { get; init; }
         public required string TvpListIdsTypeName { get; init; }
         public required string GetLatestSnapToken { get; init; }
         public required string GetAttribute { get; init; }
@@ -1441,6 +1450,34 @@ public class SqlServerDataReaderProvider : RateLimiterExecuter, IDataReaderProvi
             await using var command = CreateCommand(connection, _q.HasUsersetJoinRelation);
             PopulateHasUsersetJoinRelationCommand(command.Parameters, entityType, entityId, relation,
                 computedRelation, subjectType, subjectId, snapToken);
+
+            return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
+        }
+        finally
+        {
+            Semaphore.Release();
+        }
+    }
+
+    public async Task<bool> HasFusedExpression(string entityType, string entityId, IReadOnlyList<FusedCheckLeaf> leaves,
+        bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        using var activity = DefaultActivitySource.Instance.StartActivity();
+        await EnterQuery(cancellationToken);
+        try
+        {
+            var sql = FusedExpressionSql.BuildCommandSql(leaves, requireAll, _q.RelationsTable, _q.AttributesTable);
+            await using var connection = (SqlConnection)_connectionFactory();
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = CreateCommand(connection, sql);
+            AddStringParameter(command.Parameters, "@EntityType", entityType, 256);
+            AddStringParameter(command.Parameters, "@EntityId", entityId, 64);
+            if (subjectType is not null) AddStringParameter(command.Parameters, "@SubjectType", subjectType, 256);
+            if (subjectId is not null) AddStringParameter(command.Parameters, "@SubjectId", subjectId, 64);
+            AddFixedCharParameter(command.Parameters, "@SnapToken", snapToken.Value, 26);
+            for (var i = 0; i < leaves.Count; i++)
+                FusedExpressionSql.WriteLeafParameters(command.Parameters, leaves[i], i, _q.TvpListIdsTypeName);
 
             return (bool)(await command.ExecuteScalarAsync(cancellationToken) ?? false);
         }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.DotNet9_0.verified.txt
@@ -34,6 +34,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -54,6 +76,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -64,6 +87,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -82,6 +106,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet10_0.verified.txt
@@ -34,6 +34,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -54,6 +76,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -64,6 +87,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -82,6 +106,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.DotNet9_0.verified.txt
@@ -34,6 +34,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -54,6 +76,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -64,6 +87,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -82,6 +106,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet11_0.verified.txt
@@ -34,6 +34,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -54,6 +76,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -64,6 +87,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -82,6 +106,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet8_0.verified.txt
@@ -33,6 +33,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -53,6 +75,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -63,6 +86,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -81,6 +105,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveDataDb.DotNet9_0.verified.txt
@@ -33,6 +33,28 @@ namespace Valtuutus.Data.Db
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbSetup(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, Valtuutus.Data.Db.DbConnectionFactory> factory, Valtuutus.Data.Db.IValtuutusDbOptions options) { }
     }
+    public sealed class FusedCheckLeaf : System.IEquatable<Valtuutus.Data.Db.FusedCheckLeaf>
+    {
+        public FusedCheckLeaf(Valtuutus.Data.Db.FusedLeafKind Kind, bool Negate, string[] Names, bool RequireAll = false, string? TtuSubEntityType = null, string? TtuComputedRelation = null) { }
+        public Valtuutus.Data.Db.FusedLeafKind Kind { get; init; }
+        public string[] Names { get; init; }
+        public bool Negate { get; init; }
+        public bool RequireAll { get; init; }
+        public string? TtuComputedRelation { get; init; }
+        public string? TtuSubEntityType { get; init; }
+    }
+    public static class FusedExpressionSqlBuilder
+    {
+        public static string BuildBooleanExpression(System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, System.Func<Valtuutus.Data.Db.FusedCheckLeaf, int, string> fragment) { }
+    }
+    public enum FusedLeafKind
+    {
+        Direct = 0,
+        MultiDirect = 1,
+        Attribute = 2,
+        MultiAttribute = 3,
+        TupleToUserSet = 4,
+    }
     public interface IBatchableCheckOp
     {
         void AddToBatch(System.Data.Common.DbBatch batch, Valtuutus.Data.Db.IRelationalBatchOps ops, Valtuutus.Core.Engines.Check.CheckRequestContext ctx, string entityType, string entityId);
@@ -53,6 +75,7 @@ namespace Valtuutus.Data.Db
         void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId);
+        void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken);
@@ -63,6 +86,7 @@ namespace Valtuutus.Data.Db
     {
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken);
     }
     public interface IValtuutusDbOptions
@@ -81,6 +105,7 @@ namespace Valtuutus.Data.Db
         public virtual void AddHasAnyOfAttributesToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasAnyOfDirectRelationsToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasDirectRelationToBatch(System.Data.Common.DbBatch batch, Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId) { }
+        public abstract void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken);
         public virtual void AddHasTrueBoolAttributeToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasTupleToUserSetRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public virtual void AddHasUsersetJoinRelationToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.DotNet9_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet10_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.DotNet9_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet11_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet8_0.verified.txt
@@ -10,6 +10,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -49,6 +50,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApprovePostgres.DotNet9_0.verified.txt
@@ -10,6 +10,7 @@ namespace Valtuutus.Data.Postgres
     public sealed class PostgresBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public PostgresBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Postgres.ValtuutusPostgresOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -49,6 +50,7 @@ namespace Valtuutus.Data.Postgres
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.DotNet9_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet10_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.DotNet9_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet11_0.verified.txt
@@ -11,6 +11,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -50,6 +51,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet8_0.verified.txt
@@ -10,6 +10,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -49,6 +50,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveSqlServer.DotNet9_0.verified.txt
@@ -10,6 +10,7 @@ namespace Valtuutus.Data.SqlServer
     public sealed class SqlServerBatchOps : Valtuutus.Data.Db.RelationalBatchProviderBase, System.IDisposable
     {
         public SqlServerBatchOps(Valtuutus.Data.Db.DbConnectionFactory connectionFactory, Valtuutus.Data.ValtuutusDataOptions options, Valtuutus.Data.Db.IValtuutusDbOptions dbOptions) { }
+        public override void AddHasFusedExpressionToBatch(System.Data.Common.DbBatch batch, string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken) { }
         public override System.Data.Common.DbBatch CreateBatch() { }
         public void Dispose() { }
         public override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteBatchAsync(System.Data.Common.DbBatch batch, System.Threading.CancellationToken cancellationToken) { }
@@ -49,6 +50,7 @@ namespace Valtuutus.Data.SqlServer
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfAttributes(string entityType, string entityId, string[] attributeNames, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.HashSet<string>> HasAnyOfDirectRelations(string entityType, string entityId, string[] relationNames, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasDirectRelation(Valtuutus.Core.Data.RelationTupleFilter tupleFilter, string subjectId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<bool> HasFusedExpression(string entityType, string entityId, System.Collections.Generic.IReadOnlyList<Valtuutus.Data.Db.FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTrueBoolAttribute(string entityType, string entityId, string attribute, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasTupleToUserSetRelation(string entityType, string entityId, string tupleSetRelation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<bool> HasUsersetJoinRelation(string entityType, string entityId, string relation, string subEntityType, string computedRelation, string subjectType, string subjectId, Valtuutus.Core.Data.SnapToken snapToken, System.Threading.CancellationToken cancellationToken) { }

--- a/tests/Valtuutus.Data.Db.Tests/FusedExpressionOpBatchSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/FusedExpressionOpBatchSpecs.cs
@@ -1,0 +1,56 @@
+using System.Collections.Immutable;
+using System.Data.Common;
+using FluentAssertions;
+using NSubstitute;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+// Covers FusedExpressionOp's IBatchableCheckOp side (AddToBatch / ReadResultAsync) — the
+// Execute-based ICheckOp path is already covered by FusedExpressionOpSpecs.
+public class FusedExpressionOpBatchSpecs
+{
+    private static CheckRequestContext Ctx() => new()
+    {
+        SubjectType = "user", SubjectId = "u1",
+        SnapToken = new SnapToken("00000000000000000000000001"),
+        Context = new Dictionary<string, object>()
+    };
+
+    private static readonly ImmutableArray<FusedCheckLeaf> Leaves =
+    [
+        new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, Negate: false, ["org"], TtuSubEntityType: "organization", TtuComputedRelation: "admin"),
+        new FusedCheckLeaf(FusedLeafKind.Direct, Negate: false, ["owner"]),
+    ];
+
+    [Fact]
+    public void AddToBatch_delegates_to_the_matching_IRelationalBatchOps_method_with_its_own_arguments()
+    {
+        var op = new FusedExpressionOp(Leaves, requireAll: false);
+        var ops = Substitute.For<IRelationalBatchOps>();
+        var batch = Substitute.For<DbBatch>();
+        var ctx = Ctx();
+
+        op.AddToBatch(batch, ops, ctx, "team", "1");
+
+        ops.Received(1).AddHasFusedExpressionToBatch(
+            batch, "team", "1", Leaves, false, "user", "u1", ctx.SnapToken);
+    }
+
+    [Fact]
+    public async Task ReadResultAsync_reports_true_only_when_a_row_comes_back_true()
+    {
+        var op = new FusedExpressionOp(Leaves, requireAll: false);
+        var sink = new RecordingSink();
+
+        await op.ReadResultAsync(new FakeBoolResultReader(true), token: 7, sink, default);
+        await op.ReadResultAsync(new FakeBoolResultReader(false), token: 9, sink, default);
+        await op.ReadResultAsync(new FakeBoolResultReader(null), token: 11, sink, default); // no rows
+
+        sink.Completed.Should().ContainSingle(c => c.Token == 7 && c.Result);
+        sink.Completed.Should().ContainSingle(c => c.Token == 9 && !c.Result);
+        sink.Completed.Should().ContainSingle(c => c.Token == 11 && !c.Result);
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/FusedExpressionOpSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/FusedExpressionOpSpecs.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using FluentAssertions;
+using NSubstitute;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+public class FusedExpressionOpSpecs
+{
+    private static CheckRequestContext Ctx() => new()
+    {
+        SubjectType = "user", SubjectId = "u1",
+        SnapToken = new SnapToken("00000000000000000000000001"),
+        Context = new Dictionary<string, object>()
+    };
+
+    private static readonly ImmutableArray<FusedCheckLeaf> Leaves =
+    [
+        new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, Negate: false, ["org"], TtuSubEntityType: "organization", TtuComputedRelation: "admin"),
+        new FusedCheckLeaf(FusedLeafKind.Direct, Negate: false, ["owner"]),
+    ];
+
+    private static IDataReaderProvider RelationalReader(bool result)
+    {
+        var reader = Substitute.For<IDataReaderProvider, IRelationalCheckOps>();
+        ((IRelationalCheckOps)reader).HasFusedExpression(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<FusedCheckLeaf>>(), Arg.Any<bool>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SnapToken>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+        return reader;
+    }
+
+    [Fact]
+    public async Task Execute_returns_the_relational_reader_result_unchanged()
+    {
+        var op = new FusedExpressionOp(Leaves, requireAll: false);
+        (await op.Execute(RelationalReader(true), Ctx(), "team", "1", default)).Should().BeTrue();
+        (await op.Execute(RelationalReader(false), Ctx(), "team", "1", default)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Execute_passes_constructor_args_and_context_through()
+    {
+        var op = new FusedExpressionOp(Leaves, requireAll: false);
+        var reader = RelationalReader(true);
+        var ctx = Ctx();
+
+        await op.Execute(reader, ctx, "team", "1", default);
+
+        ((IRelationalCheckOps)reader).Received(1).HasFusedExpression(
+            "team", "1", Leaves, false, "user", "u1", ctx.SnapToken, default);
+    }
+
+    [Fact]
+    public async Task Non_relational_reader_fails_with_a_pointed_message()
+    {
+        var op = new FusedExpressionOp(Leaves, requireAll: false);
+        var reader = Substitute.For<IDataReaderProvider>(); // no IRelationalCheckOps
+        var act = () => op.Execute(reader, Ctx(), "team", "1", default).AsTask();
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*IRelationalCheckOps*");
+    }
+
+    [Fact]
+    public void Describe_renders_every_leaf_kind_and_negation()
+    {
+        var leaves = ImmutableArray.Create(
+            new FusedCheckLeaf(FusedLeafKind.MultiDirect, Negate: false, ["owner", "member"], RequireAll: true),
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: true, ["banned"]));
+        var op = new FusedExpressionOp(leaves, requireAll: true);
+        op.Describe().Should().Be("FusedExpression([MultiDirect([owner, member], all), not Direct(banned)], all)");
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/FusedExpressionSqlBuilderSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/FusedExpressionSqlBuilderSpecs.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Valtuutus.Data.Db;
+
+namespace Valtuutus.Data.Db.Tests;
+
+public class FusedExpressionSqlBuilderSpecs
+{
+    [Fact]
+    public void Joins_leaves_with_or_for_any_semantics()
+    {
+        var leaves = new[]
+        {
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: false, ["owner"]),
+            new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, Negate: false, ["org"], TtuSubEntityType: "organization", TtuComputedRelation: "admin"),
+        };
+        var sql = FusedExpressionSqlBuilder.BuildBooleanExpression(leaves, requireAll: false,
+            (leaf, i) => $"FRAG_{leaf.Kind}_{i}");
+        sql.Should().Be("(FRAG_Direct_0 OR FRAG_TupleToUserSet_1)");
+    }
+
+    [Fact]
+    public void Joins_leaves_with_and_for_all_semantics()
+    {
+        var leaves = new[]
+        {
+            new FusedCheckLeaf(FusedLeafKind.MultiDirect, Negate: false, ["owner", "member"], RequireAll: true),
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: true, ["banned"]),
+        };
+        var sql = FusedExpressionSqlBuilder.BuildBooleanExpression(leaves, requireAll: true,
+            (leaf, i) => $"FRAG_{i}");
+        sql.Should().Be("(FRAG_0 AND NOT FRAG_1)");
+    }
+
+    [Fact]
+    public void Wraps_negated_leaf_regardless_of_position()
+    {
+        var leaves = new[]
+        {
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: true, ["a"]),
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: false, ["b"]),
+            new FusedCheckLeaf(FusedLeafKind.Direct, Negate: true, ["c"]),
+        };
+        var sql = FusedExpressionSqlBuilder.BuildBooleanExpression(leaves, requireAll: false,
+            (leaf, i) => $"F{i}");
+        sql.Should().Be("(NOT F0 OR F1 OR NOT F2)");
+    }
+}

--- a/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/RelationalPlanRewriterSpecs.cs
@@ -118,24 +118,24 @@ public class RelationalPlanRewriterSpecs
     }
 
     [Fact]
-    public void Mixed_children_partial_fusion()
+    public void Full_fusion_when_every_child_is_recognizable()
     {
-        // Two batchable refs + one TTU: the refs fuse, the TTU child survives — fused node
-        // first, then the non-batchable children in their original order, reference-identical.
-        var rewritten = Rewrite(Parse(HouseholdSchema), "household", "mixed", "user", out var compiledRoot);
-        var union = rewritten.Should().BeOfType<UnionNode>().Subject;
-        union.Children.Should().HaveCount(2);
-        union.Children[0].Should().BeOfType<PhysicalCheckNode>()
-            .Which.Op.Describe().Should().Be("HasAnyOfDirectRelations([owner, admin], any)");
-        var originalTtu = compiledRoot.Should().BeOfType<UnionNode>().Subject.Children[^1];
-        union.Children[1].Should().BeSameAs(originalTtu).And.BeOfType<TupleToUserSetNode>();
+        // household.mixed := owner or admin or parent.admin — owner/admin group into MultiDirect,
+        // parent.admin is TTU-fast-path-eligible (organization.admin is a direct relation
+        // admitting user) — every child recognized, 2 leaves, so the WHOLE union fuses, not just
+        // the direct-relation pair.
+        var rewritten = Rewrite(Parse(HouseholdSchema), "household", "mixed", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([MultiDirect([owner, admin], any), Ttu(parent -> organization#admin)], any)");
     }
 
     [Fact]
-    public void Single_attribute_sibling_stays_when_only_the_direct_pair_fuses()
+    public void Full_fusion_when_attribute_and_direct_groups_are_the_only_children()
     {
-        // One attribute ref is below the >= 2 threshold for its own group — it stays a plain
-        // walked sibling next to the fused direct-relation pair.
+        // household.browse := owner or admin or open — owner/admin group into MultiDirect,
+        // open is a single attribute leaf. Both leaves are already-fused-or-singleton groups
+        // with nothing left over, so the whole union fuses into one FusedExpressionOp instead
+        // of staying two separate PhysicalCheckNode children of a Union.
         const string s = """
             entity user {}
             entity household {
@@ -146,20 +146,17 @@ public class RelationalPlanRewriterSpecs
             }
             """;
         var rewritten = Rewrite(Parse(s), "household", "browse", "user", out _);
-        var union = rewritten.Should().BeOfType<UnionNode>().Subject;
-        union.Children.Should().HaveCount(2);
-        union.Children[0].Should().BeOfType<PhysicalCheckNode>()
-            .Which.Op.Describe().Should().Be("HasAnyOfDirectRelations([owner, admin], any)");
-        union.Children[1].Should().Be(new PlanRefNode("open"));
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([Attribute(open), MultiDirect([owner, admin], any)], any)");
     }
 
     [Fact]
     public void Direct_and_attribute_sibling_groups_both_fuse_under_one_parent()
     {
-        // Both groups may fire under the same parent. The rewritten plan's shape is
-        // deterministic and contractual: fused attribute group first, fused direct group
-        // second, unfused children in original order. (Same shape the old sequential compiler
-        // passes produced: directs grouped first, attributes then prepended.)
+        // Both groups fuse AND the whole union collapses into one FusedExpressionOp (2 leaves,
+        // full fusion) rather than staying two separate PhysicalCheckNode children of a Union.
+        // Deterministic leaf order matches the pre-existing group-ordering contract: attribute
+        // group first, direct-relation group second.
         const string s = """
             entity user {}
             entity doc {
@@ -171,12 +168,8 @@ public class RelationalPlanRewriterSpecs
             }
             """;
         var rewritten = Rewrite(Parse(s), "doc", "view", "user", out _);
-        var union = rewritten.Should().BeOfType<UnionNode>().Subject;
-        union.Children.Should().HaveCount(2);
-        union.Children[0].Should().BeOfType<PhysicalCheckNode>()
-            .Which.Op.Describe().Should().Be("HasAnyOfAttributes([a0, a1], any)");
-        union.Children[1].Should().BeOfType<PhysicalCheckNode>()
-            .Which.Op.Describe().Should().Be("HasAnyOfDirectRelations([r0, r1], any)");
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([MultiAttribute([a0, a1], any), MultiDirect([r0, r1], any)], any)");
     }
 
     [Fact]
@@ -221,13 +214,15 @@ public class RelationalPlanRewriterSpecs
     }
 
     [Fact]
-    public void Unrecognized_nodes_pass_through_as_the_same_instance()
+    public void Single_direct_and_single_ttu_leaf_fuse_together()
     {
-        // escalate := owner or parent.admin — one batchable ref + a TTU: below the >= 2
-        // threshold nothing fuses, and the contract says untouched trees come back
-        // reference-identical.
-        var rewritten = Rewrite(Parse(HouseholdSchema), "household", "escalate", "user", out var compiledRoot);
-        rewritten.Should().BeSameAs(compiledRoot);
+        // household.escalate := owner or parent.admin — one unfused Direct (below the >= 2 group
+        // threshold) + one TTU-fast-path leaf. Neither alone is worth wrapping, but together they
+        // fuse (mirrors benchmarks/Valtuutus.Benchmarks/schema.vtt's team.edit := org.admin or
+        // owner) — 2 leaves, full fusion.
+        var rewritten = Rewrite(Parse(HouseholdSchema), "household", "escalate", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([Direct(owner), Ttu(parent -> organization#admin)], any)");
     }
 
     [Fact]
@@ -296,5 +291,112 @@ public class RelationalPlanRewriterSpecs
         var rewritten = Rewrite(Parse(UsersetJoinSchema), "folder", "owner", null, out var compiledRoot);
         rewritten.Should().BeSameAs(compiledRoot);
         rewritten.Should().BeOfType<DirectRelationNode>();
+    }
+
+    private const string TeamSchema = """
+        entity user {}
+        entity organization { relation admin @user; }
+        entity team {
+            relation owner @user;
+            relation member @user;
+            relation banned @user;
+            relation org @organization;
+            permission edit := org.admin or owner;
+            permission invite := org.admin and (owner or member);
+            permission negate_sibling_batch := owner and member and not(banned);
+        }
+        """;
+
+    [Fact]
+    public void Ttu_and_direct_fuse_under_union()
+    {
+        var rewritten = Rewrite(Parse(TeamSchema), "team", "edit", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([Direct(owner), Ttu(org -> organization#admin)], any)");
+    }
+
+    [Fact]
+    public void Ttu_and_nested_multi_direct_fuse_under_intersect()
+    {
+        // org.admin and (owner or member): the outer Intersect's raw children are [Ttu,
+        // Union(owner, member)] — NEITHER is a raw PlanRefNode, so the outer relations/attributes
+        // lists stay empty; walking the second child fuses the inner union to
+        // PhysicalCheckNode(MultiDirect) first, and TryRecognizeSingleLeaf picks that up as a
+        // MultiDirect leaf. Both leaves land in singleLeaves in encounter order — Ttu first (it
+        // was the first original child), MultiDirect second (unlike Full_fusion_when_every_
+        // child_is_recognizable's household.mixed case above, where owner/admin ARE raw
+        // PlanRefNode siblings at THIS level, so they populate the outer `relations` list
+        // directly and the group-leaf-before-singleLeaves ordering rule applies instead).
+        var rewritten = Rewrite(Parse(TeamSchema), "team", "invite", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([Ttu(org -> organization#admin), MultiDirect([owner, member], any)], all)");
+    }
+
+    [Fact]
+    public void Negated_single_leaf_fuses_alongside_a_multi_direct_group()
+    {
+        // owner and member and not(banned): {owner, member} group into MultiDirect(all);
+        // not(banned) is a negated single Direct leaf — both recognized, 2 leaves, full fusion.
+        var rewritten = Rewrite(Parse(TeamSchema), "team", "negate_sibling_batch", "user", out _);
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be("FusedExpression([MultiDirect([owner, member], all), not Direct(banned)], all)");
+    }
+
+    [Fact]
+    public void Full_fusion_does_not_fire_when_subject_type_unknown()
+    {
+        // Without subjectType: PlanCompiler.PruneTupleToUserSet returns early before ever setting
+        // FastPathSubEntityType, so org.admin isn't recognized either — and directGate being
+        // false means owner never enters the relations group. Both children stay unrecognized,
+        // so nothing fuses at all (falls all the way through to RebuildIfChanged unchanged).
+        var rewritten = Rewrite(Parse(TeamSchema), "team", "edit", null, out var compiledRoot);
+        rewritten.Should().BeSameAs(compiledRoot);
+    }
+
+    [Fact]
+    public void Nested_fused_expression_flattens_into_the_outer_fusion()
+    {
+        // A hand-built tree standing in for "(a or b or org.admin) or member", built directly
+        // rather than through PlanCompiler.Compile: SchemaBuilder flattens any homogeneous
+        // "or of or"/"and of and" chain in a permission's DSL text into one flat n-ary
+        // Union/Intersect (PermissionNode.Flatten) BEFORE PlanCompiler.CompileTree ever runs —
+        // confirmed by compiling this exact permission text and observing a/b/member all land in
+        // one MultiDirect group with no nesting left for GroupChildren to recurse into. Only
+        // heterogeneous nesting (mixed AND/OR, e.g. Ttu_and_nested_multi_direct_fuse_under_
+        // intersect above) survives the schema compiler, and that always has a mismatched
+        // combinator for this flatten guard (inner requireAll can only equal outer's !isUnion
+        // when both levels share one combinator — which is exactly the case Flatten already
+        // collapses). So the only way to exercise GroupChildren's own recursive recognition of a
+        // nested FusedExpressionOp is a directly constructed PlanNode tree, which any provider
+        // rewriter must still handle correctly regardless of how it got here.
+        const string s = """
+            entity user {}
+            entity organization { relation admin @user; }
+            entity team {
+                relation a @user;
+                relation b @user;
+                relation member @user;
+                relation org @organization;
+            }
+            """;
+        var schema = Parse(s);
+        var innerUnion = new UnionNode([
+            new PlanRefNode("a"),
+            new PlanRefNode("b"),
+            new TupleToUserSetNode("org", "admin", FastPathSubEntityType: "organization"),
+        ]);
+        var outerUnion = new UnionNode([innerUnion, new PlanRefNode("member")]);
+
+        // Walking the inner union first fuses it to PhysicalCheckNode(FusedExpressionOp(
+        // [MultiDirect([a, b], any), Ttu(...)], requireAll: false)) — its own combinator (any,
+        // from being a Union) matches what the outer Union needs, so the outer classification
+        // loop splices those 2 leaves straight into singleLeaves instead of treating the whole
+        // nested op as one opaque leaf. `member` is a plain PlanRefNode at the outer level, so it
+        // populates the outer `relations` group (count 1) as its own Direct leaf, ordered before
+        // the flattened leaves per the existing group-before-singleLeaves contract.
+        var rewritten = new RelationalPlanRewriter().Rewrite(outerUnion, schema, "team", "user");
+        var physical = rewritten.Should().BeOfType<PhysicalCheckNode>().Subject;
+        physical.Op.Describe().Should().Be(
+            "FusedExpression([Direct(member), MultiDirect([a, b], any), Ttu(org -> organization#admin)], any)");
     }
 }

--- a/tests/Valtuutus.Data.Postgres.Tests/BatchedExecutorRoundTripSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/BatchedExecutorRoundTripSpecs.cs
@@ -12,18 +12,24 @@ using Valtuutus.Tests.Shared;
 namespace Valtuutus.Data.Postgres.Tests;
 
 /// <summary>
-/// DbBatch-Task 8, Step 3: the one claim in the whole R4 plan that only real Postgres can prove —
-/// BatchedPhysicalExecutor genuinely collapses a wave's several batchable ops into fewer physical
-/// round trips than running them individually, and produces the identical answer either way.
+/// The one claim only real Postgres can prove — BatchedPhysicalExecutor genuinely collapses a
+/// wave's several batchable ops into fewer physical round trips than running them individually,
+/// and produces the identical answer either way.
 ///
-/// The schema's `view := owner or team_link.member or public` union has three sibling children
-/// of three DIFFERENT op kinds (HasDirectRelation, TtuFastPath, HasTrueBoolAttribute) — each
-/// appears only once, so RelationalPlanRewriter's sibling fusion (same-kind, ≥2 siblings) never
-/// fires at plan-rewrite time. All three land in the executor as separate leaf ops in the same
-/// wave, which is exactly the shape BatchedPhysicalExecutor's DbBatch packing targets — as
-/// opposed to reusing the R4 attribute fixture from Step 2, where the fusion already collapses
-/// to a single op at PLAN REWRITE time, before the physical executor ever sees more than one op
-/// to batch.
+/// The schema's `view` union has FOUR sibling children that can never fuse into one op: a bare
+/// relation ref (`owner`), a tuple-to-userset fast-path ref (`team_link.member`), a bare
+/// attribute ref (`public`), and a reference to another PERMISSION
+/// (`unfusable_sub_permission`, itself `owner and public`). RelationalPlanRewriter's
+/// full-fusion pass requires every child of the union to resolve to a recognizable leaf kind
+/// (direct relation, attribute, TTU fast path, or an already-fused sibling group) — a reference
+/// to another permission resolves to `RelationType.Permission`, which none of those checks
+/// recognize, so the pass can't fully fuse this union. Partial fusion (which only groups >= 2
+/// same-kind siblings) also can't fire here, since `owner` and `public` each appear only once at
+/// this level. The result: `owner`, `team_link.member`, `public`, and the sub-permission's own
+/// resolved op each land in the executor as separate leaf ops in the same wave — exactly the
+/// shape BatchedPhysicalExecutor's DbBatch packing targets, as opposed to a union whose children
+/// the rewriter CAN fully fuse, where fusion already collapses everything to a single op at plan
+/// rewrite time, before the physical executor ever sees more than one op to batch.
 ///
 /// Forcing the "one round trip per op" comparison can't go through DefaultPhysicalExecutor
 /// directly — it's internal to Valtuutus.Core with no InternalsVisibleTo grant to this test
@@ -47,7 +53,8 @@ public sealed class BatchedExecutorRoundTripSpecs : IAsyncLifetime
             relation owner @user;
             relation team_link @team;
             attribute public bool;
-            permission view := owner or team_link.member or public;
+            permission unfusable_sub_permission := owner and public;
+            permission view := owner or team_link.member or public or unfusable_sub_permission;
         }
         """;
 

--- a/tests/Valtuutus.Data.Postgres.Tests/FusedExpressionRoundTripSpecs.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/FusedExpressionRoundTripSpecs.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.Postgres.Tests;
+
+/// <summary>
+/// Real-Postgres proof that RelationalPlanRewriter's full-fusion pass collapses a genuinely
+/// heterogeneous multi-leaf boolean combination into exactly one physical round trip, for the
+/// three shapes distinguished in RelationalPlanRewriterSpecs: an OR of a direct relation and a
+/// tuple-to-userset fast-path ref, an AND of a fast-path ref with a nested OR of direct
+/// relations, and an AND chain with a negated sibling.
+///
+/// A fused `PhysicalCheckNode(FusedExpressionOp)` is a single op regardless of whether
+/// IRelationalBatchOps is registered — DbBatch packing only matters once a wave has more than
+/// one op to pack, and fusion here already reduces the wave to one op at plan-rewrite time. So
+/// these tests don't register IRelationalBatchOps at all and rely on the simpler
+/// individual-dispatch path (the same one BatchedExecutorRoundTripSpecs exercises with
+/// batching: false) — HasFusedExpression still lands on the counted reader below as exactly one
+/// call either way, with no need to also stand up a counting batch decorator.
+/// </summary>
+[Collection("PostgreSqlSpec")]
+public sealed class FusedExpressionRoundTripSpecs : IAsyncLifetime
+{
+    private const string Schema = """
+        entity user {}
+        entity organization { relation admin @user; }
+        entity team {
+            relation owner @user;
+            relation member @user;
+            relation banned @user;
+            relation org @organization;
+            permission edit := org.admin or owner;
+            permission invite := org.admin and (owner or member);
+            permission negate_sibling_batch := owner and member and not(banned);
+        }
+        """;
+
+    public FusedExpressionRoundTripSpecs(PostgresFixture fixture, Xunit.Abstractions.ITestOutputHelper output)
+    {
+        Fixture = fixture;
+        Output = output;
+    }
+
+    private PostgresFixture Fixture { get; }
+    private Xunit.Abstractions.ITestOutputHelper Output { get; }
+
+    public Task InitializeAsync() => Fixture.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task OrFusion_NoTuplesAtAll_ReturnsFalse_WithOneRoundTrip()
+    {
+        // Nobody holds org.admin or owner on team:t1 — both the TTU fast-path branch and the
+        // direct-relation branch must be evaluated (a miss can't short-circuit on the first
+        // branch alone), which is exactly the shape that used to cost one round trip per branch
+        // before fusion collapsed the whole union into one FusedExpressionOp.
+        var (result, roundTrips) = await RunCheck("team", "t1", "edit", []);
+
+        Output.WriteLine($"edit (no grants): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AndOrFusion_AdminAndMember_ReturnsTrue_WithOneRoundTrip()
+    {
+        // org.admin and (owner or member): alice holds admin on the team's organization and
+        // member (not owner) on the team itself — the AND requires both sides to actually
+        // resolve, and the nested OR requires at least one of its two direct relations to hold.
+        var (result, roundTrips) = await RunCheck("team", "t1", "invite",
+        [
+            new RelationTuple("organization", "org1", "admin", "user", "alice"),
+            new RelationTuple("team", "t1", "org", "organization", "org1"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"invite (admin+member): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeTrue();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AndOrFusion_OwnerWithoutAdmin_ReturnsFalse_WithOneRoundTrip()
+    {
+        // Owner alone satisfies the nested (owner or member) OR, but org.admin never holds for
+        // alice, so the outer AND must still fail — proving the fused SQL actually enforces the
+        // AND rather than only ever reporting the OR's answer.
+        var (result, roundTrips) = await RunCheck("team", "t1", "invite",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"invite (owner only): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NegationFusion_BannedSubjectExcluded_ReturnsFalse_WithOneRoundTrip()
+    {
+        // owner and member and not(banned): alice holds owner and member but is ALSO banned —
+        // the negated sibling must still veto the whole AND despite the other two branches
+        // holding.
+        var (result, roundTrips) = await RunCheck("team", "t1", "negate_sibling_batch",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+            new RelationTuple("team", "t1", "banned", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"negate_sibling_batch (banned): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NegationFusion_NotBanned_ReturnsTrue_WithOneRoundTrip()
+    {
+        // Same owner+member grant, without the banned tuple — the negated sibling now resolves
+        // to "not banned" == true, so the whole AND holds.
+        var (result, roundTrips) = await RunCheck("team", "t1", "negate_sibling_batch",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"negate_sibling_batch (not banned): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeTrue();
+        roundTrips.Should().Be(1);
+    }
+
+    private async Task<(bool Result, int RoundTrips)> RunCheck(
+        string entityType, string entityId, string permission, RelationTuple[] tuples)
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddPostgres(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+
+        var counter = new RoundTripCounter();
+        services.AddSingleton(counter);
+
+        // Same counting decorator BatchedExecutorRoundTripSpecs uses for the individual-dispatch
+        // run — no IRelationalBatchOps is registered here at all, so every op (fused or not)
+        // lands on this reader.
+        services.Replace(ServiceDescriptor.Scoped<IDataReaderProvider>(sp =>
+        {
+            var real = ActivatorUtilities.CreateInstance<Postgres.PostgresDataReaderProvider>(sp);
+            return new CountingReaderProvider(real, sp.GetRequiredService<RoundTripCounter>());
+        }));
+        services.RemoveAll<IRelationalBatchOps>();
+
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+
+        // The write's own return value carries a SnapToken for the data it just committed, so
+        // passing it explicitly on the CheckRequest below avoids a separate GetLatestSnapToken
+        // call — that call goes through the same counted reader as HasFusedExpression, and would
+        // otherwise inflate the round-trip count by one regardless of fusion. Writer.Write itself
+        // never touches IDataReaderProvider, so it's never counted here either way. An empty
+        // table (freshly reset per test) has nothing to miss regardless of which snapshot bound
+        // is used, so the no-tuple scenario can use SnapToken.MinValue without writing anything.
+        var snapToken = SnapToken.MinValue;
+        if (tuples.Length > 0)
+        {
+            var writer = scope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(tuples, [], default);
+        }
+
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+        var result = await engine.Check(
+            new CheckRequest(entityType, entityId, permission, "user", "alice", snapToken: snapToken), default);
+        return (result, counter.Count);
+    }
+}

--- a/tests/Valtuutus.Data.Postgres.Tests/RoundTripCountingReaderProvider.cs
+++ b/tests/Valtuutus.Data.Postgres.Tests/RoundTripCountingReaderProvider.cs
@@ -94,6 +94,14 @@ internal sealed class CountingReaderProvider(PostgresDataReaderProvider inner, R
             subjectType, subjectId, snapToken, cancellationToken);
     }
 
+    public async Task<bool> HasFusedExpression(string entityType, string entityId, IReadOnlyList<FusedCheckLeaf> leaves,
+        bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        counter.Increment();
+        return await inner.HasFusedExpression(entityType, entityId, leaves, requireAll, subjectType, subjectId,
+            snapToken, cancellationToken);
+    }
+
     public async Task<PooledList<RelationTuple>> GetIndirectRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
     {
         counter.Increment();
@@ -242,6 +250,10 @@ internal sealed class CountingBatchOps(IRelationalBatchOps inner, RoundTripCount
         string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken)
         => inner.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
             computedRelation, subjectType, subjectId, snapToken);
+
+    public void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken)
+        => inner.AddHasFusedExpressionToBatch(batch, entityType, entityId, leaves, requireAll, subjectType, subjectId, snapToken);
 
     public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,
         string subjectId, SnapToken snapToken)

--- a/tests/Valtuutus.Data.SqlServer.Tests/BatchedExecutorRoundTripSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/BatchedExecutorRoundTripSpecs.cs
@@ -14,12 +14,32 @@ namespace Valtuutus.Data.SqlServer.Tests;
 /// SqlServer counterpart of Valtuutus.Data.Postgres.Tests.BatchedExecutorRoundTripSpecs — the one
 /// claim only a real SqlServer can prove: BatchedPhysicalExecutor genuinely collapses a wave's
 /// several batchable ops into fewer physical round trips than running them individually, and
-/// produces the identical answer either way. Same schema/scenario/technique as the Postgres
-/// version — see that file's doc comment for full rationale (three different op kinds in one
-/// Union, so RelationalPlanRewriter's sibling fusion never fuses any of them away at
-/// plan-rewrite time; toggling IRelationalBatchOps presence via a counting decorator instead of
-/// touching DefaultPhysicalExecutor directly, since that type is internal to Valtuutus.Core with
-/// no InternalsVisibleTo grant to this test assembly).
+/// produces the identical answer either way.
+///
+/// The schema's `view` union has FOUR sibling children that can never fuse into one op: a bare
+/// relation ref (`owner`), a tuple-to-userset fast-path ref (`team_link.member`), a bare
+/// attribute ref (`public`), and a reference to another PERMISSION
+/// (`unfusable_sub_permission`, itself `owner and public`). RelationalPlanRewriter's
+/// full-fusion pass requires every child of the union to resolve to a recognizable leaf kind
+/// (direct relation, attribute, TTU fast path, or an already-fused sibling group) — a reference
+/// to another permission resolves to `RelationType.Permission`, which none of those checks
+/// recognize, so the pass can't fully fuse this union. Partial fusion (which only groups >= 2
+/// same-kind siblings) also can't fire here, since `owner` and `public` each appear only once at
+/// this level. The result: `owner`, `team_link.member`, `public`, and the sub-permission's own
+/// resolved op each land in the executor as separate leaf ops in the same wave — exactly the
+/// shape BatchedPhysicalExecutor's DbBatch packing targets, as opposed to a union whose children
+/// the rewriter CAN fully fuse, where fusion already collapses everything to a single op at plan
+/// rewrite time, before the physical executor ever sees more than one op to batch.
+///
+/// Forcing the "one round trip per op" comparison can't go through DefaultPhysicalExecutor
+/// directly — it's internal to Valtuutus.Core with no InternalsVisibleTo grant to this test
+/// assembly. Instead this toggles whether an IRelationalBatchOps is registered at all:
+/// BatchedPhysicalExecutor now receives its batch capability injected (constructed once per
+/// Schema by AddSqlServer's Func&lt;Schema, IPhysicalExecutor&gt; factory, which resolves
+/// IRelationalBatchOps via IServiceProvider.GetService — optional, not required), so removing
+/// the registration entirely reproduces the exact same SubmitAllIndividually fallback
+/// BatchedPhysicalExecutor takes when a provider has no batch implementation. Same code path,
+/// no internals access required.
 /// </summary>
 [Collection("SqlServerSpec")]
 public sealed class BatchedExecutorRoundTripSpecs : IAsyncLifetime
@@ -33,7 +53,8 @@ public sealed class BatchedExecutorRoundTripSpecs : IAsyncLifetime
             relation owner @user;
             relation team_link @team;
             attribute public bool;
-            permission view := owner or team_link.member or public;
+            permission unfusable_sub_permission := owner and public;
+            permission view := owner or team_link.member or public or unfusable_sub_permission;
         }
         """;
 

--- a/tests/Valtuutus.Data.SqlServer.Tests/FusedExpressionRoundTripSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/FusedExpressionRoundTripSpecs.cs
@@ -1,0 +1,189 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Valtuutus.Core;
+using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Data;
+using Valtuutus.Core.Engines.Check;
+using Valtuutus.Data.Db;
+using Valtuutus.Tests.Shared;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+/// <summary>
+/// Real-SqlServer proof that RelationalPlanRewriter's full-fusion pass collapses a genuinely
+/// heterogeneous multi-leaf boolean combination into exactly one physical round trip, for the
+/// three shapes distinguished in RelationalPlanRewriterSpecs: an OR of a direct relation and a
+/// tuple-to-userset fast-path ref, an AND of a fast-path ref with a nested OR of direct
+/// relations, and an AND chain with a negated sibling.
+///
+/// A fused `PhysicalCheckNode(FusedExpressionOp)` is a single op regardless of whether
+/// IRelationalBatchOps is registered — DbBatch packing only matters once a wave has more than
+/// one op to pack, and fusion here already reduces the wave to one op at plan-rewrite time. So
+/// these tests don't register IRelationalBatchOps at all and rely on the simpler
+/// individual-dispatch path (the same one BatchedExecutorRoundTripSpecs exercises with
+/// batching: false) — HasFusedExpression still lands on the counted reader below as exactly one
+/// call either way, with no need to also stand up a counting batch decorator.
+/// </summary>
+[Collection("SqlServerSpec")]
+public sealed class FusedExpressionRoundTripSpecs : IAsyncLifetime
+{
+    private const string Schema = """
+        entity user {}
+        entity organization { relation admin @user; }
+        entity team {
+            relation owner @user;
+            relation member @user;
+            relation banned @user;
+            relation org @organization;
+            permission edit := org.admin or owner;
+            permission invite := org.admin and (owner or member);
+            permission negate_sibling_batch := owner and member and not(banned);
+        }
+        """;
+
+    public FusedExpressionRoundTripSpecs(SqlServerFixture fixture, Xunit.Abstractions.ITestOutputHelper output)
+    {
+        Fixture = fixture;
+        Output = output;
+    }
+
+    private SqlServerFixture Fixture { get; }
+    private Xunit.Abstractions.ITestOutputHelper Output { get; }
+
+    public Task InitializeAsync() => Fixture.ResetDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task OrFusion_NoTuplesAtAll_ReturnsFalse_WithOneRoundTrip()
+    {
+        // Nobody holds org.admin or owner on team:t1 — both the TTU fast-path branch and the
+        // direct-relation branch must be evaluated (a miss can't short-circuit on the first
+        // branch alone), which is exactly the shape that used to cost one round trip per branch
+        // before fusion collapsed the whole union into one FusedExpressionOp.
+        var (result, roundTrips) = await RunCheck("team", "t1", "edit", []);
+
+        Output.WriteLine($"edit (no grants): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AndOrFusion_AdminAndMember_ReturnsTrue_WithOneRoundTrip()
+    {
+        // org.admin and (owner or member): alice holds admin on the team's organization and
+        // member (not owner) on the team itself — the AND requires both sides to actually
+        // resolve, and the nested OR requires at least one of its two direct relations to hold.
+        var (result, roundTrips) = await RunCheck("team", "t1", "invite",
+        [
+            new RelationTuple("organization", "org1", "admin", "user", "alice"),
+            new RelationTuple("team", "t1", "org", "organization", "org1"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"invite (admin+member): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeTrue();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AndOrFusion_OwnerWithoutAdmin_ReturnsFalse_WithOneRoundTrip()
+    {
+        // Owner alone satisfies the nested (owner or member) OR, but org.admin never holds for
+        // alice, so the outer AND must still fail — proving the fused SQL actually enforces the
+        // AND rather than only ever reporting the OR's answer.
+        var (result, roundTrips) = await RunCheck("team", "t1", "invite",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"invite (owner only): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NegationFusion_BannedSubjectExcluded_ReturnsFalse_WithOneRoundTrip()
+    {
+        // owner and member and not(banned): alice holds owner and member but is ALSO banned —
+        // the negated sibling must still veto the whole AND despite the other two branches
+        // holding.
+        var (result, roundTrips) = await RunCheck("team", "t1", "negate_sibling_batch",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+            new RelationTuple("team", "t1", "banned", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"negate_sibling_batch (banned): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeFalse();
+        roundTrips.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NegationFusion_NotBanned_ReturnsTrue_WithOneRoundTrip()
+    {
+        // Same owner+member grant, without the banned tuple — the negated sibling now resolves
+        // to "not banned" == true, so the whole AND holds.
+        var (result, roundTrips) = await RunCheck("team", "t1", "negate_sibling_batch",
+        [
+            new RelationTuple("team", "t1", "owner", "user", "alice"),
+            new RelationTuple("team", "t1", "member", "user", "alice"),
+        ]);
+
+        Output.WriteLine($"negate_sibling_batch (not banned): result={result}, roundTrips={roundTrips}");
+
+        result.Should().BeTrue();
+        roundTrips.Should().Be(1);
+    }
+
+    private async Task<(bool Result, int RoundTrips)> RunCheck(
+        string entityType, string entityId, string permission, RelationTuple[] tuples)
+    {
+        var dbFactory = ((IWithDbConnectionFactory)Fixture).DbFactory;
+
+        var services = new ServiceCollection().AddValtuutusCore(Schema);
+        services.AddSqlServer(_ => dbFactory).AddConcurrentQueryLimit(3);
+        services.AddValtuutusCheckV2();
+
+        var counter = new RoundTripCounter();
+        services.AddSingleton(counter);
+
+        // Same counting decorator BatchedExecutorRoundTripSpecs uses for the individual-dispatch
+        // run — no IRelationalBatchOps is registered here at all, so every op (fused or not)
+        // lands on this reader.
+        services.Replace(ServiceDescriptor.Scoped<IDataReaderProvider>(sp =>
+        {
+            var real = ActivatorUtilities.CreateInstance<SqlServerDataReaderProvider>(sp);
+            return new CountingReaderProvider(real, sp.GetRequiredService<RoundTripCounter>());
+        }));
+        services.RemoveAll<IRelationalBatchOps>();
+
+        await using var sp = services.BuildServiceProvider();
+        await using var scope = sp.CreateAsyncScope();
+
+        // The write's own return value carries a SnapToken for the data it just committed, so
+        // passing it explicitly on the CheckRequest below avoids a separate GetLatestSnapToken
+        // call — that call goes through the same counted reader as HasFusedExpression, and would
+        // otherwise inflate the round-trip count by one regardless of fusion. Writer.Write itself
+        // never touches IDataReaderProvider, so it's never counted here either way. An empty
+        // table (freshly reset per test) has nothing to miss regardless of which snapshot bound
+        // is used, so the no-tuple scenario can use SnapToken.MinValue without writing anything.
+        var snapToken = SnapToken.MinValue;
+        if (tuples.Length > 0)
+        {
+            var writer = scope.ServiceProvider.GetRequiredService<IDataWriterProvider>();
+            snapToken = await writer.Write(tuples, [], default);
+        }
+
+        var engine = scope.ServiceProvider.GetRequiredService<ICheckEngine>();
+        var result = await engine.Check(
+            new CheckRequest(entityType, entityId, permission, "user", "alice", snapToken: snapToken), default);
+        return (result, counter.Count);
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/FusedExpressionSqlCacheSpecs.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/FusedExpressionSqlCacheSpecs.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Valtuutus.Data.Db;
+using Xunit;
+
+namespace Valtuutus.Data.SqlServer.Tests;
+
+/// <summary>
+/// Proves FusedExpressionSql.BuildCommandSql's cache actually hits for a stable leaves reference —
+/// not just that it returns equal-content strings, but the literal same string object — which is
+/// what makes repeated Check() calls against the same compiled plan skip re-interpolating the
+/// full command text on every call. No database is involved: BuildCommandSql is a pure function of
+/// its inputs.
+/// </summary>
+public class FusedExpressionSqlCacheSpecs
+{
+    [Fact]
+    public void BuildCommandSql_SameLeavesInstance_ReturnsReferenceIdenticalStringOnSecondCall()
+    {
+        IReadOnlyList<FusedCheckLeaf> leaves =
+        [
+            new FusedCheckLeaf(FusedLeafKind.Direct, false, ["owner"]),
+            new FusedCheckLeaf(FusedLeafKind.TupleToUserSet, false, ["org"], TtuSubEntityType: "organization", TtuComputedRelation: "admin"),
+        ];
+
+        var first = FusedExpressionSql.BuildCommandSql(leaves, requireAll: false, "relations", "attributes");
+        var second = FusedExpressionSql.BuildCommandSql(leaves, requireAll: false, "relations", "attributes");
+
+        ReferenceEquals(first, second).Should().BeTrue(
+            "the second call for the same leaves reference must hit the cache instead of rebuilding the SQL text");
+    }
+
+    [Fact]
+    public void BuildCommandSql_DifferentLeavesInstance_ReturnsIndependentEntry()
+    {
+        IReadOnlyList<FusedCheckLeaf> leavesA = [new FusedCheckLeaf(FusedLeafKind.Direct, false, ["owner"])];
+        IReadOnlyList<FusedCheckLeaf> leavesB = [new FusedCheckLeaf(FusedLeafKind.Direct, false, ["owner"])];
+
+        var exprA = FusedExpressionSql.BuildCommandSql(leavesA, requireAll: false, "relations", "attributes");
+        var exprB = FusedExpressionSql.BuildCommandSql(leavesB, requireAll: false, "relations", "attributes");
+
+        // Equal-content leaves that are NOT the same list reference get their own cache entry
+        // (identity-keyed, not value-keyed) — the text still comes out equal, just not the same
+        // object, confirming the key really is leaves' reference identity and not some incidental
+        // value-based memoization.
+        exprA.Should().Be(exprB);
+        ReferenceEquals(exprA, exprB).Should().BeFalse();
+    }
+}

--- a/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
+++ b/tests/Valtuutus.Data.SqlServer.Tests/RoundTripCountingReaderProvider.cs
@@ -94,6 +94,14 @@ internal sealed class CountingReaderProvider(SqlServerDataReaderProvider inner, 
             subjectType, subjectId, snapToken, cancellationToken);
     }
 
+    public async Task<bool> HasFusedExpression(string entityType, string entityId, IReadOnlyList<FusedCheckLeaf> leaves,
+        bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken, CancellationToken cancellationToken)
+    {
+        counter.Increment();
+        return await inner.HasFusedExpression(entityType, entityId, leaves, requireAll, subjectType, subjectId,
+            snapToken, cancellationToken);
+    }
+
     public async Task<PooledList<RelationTuple>> GetIndirectRelations(RelationTupleFilter tupleFilter, CancellationToken cancellationToken)
     {
         counter.Increment();
@@ -242,6 +250,10 @@ internal sealed class CountingBatchOps(IRelationalBatchOps inner, RoundTripCount
         string subEntityType, string computedRelation, string subjectType, string subjectId, SnapToken snapToken)
         => inner.AddHasUsersetJoinRelationToBatch(batch, entityType, entityId, relation, subEntityType,
             computedRelation, subjectType, subjectId, snapToken);
+
+    public void AddHasFusedExpressionToBatch(DbBatch batch, string entityType, string entityId,
+        IReadOnlyList<FusedCheckLeaf> leaves, bool requireAll, string? subjectType, string? subjectId, SnapToken snapToken)
+        => inner.AddHasFusedExpressionToBatch(batch, entityType, entityId, leaves, requireAll, subjectType, subjectId, snapToken);
 
     public void AddHasAnyDirectRelationToBatch(DbBatch batch, string entityType, string[] entityIds, string relation,
         string subjectId, SnapToken snapToken)


### PR DESCRIPTION
## Summary
- Collapses a compiled Union/Intersect into one compound SQL statement (`SELECT (EXISTS(...) OR/AND EXISTS(...))`) whenever every child resolves to a recognizable relational leaf — a plain direct-relation ref, an already-fused sibling group, a plan-time-eligible tuple-to-userset node, an attribute ref, or `Negate` over any of those — instead of one round trip per leaf (or one `DbBatch` packing N separate statement executions).
- Last of the CheckV2 rewrite rules; subsumes R2/R3/R4 leaves into single-statement expressions.
- New `FusedExpressionOp` (Data.Db) + `FusedCheckLeaf`/`FusedLeafKind` descriptor crossing the `IRelationalCheckOps`/`IRelationalBatchOps` seam; `RelationalPlanRewriter` gains a full-fusion decision on top of existing partial (sibling-group) fusion, including flattening an already-fused nested `FusedExpressionOp` into the outer expression when combinators agree.
- Both Postgres and SqlServer implement the op end-to-end (single-op and `DbBatch` dispatch), with per-provider SQL text cached by leaf-list reference identity (built once per compiled plan, not re-interpolated per Check call).
- `Valtuutus.Core` untouched — this is entirely a Data.Db/Postgres/SqlServer feature.

## Benchmarks (`Check_UnionTtuDirect`, real Testcontainers)
- Postgres: ~137us / 14.7KB vs V1's ~150us / 16.5KB — faster **and** lower-allocating.
- SqlServer: ~6% faster, allocation flat (~26KB).
- InMemory: unaffected (no rewriter registered there, same accepted tradeoff as prior rewrite rules).

## Test plan
- [x] Whole-solution build: 0 errors
- [x] `CI=true dotnet test Valtuutus.slnx`: 0 failures, 5327 tests passing across InMemory/Postgres/SqlServer/Lang/Api, all 4 TFMs (net8/9/10/11)
- [x] Postgres/SqlServer integration tests against real Testcontainers instances (round-trip-count proofs for OR-fusion, AND/OR-fusion, negation-fusion)
- [x] `ApiSpecs` snapshots regenerated for `ApproveDataDb`/`ApprovePostgres`/`ApproveSqlServer` (plain+twin, all TFMs); `ApproveCore` confirmed zero diff