### PR TITLE
perf: fix SubjectPermission's remaining allocation leads

### DIFF
--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -132,7 +132,7 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
         var permissions = schema.GetPermissions(req.EntityType);
         var snapToken = await SnapTokenUtils.ResolveLatest(reader, req.SnapToken, cancellationToken);
 
-        var count = permissions.Count;
+        var count = permissions.Length;
         var names = new string[count];
         var tasks = new Task<bool>[count];
         var memo = new CheckMemo();

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckEngineV2.cs
@@ -55,34 +55,39 @@ internal sealed class CheckEngineV2(IDataReaderProvider reader, Schema schema, C
         };
 
         var permissions = schema.GetPermissions(req.EntityType);
-        var roots = new CheckRootRequest[permissions.Count];
-        var names = new string[permissions.Count];
+
+        // Roots buffer is rented from the executor itself (reused across calls on this pooled
+        // instance — see CheckPlanExecutor.RentMultiRootBuffer), not a fresh `new
+        // CheckRootRequest[permissions.Length]` every call. Rent the executor before filling it:
+        // the buffer is owned by the executor instance, so it must be picked first.
+        var executor = executorPool.Rent(reader);
+        var roots = executor.RentMultiRootBuffer(permissions.Length);
+        var rootsSpan = roots.Span;
         var i = 0;
         foreach (var perm in permissions)
-        {
-            names[i] = perm.Name;
-            roots[i] = new CheckRootRequest(req.EntityType, req.EntityId, perm.Name, null, req.Depth);
-            i++;
-        }
+            rootsSpan[i++] = new CheckRootRequest(req.EntityType, req.EntityId, perm.Name, null, req.Depth);
 
         // Combined plan: all N permission trees hash-consed together (cached per
         // (EntityType, SubjectType)), so a subtree shared across two permissions gets one slot
         // in one shared array below instead of one array per root. Roots is index-aligned with
-        // roots[]/names[] because both this loop and CombinedPlanCache iterate the same
-        // schema.GetPermissions(entityType) FrozenDictionary.Values, whose iteration order is
-        // fixed once the schema is built.
+        // combined.Roots and (below) with permissions itself, because this loop, CombinedPlanCache,
+        // and the result-building loop below all iterate the same schema.GetPermissions(entityType)
+        // FrozenDictionary.Values, whose iteration order is fixed once the schema is built.
         var combined = combinedPlans.GetOrCompile(req.EntityType, ctx.SubjectType);
 
         // One driver loop, N roots: all permissions evaluate concurrently and share the
         // request's dynamic memo — the V2 equivalent of V1's shared CheckMemo here.
-        var executor = executorPool.Rent(reader);
         var results = await executor.ExecuteAsync(roots, ctx, cancellationToken,
             precompiledRoots: combined.Roots, combinedSlotCount: combined.SlotCount);
         _ = DrainAndReturn(executor);
 
-        var dict = new Dictionary<string, bool>(names.Length);
-        for (var j = 0; j < names.Length; j++)
-            dict[names[j]] = results[j];
+        // Re-enumerate permissions (instead of a `names[]` array built alongside roots above) to
+        // pair each name with its result — avoids a second heap array purely to carry names
+        // across the await.
+        var dict = new Dictionary<string, bool>(permissions.Length);
+        var j = 0;
+        foreach (var perm in permissions)
+            dict[perm.Name] = results[j++];
         return dict;
     }
 

--- a/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CheckPlanExecutor.cs
@@ -51,6 +51,24 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // `roots` synchronously in its prologue, before any await — nothing else can be writing to
     // this same pooled instance's buffer concurrently (see pool ownership sequencing above).
     private readonly CheckRootRequest[] _singleRootBuffer = new CheckRootRequest[1];
+    // Analogous buffer for the N-root case (CheckEngineV2.SubjectPermission) — grown to fit,
+    // never shrunk, reused across calls on this pooled instance. Same safety argument as
+    // _singleRootBuffer: the caller fills it synchronously, before ExecuteAsync's first await,
+    // so nothing else on this pooled instance can be writing to it concurrently. Sized to exactly
+    // fit the last call's root count in steady state (repeated SubjectPermission calls against
+    // the same EntityType always request the same count), so growth only recurs when the
+    // permission-set size actually changes.
+    private CheckRootRequest[] _multiRootBuffer = [];
+
+    /// <summary>Returns this pooled instance's reusable multi-root buffer, grown to fit
+    /// <paramref name="count"/> if needed, sliced to exactly <paramref name="count"/> entries.
+    /// Caller must fill every slot before the first await inside <see cref="ExecuteAsync"/>.</summary>
+    internal Memory<CheckRootRequest> RentMultiRootBuffer(int count)
+    {
+        if (_multiRootBuffer.Length < count)
+            _multiRootBuffer = new CheckRootRequest[count];
+        return _multiRootBuffer.AsMemory(0, count);
+    }
     // Total dispatched-but-not-yet-completed ops, independent of _rootsPending. A short-circuited
     // Union/Intersect can make _rootsPending hit 0 while sibling ops are still in flight — this
     // instance is NOT safe to return to the pool until _pendingOps also reaches 0 (see
@@ -176,8 +194,13 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
     // entirely (mirrors V1 CheckEngine.Check() passing memoize: false to its one CheckInternal
     // call). SubjectPermission's N roots keep memoizing (V1 default) since they can
     // legitimately reference each other.
-    public async Task<bool[]> ExecuteAsync(CheckRootRequest[] roots, CheckRequestContext ctx, CancellationToken ct,
-        bool memoizeRoots = true, bool explain = false,
+    // ReadOnlyMemory<T> (not CheckRootRequest[] or ReadOnlySpan<T>): a Span can't be an async
+    // method parameter, but Memory<T> can — this lets ExecuteSingleAsync/SubjectPermission pass a
+    // slice of a buffer they own (_singleRootBuffer / CheckPlanExecutor's own _multiRootBuffer)
+    // without allocating a fresh array sized to exactly `roots.Length` on every call. A plain
+    // T[] converts to ReadOnlyMemory<T> implicitly, so every existing caller is unaffected.
+    public async Task<bool[]> ExecuteAsync(ReadOnlyMemory<CheckRootRequest> roots, CheckRequestContext ctx,
+        CancellationToken ct, bool memoizeRoots = true, bool explain = false,
         PlanNode[]? precompiledRoots = null, int combinedSlotCount = 0)
     {
         _ctx = ctx;
@@ -212,18 +235,23 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
             "precompiledRoots, when supplied, must be index-aligned with roots — the caller (CheckEngineV2.SubjectPermission) builds both from the same schema.GetPermissions(entityType) iteration.");
         try
         {
-            for (var i = 0; i < roots.Length; i++)
+            // .Span is safe here (and only here): this whole prologue runs synchronously, before
+            // the first await below — see the type this method's `roots` docs point at
+            // (_singleRootBuffer/_multiRootBuffer) for why nothing else can mutate the backing
+            // buffer out from under this span mid-loop.
+            var rootsSpan = roots.Span;
+            for (var i = 0; i < rootsSpan.Length; i++)
             {
                 CheckNode? rootNode = _explain
                     ? new CheckNode
                     {
-                        Type = CheckNodeType.Permission, Name = roots[i].Permission,
-                        EntityType = roots[i].EntityType, EntityId = roots[i].EntityId,
+                        Type = CheckNodeType.Permission, Name = rootsSpan[i].Permission,
+                        EntityType = rootsSpan[i].EntityType, EntityId = rootsSpan[i].EntityId,
                         SubjectType = _ctx.SubjectType, SubjectId = _ctx.SubjectId,
                     }
                     : null;
-                ResolveDynamic(roots[i].EntityType, roots[i].EntityId, roots[i].Permission,
-                    roots[i].SubjectRelation, roots[i].Depth, NoParent, i, memoizeRoots, rootNode,
+                ResolveDynamic(rootsSpan[i].EntityType, rootsSpan[i].EntityId, rootsSpan[i].Permission,
+                    rootsSpan[i].SubjectRelation, rootsSpan[i].Depth, NoParent, i, memoizeRoots, rootNode,
                     precompiledRoots?[i], sharedSlots);
             }
 
@@ -1182,16 +1210,23 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
         ref var frame = ref _frames[idx];
         if (frame.Completed)
         {
-            (completion.Payload as IDisposable)?.Dispose();
+            // Payload travels as the raw List<RelationTuple> (not a PooledList<RelationTuple>) to
+            // avoid boxing the struct through this `object` field — see PhysicalOpRunner/
+            // BatchedPhysicalExecutor's .Transfer() calls. Return it to the pool directly instead
+            // of via PooledList<T>.Dispose(), which this payload shape no longer offers.
+            if (completion.Payload is List<RelationTuple> staleList) ListPool<RelationTuple>.Return(staleList);
             return; // stale — most commonly a short-circuit straggler (see DrainStragglersAsync)
         }
 
         switch (frame.Node)
         {
             case DirectRelationNode d:
-                if (completion.Payload is PooledList<RelationTuple> indirect)
+                if (completion.Payload is List<RelationTuple> indirectList)
                 {
-                    OnIndirectRelationsFetched(idx, indirect);
+                    // Re-wrap into a PooledList<T> here (not further down the call chain) so
+                    // OnIndirectRelationsFetched's `using var _ = relations;` still returns it to
+                    // the pool exactly once, same as before this payload shape changed.
+                    OnIndirectRelationsFetched(idx, new PooledList<RelationTuple>(indirectList));
                 }
                 else if (completion.Result || !d.HasSubRelationPaths)
                 {
@@ -1229,9 +1264,9 @@ internal sealed class CheckPlanExecutor(Schema schema, CheckPlanCache plans) : I
                 break;
 
             case TupleToUserSetNode t:
-                if (completion.Payload is PooledList<RelationTuple> rels)
+                if (completion.Payload is List<RelationTuple> relsList)
                 {
-                    OnTupleToUserSetExpanded(idx, t, rels);
+                    OnTupleToUserSetExpanded(idx, t, new PooledList<RelationTuple>(relsList));
                 }
                 else
                 {

--- a/src/Valtuutus.Core/Engines/Check/V2/CombinedPlanCache.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/CombinedPlanCache.cs
@@ -26,7 +26,7 @@ internal sealed class CombinedPlanCache(Schema schema, IEnumerable<IPlanRewriter
             static (key, self) =>
             {
                 var permissions = self._schema.GetPermissions(key.EntityType);
-                var pruned = new PlanNode[permissions.Count];
+                var pruned = new PlanNode[permissions.Length];
                 var i = 0;
                 foreach (var perm in permissions)
                 {

--- a/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/PhysicalExecution.cs
@@ -204,12 +204,17 @@ public static class PhysicalOpRunner
                         op.EntityType, op.EntityIds!, op.Relation!, ctx.SubjectId!, ctx.SnapToken, ct).ConfigureAwait(false));
                     break;
                 case OpKind.GetRelations:
-                    sink.CompleteWithPayload(op.Token, await reader.GetRelations(
-                        Filter(op, op.Relation!, ctx), ct).ConfigureAwait(false));
+                    // .Transfer() (not the PooledList<T> struct itself): CompleteWithPayload
+                    // takes `object`, and boxing a struct there is a real per-op heap allocation.
+                    // The underlying List<T> is already a reference type — pass it directly and
+                    // let CheckPlanExecutor re-wrap it in a PooledList<T> on the consuming side
+                    // (see CheckPlanExecutor.OnOpCompleted).
+                    sink.CompleteWithPayload(op.Token, (await reader.GetRelations(
+                        Filter(op, op.Relation!, ctx), ct).ConfigureAwait(false)).Transfer());
                     break;
                 case OpKind.GetIndirectRelations:
-                    sink.CompleteWithPayload(op.Token, await reader.GetIndirectRelations(
-                        Filter(op, op.Relation!, ctx), ct).ConfigureAwait(false));
+                    sink.CompleteWithPayload(op.Token, (await reader.GetIndirectRelations(
+                        Filter(op, op.Relation!, ctx), ct).ConfigureAwait(false)).Transfer());
                     break;
                 case OpKind.CheckOp:
                     sink.Complete(op.Token, await op.Op!.Execute(reader, ctx, op.EntityType, op.EntityId, ct)

--- a/src/Valtuutus.Core/Pools/PooledList.cs
+++ b/src/Valtuutus.Core/Pools/PooledList.cs
@@ -27,13 +27,13 @@ public readonly struct PooledList<T> : IEnumerable<T>, IDisposable
     public void Add(T item) => _list.Add(item);
     public void AddRange(IEnumerable<T> items) => _list.AddRange(items);
 
+    public ReadOnlySpan<T> AsSpan() => CollectionsMarshal.AsSpan(_list);
+
     /// <summary>
     /// Transfers ownership of the underlying list to the caller.
     /// The list is NOT returned to the pool — the caller is responsible for its lifecycle.
     /// </summary>
-    public ReadOnlySpan<T> AsSpan() => CollectionsMarshal.AsSpan(_list);
-
-    internal List<T> Transfer() => _list;
+    public List<T> Transfer() => _list;
 
     public void Dispose() => ListPool<T>.Return(_list);
 }

--- a/src/Valtuutus.Core/Schemas/Schema.cs
+++ b/src/Valtuutus.Core/Schemas/Schema.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Valtuutus.Core.Engines.Check;
 
@@ -52,7 +53,12 @@ public record Schema
         return Entities[entityType].Attributes[attribute];
     }
 
-    internal IReadOnlyCollection<Permission> GetPermissions(string entityType)
+    // Concrete return type (not IReadOnlyCollection<Permission>) so `var`-typed callers get
+    // ImmutableArray<Permission>'s own struct enumerator via foreach's pattern-based binding,
+    // instead of boxing through IEnumerator<Permission> — this is on the SubjectPermission hot
+    // path (CheckEngineV2.SubjectPermission, V1 CheckEngine.SubjectPermission). Callers use
+    // .Length, not .Count (ImmutableArray<T> only exposes Count via explicit interface impl).
+    internal ImmutableArray<Permission> GetPermissions(string entityType)
     {
         return Entities[entityType].Permissions.Values;
     }

--- a/src/Valtuutus.Data.Db/BatchedPhysicalExecutor.cs
+++ b/src/Valtuutus.Data.Db/BatchedPhysicalExecutor.cs
@@ -179,7 +179,11 @@ internal sealed class BatchedPhysicalExecutor(Schema schema, IRelationalBatchOps
                     pooled.Dispose();
                     throw;
                 }
-                sink.CompleteWithPayload(op.Token, pooled);
+                // .Transfer() (not pooled itself): CompleteWithPayload takes `object`, and boxing
+                // the PooledList<T> struct there is a real per-op heap allocation. The underlying
+                // List<T> is already a reference type — CheckPlanExecutor re-wraps it in a
+                // PooledList<T> on the consuming side (see CheckPlanExecutor.OnOpCompleted).
+                sink.CompleteWithPayload(op.Token, pooled.Transfer());
                 break;
             }
             case OpKind.CheckOp:

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -484,6 +484,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -484,6 +484,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -484,6 +484,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -484,6 +484,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -483,6 +483,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -483,6 +483,7 @@ namespace Valtuutus.Core.Pools
         public System.ReadOnlySpan<T> AsSpan() { }
         public void Dispose() { }
         public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { }
+        public System.Collections.Generic.List<T> Transfer() { }
         public static Valtuutus.Core.Pools.PooledList<T> Rent() { }
     }
 }

--- a/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
+++ b/tests/Valtuutus.Data.InMemory.Tests/V2/CheckPlanExecutorSpecs.cs
@@ -156,7 +156,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema))
             { Physical = new DefaultPhysicalExecutor(schema) { Reader = reader } };
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest(entityType, entityId, permission, subjectRelation, depth)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest(entityType, entityId, permission, subjectRelation, depth) }, ctx, default);
         return results[0];
     }
 
@@ -222,7 +222,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = physical };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10)],
+            new CheckRootRequest[] { new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10) },
             ctx, default, precompiledRoots: combined.Roots, combinedSlotCount: combined.SlotCount);
 
         results.Should().Equal(true, true);
@@ -262,7 +262,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = physical };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10)],
+            new CheckRootRequest[] { new CheckRootRequest("team", "1", "edit", null, 10), new CheckRootRequest("team", "1", "delete", null, 10) },
             ctx, default);
 
         results.Should().Equal(true, true);
@@ -606,7 +606,7 @@ public class CheckPlanExecutorSpecs
             { SubjectType = "user", SubjectId = "u1", SnapToken = default, Context = new Dictionary<string, object>() };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, ctx, default, memoizeRoots: false);
         results[0].Should().BeTrue("r0 resolves immediately true and short-circuits the union");
 
         // r1's op is still genuinely outstanding at this point — the executor must not be
@@ -726,7 +726,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("household", "1", "view", null, 10)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest("household", "1", "view", null, 10) }, ctx, default);
 
         results[0].Should().BeTrue();
         recording.SubmitCalls.Should().ContainSingle();
@@ -762,7 +762,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, ctx, default);
 
         results[0].Should().BeTrue("owner is granted");
         recording.SubmitCalls.Should().ContainSingle(
@@ -813,7 +813,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, ctx, default);
 
         results[0].Should().BeTrue();
         recording.SubmitCalls.Should().ContainSingle();
@@ -851,7 +851,7 @@ public class CheckPlanExecutorSpecs
         executor.Physical = physical;
 
         var act = async () => await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Should().BeSameAs(boom);
 
         var drainTask = executor.DrainStragglersAsync();
@@ -873,7 +873,7 @@ public class CheckPlanExecutorSpecs
         executor.Physical = physical;
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         results[0].Should().BeTrue("r0 short-circuits the union");
 
         var drainTask = executor.DrainStragglersAsync();
@@ -884,7 +884,7 @@ public class CheckPlanExecutorSpecs
         // The instance must still be fully usable afterwards (this is what pooling relies on).
         physical.HeldRelations.Clear();
         var again = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         again[0].Should().BeTrue();
     }
 
@@ -910,21 +910,22 @@ public class CheckPlanExecutorSpecs
         executor.Physical = physical;
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         results[0].Should().BeTrue("r0 short-circuits before the TTU expansion arrives");
 
         var drainTask = executor.DrainStragglersAsync();
-        // PooledList is a readonly struct rented from the shared pool; boxing it into the
-        // object-typed payload channel is exactly what DefaultPhysicalExecutor does for real.
+        // Rent a PooledList and hand off its raw List<T> via .Transfer() — mirrors what
+        // PhysicalOpRunner does for real (see PhysicalExecution.cs): the object-typed payload
+        // channel carries the List<T> itself, not the PooledList<T> struct, to avoid boxing it.
         var payload = Valtuutus.Core.Pools.PooledList<RelationTuple>.Rent();
         payload.Add(new RelationTuple("doc", "1", "shared", "group", "g1"));
         payload.Add(new RelationTuple("doc", "1", "shared", "group", "g2"));
-        physical.ReleaseWithPayload("shared", payload);
+        physical.ReleaseWithPayload("shared", payload.Transfer());
         await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         physical.HeldRelations.Clear();
         var again = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         again[0].Should().BeTrue("the drained straggler expansion must not leak into this call");
     }
 
@@ -954,7 +955,7 @@ public class CheckPlanExecutorSpecs
         executor.Physical = recording;
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), default, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), default, memoizeRoots: false);
         results[0].Should().BeTrue("r0 short-circuits the union");
         var submittedBeforeDrain = recording.Submitted.Count;
 
@@ -962,7 +963,7 @@ public class CheckPlanExecutorSpecs
         var payload = Valtuutus.Core.Pools.PooledList<RelationTuple>.Rent();
         payload.Add(new RelationTuple("doc", "1", "shared", "group", "g1"));
         payload.Add(new RelationTuple("doc", "1", "shared", "group", "g2"));
-        controllable.ReleaseWithPayload("shared", payload);
+        controllable.ReleaseWithPayload("shared", payload.Transfer());
         await drainTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         recording.Submitted.Count.Should().Be(submittedBeforeDrain,
@@ -984,7 +985,7 @@ public class CheckPlanExecutorSpecs
 
         using var cts = new CancellationTokenSource(50);
         var act = async () => await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], Ctx(), cts.Token, memoizeRoots: false);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, Ctx(), cts.Token, memoizeRoots: false);
         await act.Should().ThrowAsync<OperationCanceledException>();
 
         var drainTask = executor.DrainStragglersAsync();
@@ -1031,7 +1032,7 @@ public class CheckPlanExecutorSpecs
         var executor = new CheckPlanExecutor(schema, new CheckPlanCache(schema)) { Physical = recording };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, ctx, default);
 
         results[0].Should().BeTrue();
         recording.SubmitCalls.Should().ContainSingle();
@@ -1072,7 +1073,7 @@ public class CheckPlanExecutorSpecs
             { Physical = new DefaultPhysicalExecutor(schema) { Reader = reader } };
 
         var results = await executor.ExecuteAsync(
-            [new CheckRootRequest("doc", "1", "view", null, 10)], ctx, default);
+            new CheckRootRequest[] { new CheckRootRequest("doc", "1", "view", null, 10) }, ctx, default);
 
         results[0].Should().BeTrue();
     }


### PR DESCRIPTION
## Summary
Follow-on from #283's trace investigation. Closes #285.

- **`CheckRootRequest[]` per `SubjectPermission` call** — `CheckPlanExecutor.ExecuteAsync` now takes `ReadOnlyMemory<CheckRootRequest>` backed by a reusable per-executor buffer (`_multiRootBuffer`, same pattern as the existing `_singleRootBuffer`), instead of a fresh array every call. Also drops the `names[]` array by re-enumerating permissions after the await instead of caching names up front.
- **`Schema.GetPermissions` enumerator boxes** — return type changed from `IReadOnlyCollection<Permission>` to `ImmutableArray<Permission>`, so `var`-typed callers get the struct enumerator instead of boxing through the interface (benefits both `CheckEngineV2.SubjectPermission` and V1 `CheckEngine.SubjectPermission`). Note: `CombinedPlanCache`'s box only fires once per `(EntityType, SubjectType)` cache miss, not per call as originally suspected — the fix still helps both sites.
- **`PooledList<AttributeTuple>`/`PooledList<RelationTuple>` — resolved, was inconclusive.** Root cause wasn't the InMemory reader (that pools correctly) — it's `IOpCompletionSink.CompleteWithPayload(int, object)` boxing the `PooledList<RelationTuple>` struct on every `GetRelations`/`GetIndirectRelations` op, in the shared `PhysicalOpRunner`/`BatchedPhysicalExecutor` code every provider goes through. Fixed by transferring the underlying `List<T>` (already a reference type, via `.Transfer()`) through the payload channel instead, re-wrapped as a `PooledList<T>` on the consuming side in `CheckPlanExecutor`. `PooledList<T>.Transfer()` is now public (was internal) since `Valtuutus.Data.Db` needs it from a separate assembly.

## Benchmarks
InMemory, `VALTUUTUS_CHECK_V2=1`, before/after via git-stash A/B (same methodology as #283):

| Benchmark | Alloc before | Alloc after | Δ |
|---|---|---|---|
| `SubjectPermission` | 1229 B | 960 B | -22% |
| `SubjectPermission_Diamond` | 1116 B | 896 B | -20% |
| `Check_Diamond` | 600 B | 552 B | -8% |
| `Check_UsersetMiss` | 600 B | 552 B | -8% |
| `Check_Simple` / `Check_Prune` / `Check_UnionTtuDirect` | unchanged | unchanged | — |

Latency flat across the board (allocation-only fixes). `Check`/`Explain` single-root paths benefit incidentally from the shared `PooledList` fix where they hit `GetRelations`/`GetIndirectRelations`; unaffected elsewhere.

## Test plan
- [x] `CI=true dotnet test Valtuutus.slnx` — full suite green (34/34 assemblies, 0 failures)
- [x] API-approval snapshots updated for `PooledList<T>.Transfer()` becoming public
- [x] Benchmarked before/after per lead, interleaved via git-stash A/B