### PR TITLE
fix: SubjectPermissionRequest has no Context, so context-access function args always evaluate false

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -141,7 +141,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             SubjectType = req.SubjectType,
             SubjectId = req.SubjectId,
             SnapToken = snapToken,
-            Context = new Dictionary<string, object>(0)
+            Context = req.Context
         };
 
         var i = 0;

--- a/src/Valtuutus.Core/Engines/Check/SubjectPermissionRequest.cs
+++ b/src/Valtuutus.Core/Engines/Check/SubjectPermissionRequest.cs
@@ -4,10 +4,13 @@ namespace Valtuutus.Core.Engines.Check;
 
 public record SubjectPermissionRequest : IWithSnapToken
 {
+    private static readonly IDictionary<string, object> EmptyContext = new Dictionary<string, object>(0);
+
     public required string EntityType { get; init; }
     public required string EntityId { get; init; }
     public required string SubjectType { get; init; }
     public required string SubjectId { get; init; }
     public SnapToken? SnapToken { get; set; }
     public int Depth { get; init; } = 10;
+    public IDictionary<string, object> Context { get; init; } = EmptyContext;
 };

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
@@ -51,7 +51,7 @@ internal sealed class CheckEngineV2(IDataReaderProvider reader, Schema schema, C
         var ctx = new CheckRequestContext
         {
             SubjectType = req.SubjectType, SubjectId = req.SubjectId,
-            SnapToken = snapToken, Context = new Dictionary<string, object>(0)
+            SnapToken = snapToken, Context = req.Context
         };
 
         var permissions = schema.GetPermissions(req.EntityType);

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -218,6 +218,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -218,6 +218,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -218,6 +218,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -218,6 +218,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -217,6 +217,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -217,6 +217,7 @@ namespace Valtuutus.Core.Engines.Check
     public class SubjectPermissionRequest : System.IEquatable<Valtuutus.Core.Engines.Check.SubjectPermissionRequest>, Valtuutus.Core.Engines.IWithSnapToken
     {
         public SubjectPermissionRequest() { }
+        public System.Collections.Generic.IDictionary<string, object> Context { get; init; }
         public int Depth { get; init; }
         public required string EntityId { get; init; }
         public required string EntityType { get; init; }

--- a/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
+++ b/tests/Valtuutus.Tests.Shared/BaseCheckEngineSpecs.cs
@@ -1254,4 +1254,62 @@ public abstract class BaseCheckEngineSpecs : IAsyncLifetime
         result.Should().ContainKey("view").WhoseValue.Should().BeTrue();
         result.Should().ContainKey("admin").WhoseValue.Should().BeTrue();
     }
+
+    private const string ContextFunctionSchema = """
+        entity user {}
+        entity account {
+            relation owner @user;
+            attribute balance int;
+            permission withdraw := check_balance(context.amount, balance) and owner;
+        }
+
+        fn check_balance(amount int, balance int) =>
+            (balance >= amount) and (amount <= 5000);
+        """;
+
+    [Fact]
+    public async Task SubjectPermissionShouldEvaluateContextAccessFunctionArgWhenContextSupplied()
+    {
+        // SubjectPermissionRequest.Context must reach the same CheckRequestContext.Context
+        // that Check() uses, or any context-access function arg (context.amount here) always
+        // evaluates its leaf to false via IsContextValid.
+        var engine = await CreateEngine(
+            [new RelationTuple("account", "1", "owner", "user", "1")],
+            [new AttributeTuple("account", "1", "balance", JsonValue.Create(5000))],
+            ContextFunctionSchema);
+
+        var result = await engine.SubjectPermission(
+            new SubjectPermissionRequest
+            {
+                EntityType = "account",
+                EntityId = "1",
+                SubjectType = "user",
+                SubjectId = "1",
+                Context = new Dictionary<string, object> { ["amount"] = 5000 }
+            }, default);
+
+        result.Should().ContainKey("withdraw").WhoseValue.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SubjectPermissionShouldKeepDefaultBehaviorWhenNoContextSupplied()
+    {
+        // When the caller supplies no Context, check_balance's context.amount arg is missing,
+        // IsContextValid fails, and the leaf evaluates to false.
+        var engine = await CreateEngine(
+            [new RelationTuple("account", "1", "owner", "user", "1")],
+            [new AttributeTuple("account", "1", "balance", JsonValue.Create(5000))],
+            ContextFunctionSchema);
+
+        var result = await engine.SubjectPermission(
+            new SubjectPermissionRequest
+            {
+                EntityType = "account",
+                EntityId = "1",
+                SubjectType = "user",
+                SubjectId = "1"
+            }, default);
+
+        result.Should().ContainKey("withdraw").WhoseValue.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- Add `Context` (`IDictionary<string, object>`) to `SubjectPermissionRequest`, matching the `EmptyContext`-singleton-default pattern already used by `CheckRequest`/`LookupEntityRequest`/`LookupSubjectRequest`
- Thread it through to `CheckRequestContext.Context` in both `CheckEngineV2.SubjectPermission` and V1 `CheckEngine.SubjectPermission`, replacing the hardcoded empty dictionary
- Update `Valtuutus.Api.Tests` approved public-API snapshots (Core assembly gained one public property)

## Test plan
- [x] New test: permission using a context-access function argument returns the correct (non-`false`) result via `SubjectPermission` when the required context value is supplied (runs against both V1/V2 engines, all data providers)
- [x] New test: existing behavior (empty/default context) unchanged when the caller supplies none
- [x] `CI=true dotnet test Valtuutus.slnx` passes clean across the whole solution

Closes #286