### PR TITLE
perf: share compiled subplans across SubjectPermission's N permissions

### DIFF
--- a/src/Valtuutus.Core/Configuration/ConfigureCheckV2.cs
+++ b/src/Valtuutus.Core/Configuration/ConfigureCheckV2.cs
@@ -16,6 +16,7 @@ public static class ConfigureCheckV2
     public static IServiceCollection AddValtuutusCheckV2(this IServiceCollection services)
     {
         services.TryAddSingleton<CheckPlanCache>();
+        services.TryAddSingleton<CombinedPlanCache>();
         // Default: the generic, provider-agnostic executor. A relational provider (e.g.
         // Valtuutus.Data.Postgres) may Replace() this with a batching factory; order between
         // AddValtuutusCheckV2() and the provider's AddXxx() doesn't matter — TryAddSingleton here

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
@@ -4,7 +4,8 @@ using Valtuutus.Core.Schemas;
 
 namespace Valtuutus.Core.Engines.Check.V2;
 
-internal sealed class CheckEngineV2(IDataReaderProvider reader, Schema schema, CheckPlanExecutorPool executorPool)
+internal sealed class CheckEngineV2(IDataReaderProvider reader, Schema schema, CheckPlanExecutorPool executorPool,
+    CombinedPlanCache combinedPlans)
     : ICheckEngine
 {
     public async Task<bool> Check(CheckRequest req, CancellationToken cancellationToken)
@@ -64,10 +65,19 @@ internal sealed class CheckEngineV2(IDataReaderProvider reader, Schema schema, C
             i++;
         }
 
+        // Combined plan: all N permission trees hash-consed together (cached per
+        // (EntityType, SubjectType)), so a subtree shared across two permissions gets one slot
+        // in one shared array below instead of one array per root. Roots is index-aligned with
+        // roots[]/names[] because both this loop and CombinedPlanCache iterate the same
+        // schema.GetPermissions(entityType) FrozenDictionary.Values, whose iteration order is
+        // fixed once the schema is built.
+        var combined = combinedPlans.GetOrCompile(req.EntityType, ctx.SubjectType);
+
         // One driver loop, N roots: all permissions evaluate concurrently and share the
         // request's dynamic memo — the V2 equivalent of V1's shared CheckMemo here.
         var executor = executorPool.Rent(reader);
-        var results = await executor.ExecuteAsync(roots, ctx, cancellationToken);
+        var results = await executor.ExecuteAsync(roots, ctx, cancellationToken,
+            precompiledRoots: combined.Roots, combinedSlotCount: combined.SlotCount);
         _ = DrainAndReturn(executor);
 
         var dict = new Dictionary<string, bool>(names.Length);

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Observability;
 using Valtuutus.Core.Pools;
@@ -57,11 +58,43 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // using a colliding frame token.
     private int _pendingOps;
 
+    // Reused List<Waiter> instances across both waiter mechanisms below (MemoEntry.Waiters,
+    // MemoSlotState.Waiters) and across requests on this pooled executor instance — avoids a
+    // fresh List<T> + backing array per shared-slot/shared-memo-key wait registration, the
+    // dominant allocation source once cross-permission sharing (CombinedPlanCache) makes
+    // multiple frames commonly wait on the same in-flight entry/slot. Rent via
+    // RentWaiterList(), return (cleared) via ReturnWaiterList() at the exact point the list's
+    // owner (a MemoEntry or MemoSlotState) drains and nulls it out — never held past that
+    // point, so a list is never referenced by two owners at once.
+    private readonly Stack<List<Waiter>> _waiterListPool = new();
+
+    private List<Waiter> RentWaiterList() => _waiterListPool.TryPop(out var list) ? list : [];
+
+    private void ReturnWaiterList(List<Waiter> list)
+    {
+        list.Clear();
+        _waiterListPool.Push(list);
+    }
+
     // Dynamic memo — the V1 CheckMemo equivalent, allocated lazily on first cross-boundary
     // resolution beyond the roots. Cleared (not reallocated) at the start of each ExecuteAsync
     // so a pooled instance reuses the same backing Dictionary/List across requests.
     private Dictionary<CheckMemoKey, int>? _memoIndex;
     private List<MemoEntry> _memoEntries = [];
+
+    // Every MemoSlotState[] rented during the current ExecuteAsync call (the shared
+    // combined-plan array from the prologue, plus one per per-permission plan spawned via the
+    // non-combined SpawnPlan branch) — returned together once _pendingOps reaches 0, the same
+    // lifetime rule _frames itself follows (a straggler frame may still hold a `ref` into one
+    // of these). Cleared, not reallocated, at the start of each ExecuteAsync.
+    private readonly List<MemoSlotState[]> _rentedSlots = [];
+
+    private MemoSlotState[] RentSlots(int count)
+    {
+        var rented = ArrayPool<MemoSlotState>.Shared.Rent(count);
+        _rentedSlots.Add(rented);
+        return rented;
+    }
 
     // Explain-only side channel. Indexed by the same frame index as _frames — populated only
     // when ExecuteAsync's `explain` parameter is true (Task 4), never touched otherwise, so
@@ -144,7 +177,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // call). SubjectPermission's N roots keep memoizing (V1 default) since they can
     // legitimately reference each other.
     public async Task<bool[]> ExecuteAsync(CheckRootRequest[] roots, CheckRequestContext ctx, CancellationToken ct,
-        bool memoizeRoots = true, bool explain = false)
+        bool memoizeRoots = true, bool explain = false,
+        PlanNode[]? precompiledRoots = null, int combinedSlotCount = 0)
     {
         _ctx = ctx;
         _ct = ct;
@@ -165,9 +199,17 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         _waveCount = 0;
         _memoIndex?.Clear();
         _memoEntries.Clear();
+        _rentedSlots.Clear();
         _results = new bool[roots.Length];
         _rootsPending = roots.Length;
         _pendingOps = 0;
+        // Shared across all N roots ONLY on the precompiled combined-plan path
+        // (CheckEngineV2.SubjectPermission) — every other caller (Check()/Explain(), and any
+        // nested SpawnPlan reached during evaluation) leaves precompiledRoots/combinedSlotCount
+        // at their defaults and keeps getting its own per-root Slots array from SpawnPlan below.
+        var sharedSlots = combinedSlotCount > 0 ? RentSlots(combinedSlotCount) : null;
+        Debug.Assert(precompiledRoots is null || precompiledRoots.Length == roots.Length,
+            "precompiledRoots, when supplied, must be index-aligned with roots — the caller (CheckEngineV2.SubjectPermission) builds both from the same schema.GetPermissions(entityType) iteration.");
         try
         {
             for (var i = 0; i < roots.Length; i++)
@@ -181,7 +223,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                     }
                     : null;
                 ResolveDynamic(roots[i].EntityType, roots[i].EntityId, roots[i].Permission,
-                    roots[i].SubjectRelation, roots[i].Depth, NoParent, i, memoizeRoots, rootNode);
+                    roots[i].SubjectRelation, roots[i].Depth, NoParent, i, memoizeRoots, rootNode,
+                    precompiledRoots?[i], sharedSlots);
             }
 
             DrainReady();
@@ -227,6 +270,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                     ArrayPool<CheckNode?>.Shared.Return(_wrapSelfNodes, clearArray: true);
                     _wrapSelfNodes = [];
                 }
+                foreach (var rented in _rentedSlots)
+                    ArrayPool<MemoSlotState>.Shared.Return(rented, clearArray: true);
+                _rentedSlots.Clear();
             }
         }
     }
@@ -295,6 +341,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             ArrayPool<CheckNode?>.Shared.Return(_wrapSelfNodes, clearArray: true);
             _wrapSelfNodes = [];
         }
+        foreach (var rented in _rentedSlots)
+            ArrayPool<MemoSlotState>.Shared.Return(rented, clearArray: true);
+        _rentedSlots.Clear();
     }
 
     // ── IOpCompletionSink (called from provider threads) ────────────────────
@@ -426,7 +475,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // charged, guards run, and the dynamic memo is consulted.
     private void ResolveDynamic(string entityType, string entityId, string permission,
         string? subjectRelation, int depth, int parent, int rootIndex, bool memoize = true,
-        CheckNode? selfNode = null)
+        CheckNode? selfNode = null, PlanNode? precompiledRoot = null, MemoSlotState[]? sharedSlots = null)
     {
         if (depth <= 0)
         {
@@ -467,7 +516,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
 
         if (!memoize)
         {
-            SpawnPlan(entityType, entityId, permission, subjectRelation, depth, parent, rootIndex, memoEntry: -1, selfNode);
+            SpawnPlan(entityType, entityId, permission, subjectRelation, depth, parent, rootIndex, memoEntry: -1,
+                selfNode, precompiledRoot, sharedSlots);
             return;
         }
 
@@ -493,7 +543,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 selfNode.Detail = "memoized";
                 AttachOrSetRoot(selfNode, parent);
             }
-            (entry.Waiters ??= []).Add(new Waiter(parent, rootIndex, -1));
+            (entry.Waiters ??= RentWaiterList()).Add(new Waiter(parent, rootIndex, -1));
             if (_explain) (entry.ExplainWaiters ??= []).Add(selfNode);
             _memoEntries[entryIdx] = entry;
             return;
@@ -503,15 +553,30 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         var newEntryIdx = _memoEntries.Count;
         _memoEntries.Add(new MemoEntry());
 
-        SpawnPlan(entityType, entityId, permission, subjectRelation, depth, parent, rootIndex, newEntryIdx, selfNode);
+        SpawnPlan(entityType, entityId, permission, subjectRelation, depth, parent, rootIndex, newEntryIdx, selfNode,
+            precompiledRoot, sharedSlots);
     }
 
     private void SpawnPlan(string entityType, string entityId, string permission, string? subjectRelation,
-        int depth, int parent, int rootIndex, int memoEntry, CheckNode? selfNode)
+        int depth, int parent, int rootIndex, int memoEntry, CheckNode? selfNode,
+        PlanNode? precompiledRoot = null, MemoSlotState[]? sharedSlots = null)
     {
-        var plan = plans.GetOrCompile(entityType, permission, _ctx.SubjectType);
+        PlanNode root;
+        MemoSlotState[]? slots;
+        if (precompiledRoot is not null)
+        {
+            root = precompiledRoot;
+            slots = sharedSlots;
+        }
+        else
+        {
+            var plan = plans.GetOrCompile(entityType, permission, _ctx.SubjectType);
+            root = plan.Root;
+            slots = plan.SlotCount > 0 ? RentSlots(plan.SlotCount) : null;
+        }
+
         int newIdx;
-        if (_explain && selfNode is not null && plan.Root is UnionNode or IntersectNode)
+        if (_explain && selfNode is not null && root is UnionNode or IntersectNode)
         {
             // V1 parity (CheckEngine.CheckExpressionWithWrapper): when the permission's own tree
             // IS a union/intersect, that combinator gets a separate "and"/"or" wrapper node as
@@ -522,7 +587,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             // logic, MarkSiblingsSkipped, and AttachOrSetRoot, all of which must treat
             // _wrapSelfNodes[idx] (when set) as the real, attachable node instead of
             // _explainNodes[idx].
-            newIdx = SpawnFrame(plan.Root, entityType, entityId, subjectRelation, depth - 1, parent, rootIndex, memoEntry,
+            newIdx = SpawnFrame(root, entityType, entityId, subjectRelation, depth - 1, parent, rootIndex, memoEntry,
                 wrapSelfNode: selfNode);
         }
         else
@@ -536,12 +601,12 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             // NEVER touches the passed node's Type at all — it only ever adds the negated
             // child as a plain child, so selfNode must keep whatever Type/Name its own caller
             // gave it (e.g. Type=Permission, Name="view").
-            if (_explain && selfNode is not null && plan.Root is not NegateNode)
-                selfNode.Type = DescribeNode(plan.Root, permission).Type;
-            newIdx = SpawnFrame(plan.Root, entityType, entityId, subjectRelation, depth - 1, parent, rootIndex, memoEntry,
+            if (_explain && selfNode is not null && root is not NegateNode)
+                selfNode.Type = DescribeNode(root, permission).Type;
+            newIdx = SpawnFrame(root, entityType, entityId, subjectRelation, depth - 1, parent, rootIndex, memoEntry,
                 explainNode: selfNode);
         }
-        _frames[newIdx].Slots = plan.SlotCount > 0 ? new MemoSlotState[plan.SlotCount] : null;
+        _frames[newIdx].Slots = slots;
     }
 
     private void Notify(int parent, int rootIndex, bool result, int childIndex = -1)
@@ -647,6 +712,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 slot.ExplainWaiters = null;
                 CompleteFrame(parentIdx, childResult);
                 if (waiters is not null)
+                {
                     for (var i = 0; i < waiters.Count; i++)
                     {
                         var w = waiters[i];
@@ -657,6 +723,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                         }
                         Notify(w.Parent, w.RootIndex, childResult, w.ChildIndex);
                     }
+                    ReturnWaiterList(waiters);
+                }
                 break;
             }
 
@@ -711,6 +779,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             entry.ExplainWaiters = null;
             _memoEntries[frame.MemoEntry] = entry;
             if (waiters is not null)
+            {
                 for (var i = 0; i < waiters.Count; i++)
                 {
                     var w = waiters[i];
@@ -721,6 +790,8 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                     }
                     Notify(w.Parent, w.RootIndex, result, w.ChildIndex);
                 }
+                ReturnWaiterList(waiters);
+            }
         }
 
         Notify(frame.Parent, frame.RootIndex, result, frame.ChildIndex);
@@ -775,6 +846,18 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                         };
                     }
                 }
+                // Deliberately does NOT forward precompiledRoot/sharedSlots — a PlanRefNode
+                // re-entry always falls back to the regular per-permission CheckPlanCache path
+                // (ResolveDynamic's default null/null), even inside a combined-plan evaluation.
+                // This is still correctly shared, not a lost optimization: when p.Permission is
+                // one of the SubjectPermission call's own N roots, every root was already
+                // registered in _memoIndex synchronously before any frame stepped (see
+                // ExecuteAsync's root loop), so this re-entry's ResolveDynamic call finds that
+                // root's existing (or in-flight) memo entry and coalesces onto it — no duplicate
+                // work happens, and no combined-plan wiring is needed to make that happen. When
+                // p.Permission is NOT one of the N roots, it's a genuinely different plan the
+                // combined cache never built a shared slot for anyway, so falling back to its own
+                // private CheckPlanCache-compiled plan and slots array is simply correct.
                 ResolveDynamic(frame.EntityType, frame.EntityId, p.Permission,
                     frame.SubjectRelation, frame.Depth + 1, idx, frame.RootIndex, selfNode: reentryNode);
                 // +1: this frame's Depth was already charged by the ResolveDynamic that spawned
@@ -855,7 +938,7 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                         CompleteFrame(idx, slot.Value);
                         break;
                     case 1:
-                        (slot.Waiters ??= []).Add(new Waiter(frame.Parent, frame.RootIndex, frame.ChildIndex));
+                        (slot.Waiters ??= RentWaiterList()).Add(new Waiter(frame.Parent, frame.RootIndex, frame.ChildIndex));
                         if (_explain)
                         {
                             var (type, name) = DescribeNode(m.Child, frame.EntityType);

--- a/src/Valtuutus.Core/Engines/Check/V2/CombinedPlanCache.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CombinedPlanCache.cs
@@ -1,0 +1,67 @@
+using System.Collections.Concurrent;
+using Valtuutus.Core.Schemas;
+
+namespace Valtuutus.Core.Engines.Check.V2;
+
+internal sealed record CombinedPlan(PlanNode[] Roots, int SlotCount);
+
+// Registered as a DI singleton alongside CheckPlanCache/Schema — same lifetime reasoning: a
+// schema reload produces a new container, so a fresh cache comes for free without an explicit
+// version field. Used only by CheckEngineV2.SubjectPermission; Check()/Explain() stay on
+// CheckPlanCache exclusively and never construct or see a CombinedPlan. Keyed by
+// (EntityType, SubjectType) only, never by permission set: SubjectPermissionRequest has no
+// permission-subset parameter, so "all permissions for EntityType" is the only set any caller
+// can request today. A future subset API should recompute the combined plan on demand from the
+// already-cached per-permission trees instead of extending this cache to a per-subset key — a
+// per-subset key risks 2^N cache growth as the requested set varies, where recomputation from
+// small pre-compiled trees is cheap and bounded.
+internal sealed class CombinedPlanCache(Schema schema, IEnumerable<IPlanRewriter>? rewriters = null)
+{
+    private readonly Schema _schema = schema;
+    private readonly IPlanRewriter[] _rewriters = rewriters?.ToArray() ?? [];
+    private readonly ConcurrentDictionary<CombinedPlanKey, CombinedPlan> _plans = new();
+
+    public CombinedPlan GetOrCompile(string entityType, string? subjectType)
+        => _plans.GetOrAdd(new CombinedPlanKey(entityType, subjectType),
+            static (key, self) =>
+            {
+                var permissions = self._schema.GetPermissions(key.EntityType);
+                var pruned = new PlanNode[permissions.Count];
+                var i = 0;
+                foreach (var perm in permissions)
+                {
+                    // Mirrors PlanCompiler.Compile's own top-level guard, applied per permission
+                    // instead of once — a permission unreachable by subjectType still needs a
+                    // ConstNode.False ROOT (not to be omitted), so combined.Roots stays index-
+                    // aligned with schema.GetPermissions(entityType) for CheckEngineV2 to zip
+                    // against its own names[] array.
+                    pruned[i++] = key.SubjectType is not null
+                        && !self._schema.CanSubjectTypeReach(key.EntityType, perm.Name, key.SubjectType)
+                        ? ConstNode.False
+                        : PlanCompiler.Prune(self._schema, key.EntityType, perm.Name, key.SubjectType);
+                }
+
+                var (consed, slotCount) = PlanCompiler.Cons(pruned);
+
+                // Rewriters run once PER ROOT, unchanged — IPlanRewriter.Rewrite already takes
+                // one root and is contractually forbidden from unwrapping a MemoNode, so N calls
+                // over N roots sharing a MemoNode child cannot double-fuse or diverge (each call
+                // stops at the MemoNode boundary by contract). Combine BEFORE rewriting so
+                // structural-sharing detection isn't blinded by PhysicalCheckNode's deliberate
+                // reference-only equality (a rewriter-fused node is never interned).
+                for (var j = 0; j < consed.Length; j++)
+                {
+                    var root = consed[j];
+                    foreach (var rewriter in self._rewriters)
+                        root = rewriter.Rewrite(root, self._schema, key.EntityType, key.SubjectType);
+                    consed[j] = root;
+                }
+#if DEBUG
+                PlanValidator.ValidateCombined(consed, slotCount);
+#endif
+                return new CombinedPlan(consed, slotCount);
+            },
+            this);
+
+    private readonly record struct CombinedPlanKey(string EntityType, string? SubjectType);
+}

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanCompiler.cs
@@ -11,20 +11,32 @@ internal static class PlanCompiler
         if (subjectType is not null && !schema.CanSubjectTypeReach(entityType, permission, subjectType))
             return new CheckPlan(ConstNode.False, SlotCount: 0);
 
-        var root = CompileRoot(schema, entityType, permission);
-        root = PruneAndFold(root, schema, entityType, subjectType);
-        var (consed, slotCount) = HashCons(root);
+        var pruned = Prune(schema, entityType, permission, subjectType);
+        var (roots, slotCount) = Cons([pruned]);
         // Sibling fusion (batching several same-entity refs into one round trip) is NOT the
         // compiler's job: it lives in provider-side IPlanRewriter implementations
         // (Valtuutus.Data.Db's RelationalPlanRewriter), applied by CheckPlanCache after compile.
-        return new CheckPlan(consed, slotCount);
+        return new CheckPlan(roots[0], slotCount);
     }
 
-    // Bottom-up interning: identical subtrees become one node; any node referenced more than
-    // once gets a MemoNode slot. MemoNode is also the rewrite barrier for later provider
-    // passes — never fuse across it: the child is shared by multiple parents, and fusing it
-    // into one duplicates the work for the others.
-    private static (PlanNode Root, int SlotCount) HashCons(PlanNode root)
+    // Prune/fold only, no hash-consing — the seam CombinedPlanCache needs to gather N permission
+    // trees BEFORE they're interned, so structural sharing can be detected across permissions
+    // instead of only within one. Compile() itself is just Cons([Prune(...)]) below; callers that
+    // don't need cross-permission sharing keep using Compile().
+    public static PlanNode Prune(Schema schema, string entityType, string permission, string? subjectType)
+    {
+        var root = CompileRoot(schema, entityType, permission);
+        return PruneAndFold(root, schema, entityType, subjectType);
+    }
+
+    // Bottom-up interning over however many roots are given: identical subtrees ACROSS all of
+    // them become one node; any node referenced more than once (whether within one root or
+    // shared between two different roots) gets a MemoNode slot, drawn from one shared slot space
+    // for the whole call. Compile() calls this with a single-element array — CombinedPlanCache
+    // calls it with N roots to detect sharing between permissions. MemoNode is also the rewrite
+    // barrier for later provider passes — never fuse across it: the child is shared by multiple
+    // parents, and fusing it into one duplicates the work for the others.
+    public static (PlanNode[] Roots, int SlotCount) Cons(PlanNode[] roots)
     {
         var interned = new Dictionary<PlanNode, PlanNode>(PlanNodeStructuralComparer.Instance);
         var refCounts = new Dictionary<PlanNode, int>(ReferenceEqualityComparer.Instance);
@@ -57,7 +69,9 @@ internal static class PlanCompiler
             return node;
         }
 
-        var canonicalRoot = Intern(root);
+        var canonicalRoots = new PlanNode[roots.Length];
+        for (var i = 0; i < roots.Length; i++)
+            canonicalRoots[i] = Intern(roots[i]);
 
         // Assign slots to shared non-Const nodes, rebuild with MemoNode wrappers.
         var slots = new Dictionary<PlanNode, int>(ReferenceEqualityComparer.Instance);
@@ -65,7 +79,7 @@ internal static class PlanCompiler
             if (count > 1 && node is not ConstNode)
                 slots[node] = slots.Count;
 
-        if (slots.Count == 0) return (canonicalRoot, 0);
+        if (slots.Count == 0) return (canonicalRoots, 0);
 
         var memoized = new Dictionary<PlanNode, MemoNode>(ReferenceEqualityComparer.Instance);
         PlanNode Wrap(PlanNode node)
@@ -84,7 +98,10 @@ internal static class PlanCompiler
             return memo;
         }
 
-        return (Wrap(canonicalRoot), slots.Count);
+        var wrapped = new PlanNode[roots.Length];
+        for (var i = 0; i < roots.Length; i++)
+            wrapped[i] = Wrap(canonicalRoots[i]);
+        return (wrapped, slots.Count);
     }
 
     private static PlanNode PruneAndFold(PlanNode node, Schema schema, string entityType, string? subjectType)

--- a/src/Valtuutus.Core/Engines/Check/V2/PlanValidator.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PlanValidator.cs
@@ -18,45 +18,61 @@ public static class PlanValidator
     /// <exception cref="InvalidOperationException">The plan violates a structural rule.</exception>
     public static void Validate(PlanNode root, int slotCount)
     {
+        var roots = new HashSet<PlanNode>(ReferenceEqualityComparer.Instance) { root };
+        Walk(root, slotCount, new HashSet<int>(), new HashSet<PlanNode>(ReferenceEqualityComparer.Instance), roots);
+    }
+
+    /// <summary>
+    /// Same rules as <see cref="Validate"/>, applied to N roots sharing ONE slot space
+    /// (<see cref="CombinedPlanCache"/>'s output) — a slot may legitimately appear as the same
+    /// MemoNode instance under more than one of the N roots; two roots independently being
+    /// root-only-legal shapes (e.g. one a DirectRelationNode, another a Union) is expected, not
+    /// an error.
+    /// </summary>
+    public static void ValidateCombined(PlanNode[] roots, int slotCount)
+    {
+        var rootSet = new HashSet<PlanNode>(roots, ReferenceEqualityComparer.Instance);
         var seenSlots = new HashSet<int>();
         var visited = new HashSet<PlanNode>(ReferenceEqualityComparer.Instance);
-        Walk(root);
+        foreach (var root in roots)
+            Walk(root, slotCount, seenSlots, visited, rootSet);
+    }
 
-        void Walk(PlanNode node)
+    private static void Walk(PlanNode node, int slotCount, HashSet<int> seenSlots, HashSet<PlanNode> visited,
+        HashSet<PlanNode> roots)
+    {
+        if (!visited.Add(node)) return; // shared subtree — already checked
+        switch (node)
         {
-            if (!visited.Add(node)) return; // shared subtree — already checked
-            switch (node)
-            {
-                case MemoNode m:
-                    if (m.SlotId < 0 || m.SlotId >= slotCount)
-                        throw new InvalidOperationException(
-                            $"Plan validation: memo slot {m.SlotId} out of range (slotCount {slotCount}).");
-                    // A re-encountered *instance* already returned early via the visited set,
-                    // so a seen slot here can only mean a second, distinct MemoNode.
-                    if (!seenSlots.Add(m.SlotId))
-                        throw new InvalidOperationException(
-                            $"Plan validation: two distinct MemoNode instances share slot {m.SlotId} — " +
-                            "a rewriter rebuilt a shared memo without preserving reference identity.");
-                    Walk(m.Child);
-                    break;
-                case PhysicalCheckNode p:
-                    if (p.Op is null)
-                        throw new InvalidOperationException(
-                            "Plan validation: a rewriter constructed a PhysicalCheckNode without an ICheckOp; " +
-                            "the op must be supplied at construction.");
-                    break;
-                case DirectRelationNode when !ReferenceEquals(node, root):
+            case MemoNode m:
+                if (m.SlotId < 0 || m.SlotId >= slotCount)
                     throw new InvalidOperationException(
-                        "Plan validation: DirectRelationNode is root-only (a bare relation compiled as its " +
-                        "own plan) and must not appear at an interior position.");
-                case AttributeTruthNode when !ReferenceEquals(node, root):
+                        $"Plan validation: memo slot {m.SlotId} out of range (slotCount {slotCount}).");
+                // A re-encountered *instance* already returned early via the visited set,
+                // so a seen slot here can only mean a second, distinct MemoNode.
+                if (!seenSlots.Add(m.SlotId))
                     throw new InvalidOperationException(
-                        "Plan validation: AttributeTruthNode is root-only (a bare attribute compiled as its " +
-                        "own plan) and must not appear at an interior position.");
-                case UnionNode u: foreach (var c in u.Children) Walk(c); break;
-                case IntersectNode i: foreach (var c in i.Children) Walk(c); break;
-                case NegateNode n: Walk(n.Child); break;
-            }
+                        $"Plan validation: two distinct MemoNode instances share slot {m.SlotId} — " +
+                        "a rewriter rebuilt a shared memo without preserving reference identity.");
+                Walk(m.Child, slotCount, seenSlots, visited, roots);
+                break;
+            case PhysicalCheckNode p:
+                if (p.Op is null)
+                    throw new InvalidOperationException(
+                        "Plan validation: a rewriter constructed a PhysicalCheckNode without an ICheckOp; " +
+                        "the op must be supplied at construction.");
+                break;
+            case DirectRelationNode when !roots.Contains(node):
+                throw new InvalidOperationException(
+                    "Plan validation: DirectRelationNode is root-only (a bare relation compiled as its " +
+                    "own plan) and must not appear at an interior position.");
+            case AttributeTruthNode when !roots.Contains(node):
+                throw new InvalidOperationException(
+                    "Plan validation: AttributeTruthNode is root-only (a bare attribute compiled as its " +
+                    "own plan) and must not appear at an interior position.");
+            case UnionNode u: foreach (var c in u.Children) Walk(c, slotCount, seenSlots, visited, roots); break;
+            case IntersectNode i: foreach (var c in i.Children) Walk(c, slotCount, seenSlots, visited, roots); break;
+            case NegateNode n: Walk(n.Child, slotCount, seenSlots, visited, roots); break;
         }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -340,6 +340,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -340,6 +340,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -340,6 +340,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -340,6 +340,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -339,6 +339,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -339,6 +339,7 @@ namespace Valtuutus.Core.Engines.Check.V2
     public static class PlanValidator
     {
         public static void Validate(Valtuutus.Core.Engines.Check.V2.PlanNode root, int slotCount) { }
+        public static void ValidateCombined(Valtuutus.Core.Engines.Check.V2.PlanNode[] roots, int slotCount) { }
     }
     public sealed class TupleToUserSetNode : Valtuutus.Core.Engines.Check.V2.PlanNode, System.IEquatable<Valtuutus.Core.Engines.Check.V2.TupleToUserSetNode>
     {

--- a/tests/Valtuutus.Data.Db.Tests/PlanValidatorSpecs.cs
+++ b/tests/Valtuutus.Data.Db.Tests/PlanValidatorSpecs.cs
@@ -87,4 +87,46 @@ public class PlanValidatorSpecs
         var act = () => PlanValidator.Validate(root, slotCount: 0);
         act.Should().Throw<InvalidOperationException>().WithMessage("*root-only*");
     }
+
+    [Fact]
+    public void ValidateCombined_accepts_a_slot_shared_across_two_roots()
+    {
+        // The case ValidateCombined exists for: ONE MemoNode instance is each of TWO roots'
+        // top-level node (not just reachable from within one tree) — Validate() alone has no
+        // concept of "multiple roots", so a naive per-root call would need its own fresh seenSlots
+        // per root and would wrongly reject this as two different MemoNode instances reusing a slot.
+        var shared = new MemoNode(0, new PlanRefNode("a"));
+
+        var act = () => PlanValidator.ValidateCombined([shared, shared], slotCount: 1);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ValidateCombined_rejects_duplicate_memo_slot_instances_across_roots()
+    {
+        var dup1 = new MemoNode(0, new PlanRefNode("a"));
+        var dup2 = new MemoNode(0, new PlanRefNode("a"));
+
+        var act = () => PlanValidator.ValidateCombined([dup1, dup2], slotCount: 1);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*two distinct MemoNode instances*");
+    }
+
+    [Fact]
+    public void ValidateCombined_accepts_direct_relation_node_as_a_second_roots_own_root()
+    {
+        // Each of the N combined roots is independently root-only-legal: a DirectRelationNode is
+        // fine as root #1 even though root #0 is a totally different shape.
+        var act = () => PlanValidator.ValidateCombined(
+            [new UnionNode([new PlanRefNode("a")]), new DirectRelationNode("owner", false)], slotCount: 0);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ValidateCombined_rejects_direct_relation_node_below_root_in_any_root()
+    {
+        var act = () => PlanValidator.ValidateCombined(
+            [new DirectRelationNode("owner", false), new UnionNode([new DirectRelationNode("editor", false)])],
+            slotCount: 0);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*root-only*");
+    }
 }

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
@@ -194,6 +194,82 @@ public class CheckPlanExecutorSpecs
     }
 
     [Fact]
+    public async Task Combined_roots_share_one_slot_and_evaluate_shared_TTU_once()
+    {
+        const string schemaText = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity team {
+                relation owner @user;
+                relation org @organization;
+                permission edit := org.admin or owner;
+                permission delete := org.admin or owner;
+            }
+            """;
+        var (_, schema, reader) = await Arrange(schemaText,
+            [new RelationTuple("team", "1", "org", "organization", "org1"),
+             new RelationTuple("organization", "org1", "admin", "user", "u1")]);
+        var ctx = new CheckRequestContext
+        {
+            SubjectType = "user", SubjectId = "u1",
+            SnapToken = (await reader.GetLatestSnapToken(default))!.Value, Context = new Dictionary<string, object>()
+        };
+
+        var combined = new CombinedPlanCache(schema).GetOrCompile("team", "user");
+        var physical = new RecordingPhysicalExecutor(new DefaultPhysicalExecutor(schema) { Reader = reader });
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = physical };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10)],
+            ctx, default, precompiledRoots: combined.Roots, combinedSlotCount: combined.SlotCount);
+
+        results.Should().Equal(true, true);
+        // The whole edit/delete body is one shared MemoNode under the combined plan — "org" gets
+        // resolved exactly once total across both permissions, not once each.
+        physical.Submitted.Count(op => op.Relation == "org").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Without_combined_roots_the_same_shared_subtree_evaluates_twice()
+    {
+        // Baseline contrast for the test above: two SEPARATE per-permission plans (today's existing
+        // behavior, precompiledRoots omitted) do NOT share a slot, so "org" gets resolved once per
+        // permission that references it.
+        const string schemaText = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity team {
+                relation owner @user;
+                relation org @organization;
+                permission edit := org.admin or owner;
+                permission delete := org.admin or owner;
+            }
+            """;
+        var (_, schema, reader) = await Arrange(schemaText,
+            [new RelationTuple("team", "1", "org", "organization", "org1"),
+             new RelationTuple("organization", "org1", "admin", "user", "u1")]);
+        var ctx = new CheckRequestContext
+        {
+            SubjectType = "user", SubjectId = "u1",
+            SnapToken = (await reader.GetLatestSnapToken(default))!.Value, Context = new Dictionary<string, object>()
+        };
+
+        var physical = new RecordingPhysicalExecutor(new DefaultPhysicalExecutor(schema) { Reader = reader });
+        var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = physical };
+
+        var results = await executor.ExecuteAsync(
+            [new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10)],
+            ctx, default);
+
+        results.Should().Equal(true, true);
+        physical.Submitted.Count(op => op.Relation == "org").Should().Be(2);
+    }
+
+    [Fact]
     public async Task Depth_zero_returns_false()
     {
         (await RunCheck(DocSchema, [new RelationTuple("doc", "1", "owner", "user", "u1")], null,

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CombinedPlanCacheSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CombinedPlanCacheSpecs.cs
@@ -1,0 +1,146 @@
+using FluentAssertions;
+using Valtuutus.Core.Engines.Check.V2;
+using Valtuutus.Core.Schemas;
+
+namespace Valtuutus.Data.InMemory.Tests.V2;
+
+public class CombinedPlanCacheSpecs
+{
+    private static Schema Parse(string text) => PlanCompilerSpecs.Parse(text);
+
+    private const string TeamSchema = """
+        entity user {}
+        entity organization {
+            relation admin @user;
+        }
+        entity team {
+            relation owner @user;
+            relation org @organization;
+            permission edit := org.admin or owner;
+            permission delete := org.admin or owner;
+        }
+        """;
+
+    [Fact]
+    public void Combines_all_permissions_for_an_entity_type()
+    {
+        var cache = new CombinedPlanCache(Parse(TeamSchema));
+        var combined = cache.GetOrCompile("team", "user");
+        combined.Roots.Should().HaveCount(2); // edit, delete
+    }
+
+    [Fact]
+    public void Identical_permission_bodies_share_one_combined_slot()
+    {
+        var cache = new CombinedPlanCache(Parse(TeamSchema));
+        var combined = cache.GetOrCompile("team", "user");
+        // 3, not 1: the outer Union AND both its leaves (org.admin, owner) are each referenced
+        // by both edit and delete, so each independently crosses the refcount>1 threshold — see
+        // the comment on PlanCompilerSpecs.Cons_of_two_roots_sharing_a_subtree_gets_one_combined_slot
+        // for why this is correct (not minimal, but the nested slots are never independently
+        // re-triggered since the outer MemoNode's memoization intercepts first). The load-bearing
+        // assertion here is the second line: both permissions get the literal same root object.
+        combined.SlotCount.Should().Be(3);
+        combined.Roots[0].Should().BeSameAs(combined.Roots[1]);
+    }
+
+    [Fact]
+    public void Cache_returns_same_instance_for_same_key()
+    {
+        var cache = new CombinedPlanCache(Parse(TeamSchema));
+        var a = cache.GetOrCompile("team", "user");
+        var b = cache.GetOrCompile("team", "user");
+        b.Roots.Should().BeSameAs(a.Roots);
+    }
+
+    [Fact]
+    public void Cache_keys_include_subjectType()
+    {
+        const string s = """
+            entity user {}
+            entity service_account {}
+            entity organization {
+                relation admin @user;
+                relation bot @service_account;
+                permission access := admin or bot;
+            }
+            """;
+        var cache = new CombinedPlanCache(Parse(s));
+        var forUser = cache.GetOrCompile("organization", "user");
+        var forBot = cache.GetOrCompile("organization", "service_account");
+        forUser.Roots.Should().NotBeSameAs(forBot.Roots);
+    }
+
+    [Fact]
+    public void Permission_unreachable_by_subjectType_becomes_ConstFalse_not_omitted()
+    {
+        const string s = """
+            entity user {}
+            entity service_account {}
+            entity organization {
+                relation admin @user;
+                relation bot @service_account;
+                permission access := admin;
+                permission botOnly := bot;
+            }
+            """;
+        var cache = new CombinedPlanCache(Parse(s));
+        var combined = cache.GetOrCompile("organization", "user");
+        // Both permissions still get a root (index alignment with schema.GetPermissions is a
+        // hard requirement for CheckEngineV2.SubjectPermission's names[]/roots[] pairing) —
+        // botOnly's root just folds to ConstNode.False for a "user" subject.
+        combined.Roots.Should().HaveCount(2);
+        combined.Roots.Should().Contain(r => r == ConstNode.False);
+    }
+
+    [Fact]
+    public void GetOrCompile_never_trips_ValidateCombineds_root_only_rule()
+    {
+        // Regression guard: PlanValidator.ValidateCombined's root-only check could in principle
+        // false-positive on a bare DirectRelationNode/AttributeTruthNode wrapped in a MemoNode
+        // across multiple combined roots. Traced and confirmed unreachable through CombinedPlanCache
+        // specifically, because Schema.GetRelationType always classifies a name drawn from
+        // schema.GetPermissions() as RelationType.Permission
+        // (Permissions dictionary is checked first) — so PlanCompiler.Prune's CompileRoot call can
+        // never take the DirectRelationNode/AttributeTruthNode branch for anything CombinedPlanCache
+        // compiles, even when a permission's entire body is just a bare relation alias (bareAlias
+        // below). This test pins that invariant so a future change can't silently reintroduce the
+        // false-positive path. #if DEBUG is required because ValidateCombined only runs in DEBUG
+        // builds inside GetOrCompile — this test needs to observe that path directly, so it calls
+        // GetOrCompile normally (which already runs ValidateCombined internally in DEBUG) and just
+        // asserts it doesn't throw; the meaningful assertion IS "doesn't throw" here.
+        const string s = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity team {
+                relation owner @user;
+                relation org @organization;
+                permission edit := org.admin or owner;
+                permission delete := org.admin or owner;
+                permission bareAlias := owner;
+            }
+            """;
+        var cache = new CombinedPlanCache(Parse(s));
+        var act = () => cache.GetOrCompile("team", "user");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Entity_type_with_no_permissions_returns_empty_combined_plan()
+    {
+        const string s = """
+            entity user {}
+            entity doc {
+                relation owner @user;
+            }
+            """;
+        var cache = new CombinedPlanCache(Parse(s));
+        var act = () => cache.GetOrCompile("doc", "user");
+        act.Should().NotThrow();
+        var combined = cache.GetOrCompile("doc", "user");
+        combined.Roots.Should().BeEmpty();
+        combined.SlotCount.Should().Be(0);
+    }
+}

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/PlanCompilerSpecs.cs
@@ -385,6 +385,65 @@ public class PlanCompilerSpecs
         second.SlotId.Should().Be(first.SlotId);
     }
 
+    [Fact]
+    public void Cons_of_single_root_matches_todays_Compile_output()
+    {
+        // Regression guard for the Prune/Cons split: Cons([Prune(...)]) must produce byte-identical
+        // output to Compile() for a single permission — every existing Compile()-based test in this
+        // file is an implicit regression test for this too, but this one is explicit about the seam.
+        const string s = """
+            entity user {}
+            entity folder {
+                relation owner @user;
+                relation editor @user;
+                permission admin := owner or (editor and owner);
+            }
+            """;
+        var schema = Parse(s);
+        var viaCompile = PlanCompiler.Compile(schema, "folder", "admin", "user");
+
+        var pruned = PlanCompiler.Prune(schema, "folder", "admin", "user");
+        var (roots, slotCount) = PlanCompiler.Cons([pruned]);
+
+        roots.Should().HaveCount(1);
+        PlanNodeStructuralComparer.Instance.Equals(roots[0], viaCompile.Root).Should().BeTrue();
+        slotCount.Should().Be(viaCompile.SlotCount);
+    }
+
+    [Fact]
+    public void Cons_of_two_roots_sharing_a_subtree_gets_one_combined_slot()
+    {
+        const string s = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity team {
+                relation owner @user;
+                relation org @organization;
+                permission edit := org.admin or owner;
+                permission delete := org.admin or owner;
+            }
+            """;
+        var schema = Parse(s);
+        var editPruned = PlanCompiler.Prune(schema, "team", "edit", "user");
+        var deletePruned = PlanCompiler.Prune(schema, "team", "delete", "user");
+
+        var (roots, slotCount) = PlanCompiler.Cons([editPruned, deletePruned]);
+
+        // edit and delete are byte-identical bodies, so the whole root interns to one canonical
+        // node — the combined plan gives BOTH permissions the exact same (Memo-wrapped) root.
+        // Refcounting is per-node, not "outermost shared node only": org.admin (TTU) and owner
+        // are each independently referenced by both edit and delete, on top of the outer Union
+        // itself, so all three cross refcount>1 and each gets a slot (3 total) — the nested
+        // slots are allocated but never independently re-triggered, since the outer MemoNode's
+        // own memoization short-circuits before the second root's traversal ever reaches them.
+        roots.Should().HaveCount(2);
+        slotCount.Should().Be(3);
+        roots[0].Should().BeOfType<MemoNode>();
+        roots[1].Should().BeSameAs(roots[0]);
+    }
+
     private const string HouseholdSchema = """
         entity user {}
         entity household {

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -498,6 +498,48 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SubjectPermissionWithSharedInlineSubtreeAcrossPermissions()
+    {
+        // The motivating case for the combined-plan work: edit/delete are byte-identical bodies
+        // referencing the SAME org.admin subtree, inlined (not factored into a shared named
+        // permission) — exactly the benchmarks/Valtuutus.Benchmarks/schema.vtt team entity shape.
+        // Correctness must be identical regardless of whether the engine evaluates org.admin
+        // once (V2 combined path) or twice (V1, and V2 before this change).
+        const string schema = """
+            entity user {}
+            entity organization {
+                relation admin @user;
+            }
+            entity team {
+                relation owner @user;
+                relation org @organization;
+                permission edit := org.admin or owner;
+                permission delete := org.admin or owner;
+                permission view := owner;
+            }
+            """;
+
+        var engine = await CreateEngine(
+            [
+                new RelationTuple("team", "t1", "org", "organization", "org1"),
+                new RelationTuple("organization", "org1", "admin", "user", "1"),
+            ], [], schema);
+
+        var result = await engine.SubjectPermission(
+            new SubjectPermissionRequest
+            {
+                EntityType = "team",
+                EntityId = "t1",
+                SubjectType = "user",
+                SubjectId = "1"
+            }, default);
+
+        result["edit"].Should().BeTrue();
+        result["delete"].Should().BeTrue();
+        result["view"].Should().BeFalse();
+    }
+
+    [Fact]
     public async Task SubjectPermissionWithDepthLimit()
     {
         // Arrange


### PR DESCRIPTION
## Summary

`SubjectPermission` compiled each requested permission as its own plan with its own slot space, so a subtree shared structurally across two different permissions — not via a named-permission reference, but inlined (e.g. `project`'s `view`/`edit`/`delete`/`cache_test` all inlining `org.admin`) — was evaluated once per permission that referenced it.

- `PlanCompiler.Compile` splits into `Prune` (prune/fold, unconsed) + `Cons` (hash-cons, now over N roots instead of always one).
- `CombinedPlanCache` compiles all of an entity type's permissions together, so a shared subtree interns to one canonical node with one slot in a combined slot space.
- `CheckPlanExecutor` threads that precompiled root/shared slot array through `SpawnPlan` only when supplied — `Check()`/`Explain()` (single-root) are unaffected and keep using the existing per-permission `CheckPlanCache` and their own small per-root slot array.
- A `dotnet-trace`/`pvanalyze` investigation showed the sharing mechanism itself has a cost (waiter-list/shared-slot-array allocation) — pooled both via this file's existing `ArrayPool`-based rent/return pattern.

Design doc + implementation plan: #274, #283.

## Verification

- Direct op-count check (project entity's 4 permissions, shared `org` relation): 5 submissions → 2.
- Benchmark (InMemory, `VALTUUTUS_CHECK_V2=1`, `--job short`), `SubjectPermission`:
  - before (V2, no sharing): 6242 ns, 1560 B
  - after sharing, before pooling: 5332 ns, 1736 B
  - after pooling: **5174 ns, 1304 B** (both down vs. baseline)
- `SubjectPermission_Diamond`: 2186 ns / 1576 B → 2132 ns / 1192 B (post-pooling).
- `Check_UnionTtuDirect` (single-root, unaffected path): 408 B / ~920-950 ns throughout every round — confirms `Check()`'s hot path never changed.
- `CI=true dotnet test Valtuutus.slnx` (full solution, all providers, all TFMs): 0 failures.

## Follow-ons filed

- #285 — remaining allocation leads from the trace investigation (not part of this PR's scope)
- #286 — `SubjectPermissionRequest` missing `Context` (pre-existing correctness bug, found during this work, affects both V1 and V2 equally — not fixed here)

## Test plan

- [x] `dotnet build Valtuutus.slnx` clean
- [x] `CI=true dotnet test Valtuutus.slnx` — 0 failures across InMemory/Postgres/SqlServer, all TFMs
- [x] New unit tests: `PlanCompilerSpecs` (Prune/Cons regression + multi-root sharing), `PlanValidatorSpecs` (`ValidateCombined`), `CombinedPlanCacheSpecs`, `CheckPlanExecutorSpecs` (shared-slot op-count proof), `BaseCheckEngineSpecs` (end-to-end correctness)
- [x] Benchmarked before/after, InMemory, interleaved reps