### PR TITLE
refactor: function execution moves from boxed dict to positional span (#290)

### DIFF
--- a/src/Valtuutus.Core/AttributeTuple.cs
+++ b/src/Valtuutus.Core/AttributeTuple.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Valtuutus.Core.Lang;
 
 namespace Valtuutus.Core;
 
@@ -20,14 +21,14 @@ public sealed record AttributeTuple
         Value = value;
     }
 
-    public object? GetValue(Type type)
+    public LiteralValueUnion GetValue(Type type)
     {
         return type switch
         {
-            { } t when t == typeof(string) => Value.GetValue<string>(),
-            { } t when t == typeof(int) => Value.GetValue<int>(),
-            { } t when t == typeof(decimal) => Value.GetValue<decimal>(),
-            { } t when t == typeof(bool) => Value.GetValue<bool>(),
+            { } t when t == typeof(string) => new LiteralValueUnion { LiteralType = LangType.String, StringValue = Value.GetValue<string>() },
+            { } t when t == typeof(int) => new LiteralValueUnion { LiteralType = LangType.Int, IntValue = Value.GetValue<int>() },
+            { } t when t == typeof(decimal) => new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = Value.GetValue<decimal>() },
+            { } t when t == typeof(bool) => new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = Value.GetValue<bool>() },
             _ => throw new NotSupportedException("Unsupported type")
         };
     }

--- a/src/Valtuutus.Core/Configuration/ConfigureSchema.cs
+++ b/src/Valtuutus.Core/Configuration/ConfigureSchema.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Engines.Check;
 using Valtuutus.Core.Engines.LookupEntity;
 using Valtuutus.Core.Engines.LookupSubject;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Lang.SchemaReaders;
 
 namespace Valtuutus.Core.Configuration;
@@ -25,7 +26,7 @@ public static class ConfigureSchema
     public static IServiceCollection AddValtuutusCore(
         this IServiceCollection services,
         string schemaText,
-        IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
+        IReadOnlyDictionary<string, FunctionExecutor>? compiledFunctions = null)
     {
         var builder = new SchemaReader(compiledFunctions);
         var result = builder.Parse(schemaText);
@@ -55,7 +56,7 @@ public static class ConfigureSchema
     public static IServiceCollection AddValtuutusCore(
         this IServiceCollection services,
         Stream stream,
-        IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
+        IReadOnlyDictionary<string, FunctionExecutor>? compiledFunctions = null)
     {
         var builder = new SchemaReader(compiledFunctions);
         var result = builder.Parse(stream);

--- a/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
+++ b/src/Valtuutus.Core/Engines/Check/CheckEngine.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Valtuutus.Core.Data;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Observability;
 using Valtuutus.Core.Pools;
 using Valtuutus.Core.Schemas;
@@ -675,20 +676,19 @@ public sealed class CheckEngine(IDataReaderProvider reader, Schema schema) : ICh
             foreach (var a in attributes)
                 attributesByName[a.Attribute] = a;
 
-            using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
-
-            using var fnArgs = paramToArg.ToLambdaArgs(
-                static (arg, state) =>
+            using var fnArgs = fn.BuildArgs(
+                leafExp.Args,
+                static (arg, paramType, state) =>
                 {
                     var (byName, entityType, sch) = state;
-                    return byName.TryGetValue(arg.AttributeName, out var a)
-                        ? a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type)
-                        : null;
+                    if (!byName.TryGetValue(arg.AttributeName, out var a))
+                        return new LiteralValueUnion { LiteralType = paramType };
+                    return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
                 },
                 (attributesByName, entityType, schema),
                 ctx.Context);
 
-            var result = fn.Lambda(fnArgs.Dictionary);
+            var result = fn.Lambda(fnArgs.Span);
             if (node is not null) node.Detail = $"fn result={result}";
             return result;
         }

--- a/src/Valtuutus.Core/Engines/Check/V2/AttributeExpressionEvaluator.cs
+++ b/src/Valtuutus.Core/Engines/Check/V2/AttributeExpressionEvaluator.cs
@@ -1,4 +1,5 @@
 using Valtuutus.Core.Data;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Pools;
 using Valtuutus.Core.Schemas;
 
@@ -37,19 +38,19 @@ internal static class AttributeExpressionEvaluator
             foreach (var a in attributes)
                 attributesByName[a.Attribute] = a;
 
-            using var paramToArg = fn.CreateParamToArgMap(leafExp.Args);
-            using var fnArgs = paramToArg.ToLambdaArgs(
-                static (arg, state) =>
+            using var fnArgs = fn.BuildArgs(
+                leafExp.Args,
+                static (arg, paramType, state) =>
                 {
                     var (byName, entityType, sch) = state;
-                    return byName.TryGetValue(arg.AttributeName, out var a)
-                        ? a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type)
-                        : null;
+                    if (!byName.TryGetValue(arg.AttributeName, out var a))
+                        return new LiteralValueUnion { LiteralType = paramType };
+                    return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
                 },
                 (attributesByName, entityType, schema),
                 ctx.Context);
 
-            return fn.Lambda(fnArgs.Dictionary);
+            return fn.Lambda(fnArgs.Span);
         }
         finally
         {

--- a/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupEntity/LookupEntityEngine.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using Valtuutus.Core.Data;
 using Valtuutus.Core.Engines.Check;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Observability;
 using Valtuutus.Core.Pools;
 using Valtuutus.Core.Schemas;
@@ -421,8 +422,7 @@ public sealed class LookupEntityEngine(
             entityIds,
             ct);
 
-        using var paramToArgMap = fn.CreateParamToArgMap(node.Args);
-        return EvaluateExpressionMatches(attributes, req, fn, paramToArgMap);
+        return EvaluateExpressionMatches(attributes, req, fn, node.Args);
     }
 
     private Task<List<LookupEntityResult>> LookupLeaf(LookupEntityRequestInternal req, PermissionNodeLeaf node, CancellationToken ct)
@@ -473,33 +473,32 @@ public sealed class LookupEntityEngine(
             (reader, attributeArguments, req, ct));
         var attributes = await attributesTask;
 
-        using var paramToArgMap = fn.CreateParamToArgMap(node.Args);
-
-        return EvaluateExpressionMatches(attributes, req, fn, paramToArgMap);
+        return EvaluateExpressionMatches(attributes, req, fn, node.Args);
     }
 
     private List<LookupEntityResult> EvaluateExpressionMatches(
         IReadOnlyDictionary<(string AttributeName, string EntityId), AttributeTuple> attributes,
         LookupEntityRequestInternal req,
         Function fn,
-        PooledDictionary<FunctionParameter, PermissionNodeExpArgument> paramToArgMap)
+        PermissionNodeExpArgument[] args)
     {
         var result = ListPool<LookupEntityResult>.Rent();
 
         foreach (var attr in attributes.Values)
         {
-            using var fnArgs = paramToArgMap.ToLambdaArgs(
-                static (arg, state) =>
+            using var fnArgs = fn.BuildArgs(
+                args,
+                static (arg, paramType, state) =>
                 {
                     var (attrs, entityId, entityType, sch) = state;
                     if (!attrs.TryGetValue((arg.AttributeName, entityId), out var a))
-                        return null;
+                        return new LiteralValueUnion { LiteralType = paramType };
                     return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
                 },
                 (attributes, attr.EntityId, req.EntityType, schema),
                 req.Context);
 
-            if (fn.Lambda(fnArgs.Dictionary))
+            if (fn.Lambda(fnArgs.Span))
             {
                 result.Add(new LookupEntityResult(attr.EntityType, attr.EntityId));
             }

--- a/src/Valtuutus.Core/Engines/LookupSubject/LookupSubjectEngine.cs
+++ b/src/Valtuutus.Core/Engines/LookupSubject/LookupSubjectEngine.cs
@@ -7,6 +7,7 @@ using Valtuutus.Core.Data;
 using Valtuutus.Core.Engines.Check;
 using Valtuutus.Core.Engines.LookupEntity;
 using Valtuutus.Core.Engines;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Observability;
 using Valtuutus.Core.Pools;
 using Valtuutus.Core.Schemas;
@@ -333,33 +334,32 @@ public sealed class LookupSubjectEngine(
                 Attributes = attributeArguments, EntityType = req.EntityType, SnapToken = req.SnapToken.Value
             }, req.EntitiesIds, ct);
 
-        using var paramToArgMap = fn.CreateParamToArgMap(node.Args);
-
-        return new RelationOrAttributeTuples(EvaluateExpressionMatches(attributes, req, fn, paramToArgMap));
+        return new RelationOrAttributeTuples(EvaluateExpressionMatches(attributes, req, fn, node.Args));
     }
 
     private List<AttributeTuple> EvaluateExpressionMatches(
         IReadOnlyDictionary<(string AttributeName, string EntityId), AttributeTuple> attributes,
         LookupSubjectRequestInternal req,
         Function fn,
-        PooledDictionary<FunctionParameter, PermissionNodeExpArgument> paramToArgMap)
+        PermissionNodeExpArgument[] args)
     {
         var result = new List<AttributeTuple>();
 
         foreach (var attr in attributes.Values)
         {
-            using var fnArgs = paramToArgMap.ToLambdaArgs(
-                static (arg, state) =>
+            using var fnArgs = fn.BuildArgs(
+                args,
+                static (arg, paramType, state) =>
                 {
                     var (attrs, entityId, entityType, sch) = state;
                     if (!attrs.TryGetValue((arg.AttributeName, entityId), out var a))
-                        return null;
+                        return new LiteralValueUnion { LiteralType = paramType };
                     return a.GetValue(sch.GetAttribute(entityType, arg.AttributeName).Type);
                 },
                 (attributes, attr.EntityId, req.EntityType, schema),
                 req.Context);
 
-            if (fn.Lambda(fnArgs.Dictionary))
+            if (fn.Lambda(fnArgs.Span))
             {
                 result.Add(attr);
             }

--- a/src/Valtuutus.Core/Lang/ExpressionNode.cs
+++ b/src/Valtuutus.Core/Lang/ExpressionNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Reflection;
 using Valtuutus.Lang;
 
@@ -6,7 +7,7 @@ namespace Valtuutus.Core.Lang;
 
 internal abstract record FunctionNode<T>
 {
-    internal abstract Expression<Func<IDictionary<string, object?>, T>> GetExpression(ParameterExpression args);
+    internal abstract Expression<FunctionNodeExecutor<T>> GetExpression(ParameterExpression args);
     internal abstract LangType TypeContext { get; }
 }
 
@@ -62,52 +63,6 @@ internal static class LangTypeExtensions
     }
 }
 
-internal record struct LiteralValueUnion : IComparable<LiteralValueUnion>
-{
-    public LangType LiteralType { get; set; }
-    public int? IntValue { get; set; }
-    public string? StringValue { get; set; }
-    public decimal? DecimalValue { get; set; }
-    public bool? BooleanValue { get; set; }
-
-    public int CompareTo(LiteralValueUnion other)
-    {
-        if (LiteralType != other.LiteralType)
-            throw new ArgumentException("Incompatible literal type comparison");
-
-        var intValueComparison = Nullable.Compare(IntValue, other.IntValue);
-        if (intValueComparison != 0)
-            return intValueComparison;
-
-        var stringValueComparison = string.Compare(StringValue, other.StringValue, StringComparison.Ordinal);
-        if (stringValueComparison != 0)
-            return stringValueComparison;
-
-        return Nullable.Compare(DecimalValue, other.DecimalValue);
-    }
-
-    public static bool operator <(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) < 0;
-
-    public static bool operator >(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) > 0;
-
-    public static bool operator <=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) <= 0;
-
-    public static bool operator >=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) >= 0;
-
-    // Named wrappers around the operators above, so ExpressionNode.cs's comparison nodes can pass an
-    // explicit MethodInfo into Expression.Equal/NotEqual/LessThan/etc. instead of relying on those
-    // factories' by-name operator-method search (GetUserDefinedBinaryOperator), which throws under
-    // NativeAOT once trimming removes an operator that's otherwise only reachable via reflection.
-    // Calling the operators here directly (a == b, a < b, ...) also keeps them reachable for the
-    // trimmer, since this is now a normal static call site rather than a reflection-only one.
-    internal static bool AreEqual(LiteralValueUnion left, LiteralValueUnion right) => left == right;
-    internal static bool AreNotEqual(LiteralValueUnion left, LiteralValueUnion right) => left != right;
-    internal static bool IsLessThan(LiteralValueUnion left, LiteralValueUnion right) => left < right;
-    internal static bool IsGreaterThan(LiteralValueUnion left, LiteralValueUnion right) => left > right;
-    internal static bool IsLessThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left <= right;
-    internal static bool IsGreaterThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left >= right;
-}
-
 internal abstract record LeafFunctionNode : FunctionNode<LiteralValueUnion>
 {
 }
@@ -117,22 +72,22 @@ internal record StringLiteralFnNode : LeafFunctionNode
     internal override LangType TypeContext => LangType.String;
     internal required string Value { get; init; }
 
-    internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
+    internal override Expression<FunctionNodeExecutor<LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
         var wrappedValue = new LiteralValueUnion { LiteralType = LangType.String, StringValue = Value };
-        return Expression.Lambda<Func<IDictionary<string, object?>, LiteralValueUnion>>(
+        return Expression.Lambda<FunctionNodeExecutor<LiteralValueUnion>>(
             Expression.Constant(wrappedValue), args);
     }
 }
 
 internal record IntegerLiteralFnNode : LeafFunctionNode
 {
-    internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
+    internal override Expression<FunctionNodeExecutor<LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
         var wrappedValue = new LiteralValueUnion { LiteralType = LangType.Int, IntValue = Value };
-        return Expression.Lambda<Func<IDictionary<string, object?>, LiteralValueUnion>>(
+        return Expression.Lambda<FunctionNodeExecutor<LiteralValueUnion>>(
             Expression.Constant(wrappedValue), args);
     }
 
@@ -145,11 +100,11 @@ internal record DecimalLiteralFnNode : LeafFunctionNode
     internal override LangType TypeContext => LangType.Decimal;
     internal required decimal Value { get; init; }
 
-    internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
+    internal override Expression<FunctionNodeExecutor<LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
         var wrappedValue = new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = Value };
-        return Expression.Lambda<Func<IDictionary<string, object?>, LiteralValueUnion>>(
+        return Expression.Lambda<FunctionNodeExecutor<LiteralValueUnion>>(
             Expression.Constant(wrappedValue), args);
     }
 }
@@ -159,87 +114,42 @@ internal record BooleanLiteralFnNode : LeafFunctionNode
     internal override LangType TypeContext => LangType.Boolean;
     internal required bool Value { get; init; }
 
-    internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
+    internal override Expression<FunctionNodeExecutor<LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
         var wrappedValue = new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = Value };
-        return Expression.Lambda<Func<IDictionary<string, object?>, LiteralValueUnion>>(
+        return Expression.Lambda<FunctionNodeExecutor<LiteralValueUnion>>(
             Expression.Constant(wrappedValue), args);
     }
 }
 
 internal record ParameterIdFnNode : LeafFunctionNode
 {
-    // IDictionary<string, object?>.get_Item, resolved once via a typeof() on the exact interface
-    // (a linker-recognized pattern that doesn't require DynamicallyAccessedMembers/produce a
-    // warning) rather than Expression.Property(instance, "Item", args), whose *overload* is
-    // unconditionally [RequiresUnreferencedCode] and throws under trimming/NativeAOT. Calling the
-    // indexer's own get_Item directly (not a wrapper method) keeps the compiled/interpreted tree
-    // identical in shape to the original code -- no extra call frame on this hot path.
-    private static readonly MethodInfo DictionaryIndexerGetMethod =
-        typeof(IDictionary<string, object?>).GetProperty("Item")!.GetGetMethod()!;
+    // Expression Trees can't build a managed-pointer node for ReadOnlySpan<T>'s indexer (see
+    // SpanIndexHelper's doc comment in LiteralValueUnion.cs) -- indexing goes through that helper
+    // via Expression.Call instead of Expression.Property/MakeIndex. Reached only via this reflected
+    // MethodInfo, so [DynamicDependency] keeps SpanIndexHelper.At rooted under trimming/NativeAOT --
+    // without it the trimmer has no ordinary call-graph edge to At and could remove it as unused.
+    [DynamicDependency(nameof(SpanIndexHelper.At), typeof(SpanIndexHelper))]
+    private static readonly MethodInfo AtMethod =
+        typeof(SpanIndexHelper).GetMethod(nameof(SpanIndexHelper.At), BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    internal override Expression<Func<IDictionary<string, object?>, LiteralValueUnion>> GetExpression(
+    internal override Expression<FunctionNodeExecutor<LiteralValueUnion>> GetExpression(
         ParameterExpression args)
     {
-        var key = Expression.Constant(ParameterName);
+        // No MemberInit/type-switch needed here (unlike the old dict-indexer version): the arg
+        // buffer built by Function.BuildArgs already carries the correctly-typed LiteralValueUnion
+        // (LiteralType + the one relevant value field) at this parameter's position -- this node
+        // just reads it back out by position.
+        var indexExpression = Expression.Call(AtMethod, args, Expression.Constant(ParameterOrder));
 
-        var indexExpression = Expression.Call(args, DictionaryIndexerGetMethod, key);
-
-        var newLiteralValueUnionExpression = ParameterType switch
-        {
-           LangType.String => Expression.MemberInit(
-                Expression.New(typeof(LiteralValueUnion)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.LiteralType))!,
-                    Expression.Constant(ParameterType)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.StringValue))!,
-                    Expression.Convert(indexExpression, typeof(string)))
-            ),
-            LangType.Int => Expression.MemberInit(
-                Expression.New(typeof(LiteralValueUnion)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.LiteralType))!,
-                    Expression.Constant(ParameterType)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.IntValue))!,
-                    Expression.Convert(indexExpression, typeof(int?)))
-            ),
-
-            LangType.Decimal => Expression.MemberInit(
-                Expression.New(typeof(LiteralValueUnion)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.LiteralType))!,
-                    Expression.Constant(ParameterType)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.DecimalValue))!,
-                    Expression.Convert(indexExpression, typeof(decimal?)))
-            ),
-            LangType.Boolean => Expression.MemberInit(
-                Expression.New(typeof(LiteralValueUnion)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.LiteralType))!,
-                    Expression.Constant(ParameterType)),
-                Expression.Bind(
-                    typeof(LiteralValueUnion).GetProperty(nameof(LiteralValueUnion.BooleanValue))!,
-                    Expression.Convert(indexExpression, typeof(bool?)))
-            ),
-
-            _ => throw new ArgumentException("Unsupported type for LiteralValueUnion")
-        };
-
-        var lambda =
-            Expression.Lambda<Func<IDictionary<string, object?>, LiteralValueUnion>>(newLiteralValueUnionExpression,
-                args);
-
-        return lambda;
+        return Expression.Lambda<FunctionNodeExecutor<LiteralValueUnion>>(indexExpression, args);
     }
 
     internal override LangType TypeContext => ParameterType;
     internal required string ParameterName { get; set; }
+    internal required int ParameterOrder { get; set; }
     internal required LangType ParameterType { get; set; }
-    
 }
 
 internal abstract record BinaryFunctionNode<TOut, TIn> : FunctionNode<TOut>
@@ -253,14 +163,14 @@ internal record LessOrEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralVa
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsLessThanOrEqual).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.LessThanOrEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -271,14 +181,14 @@ internal record LessExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUnio
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsLessThan).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.LessThan(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -289,14 +199,14 @@ internal record GreaterOrEqualExpressionFnNode : BinaryFunctionNode<bool, Litera
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsGreaterThanOrEqual).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.GreaterThanOrEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -307,14 +217,14 @@ internal record GreaterExpressionFnNode : BinaryFunctionNode<bool, LiteralValueU
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.IsGreaterThan).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.GreaterThan(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -325,14 +235,14 @@ internal record NotEqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValue
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.AreNotEqual).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.NotEqual(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -343,14 +253,14 @@ internal record EqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUni
     private static readonly MethodInfo Method =
         ((Func<LiteralValueUnion, LiteralValueUnion, bool>)LiteralValueUnion.AreEqual).Method;
 
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.Equal(leftExpression, rightExpression, liftToNull: false, method: Method);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -358,14 +268,14 @@ internal record EqualExpressionFnNode : BinaryFunctionNode<bool, LiteralValueUni
 
 internal record OrExpressionFnNode : BinaryFunctionNode<bool, bool>
 {
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.OrElse(leftExpression, rightExpression);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -373,11 +283,11 @@ internal record OrExpressionFnNode : BinaryFunctionNode<bool, bool>
 
 internal record ParenthesisExpressionFnNode : UnaryFunctionNode<bool>
 {
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var childExpression = Child.GetExpression(args).Body;
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(childExpression, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(childExpression, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -385,11 +295,11 @@ internal record ParenthesisExpressionFnNode : UnaryFunctionNode<bool>
 
 internal record NotExpressionFnNode : UnaryFunctionNode<bool>
 {
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var childExpression = Child.GetExpression(args).Body;
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(Expression.Not(childExpression), args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(Expression.Not(childExpression), args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;
@@ -397,14 +307,14 @@ internal record NotExpressionFnNode : UnaryFunctionNode<bool>
 
 internal record AndExpressionFnNode : BinaryFunctionNode<bool, bool>
 {
-    internal override Expression<Func<IDictionary<string, object?>, bool>> GetExpression(ParameterExpression args)
+    internal override Expression<FunctionNodeExecutor<bool>> GetExpression(ParameterExpression args)
     {
         var leftExpression = Left.GetExpression(args).Body;
         var rightExpression = Right.GetExpression(args).Body;
 
         var comparison = Expression.AndAlso(leftExpression, rightExpression);
 
-        return Expression.Lambda<Func<IDictionary<string, object?>, bool>>(comparison, args);
+        return Expression.Lambda<FunctionNodeExecutor<bool>>(comparison, args);
     }
 
     internal override LangType TypeContext => LangType.Boolean;

--- a/src/Valtuutus.Core/Lang/LiteralValueUnion.cs
+++ b/src/Valtuutus.Core/Lang/LiteralValueUnion.cs
@@ -1,0 +1,81 @@
+namespace Valtuutus.Core.Lang;
+
+/// <summary>
+/// Positional, boxing-free calling convention for schema DSL function bodies. Both the
+/// source-generated compiled path (<c>SchemaFunctionsGen.All</c>) and the Expression-tree-compiled
+/// fallback path (<see cref="Valtuutus.Core.Lang.SchemaReaders.SchemaFunctionReader"/>) produce
+/// this delegate shape.
+/// </summary>
+public delegate bool FunctionExecutor(ReadOnlySpan<LiteralValueUnion> args);
+
+// Internal composition delegate used while building a FunctionExecutor out of nested
+// FunctionNode<T> expression trees (T is LiteralValueUnion for leaf/comparison operands, bool for
+// the top-level function body) -- same fixed ReadOnlySpan<LiteralValueUnion> parameter, only the
+// return type varies per node. Kept distinct from FunctionExecutor (rather than just using
+// FunctionExecutor everywhere) because generic BCL delegates (Func<T>) cannot have a ref struct
+// like ReadOnlySpan<T> substituted for a type parameter -- this hand-written delegate sidesteps
+// that by keeping the span parameter fixed/closed and only T (the return type) open.
+internal delegate T FunctionNodeExecutor<T>(ReadOnlySpan<LiteralValueUnion> args);
+
+// Expression Trees can't represent ReadOnlySpan<T>'s indexer directly: its getter returns by
+// managed pointer, and Expression.Property/Expression.MakeIndex throw "Property cannot have a
+// managed pointer type" for it (confirmed during the #275 spike). Routing the read through this
+// ordinary static method sidesteps that -- the method returns by value, so Expression.Call has no
+// managed-pointer node to build.
+internal static class SpanIndexHelper
+{
+    // Reached only via the reflected MethodInfo in ParameterIdFnNode (Expression.Call), so the
+    // trimmer has no ordinary call-graph edge to it and would otherwise remove it as unused, the
+    // same class of risk the DictionaryIndexerGetMethod comment on ParameterIdFnNode already
+    // documents. The [DynamicDependency] that keeps it rooted lives on that reflecting call site
+    // (ParameterIdFnNode.AtMethod), not here -- the attribute has to sit on the consumer that does
+    // the reflection, not on the target itself (a self-referential declaration on the target
+    // protects nothing).
+    internal static LiteralValueUnion At(ReadOnlySpan<LiteralValueUnion> args, int index) => args[index];
+}
+
+public record struct LiteralValueUnion : IComparable<LiteralValueUnion>
+{
+    public LangType LiteralType { get; set; }
+    public int? IntValue { get; set; }
+    public string? StringValue { get; set; }
+    public decimal? DecimalValue { get; set; }
+    public bool? BooleanValue { get; set; }
+
+    public int CompareTo(LiteralValueUnion other)
+    {
+        if (LiteralType != other.LiteralType)
+            throw new ArgumentException("Incompatible literal type comparison");
+
+        var intValueComparison = Nullable.Compare(IntValue, other.IntValue);
+        if (intValueComparison != 0)
+            return intValueComparison;
+
+        var stringValueComparison = string.Compare(StringValue, other.StringValue, StringComparison.Ordinal);
+        if (stringValueComparison != 0)
+            return stringValueComparison;
+
+        return Nullable.Compare(DecimalValue, other.DecimalValue);
+    }
+
+    public static bool operator <(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) < 0;
+
+    public static bool operator >(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) > 0;
+
+    public static bool operator <=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) <= 0;
+
+    public static bool operator >=(LiteralValueUnion left, LiteralValueUnion right) => left.CompareTo(right) >= 0;
+
+    // Named wrappers around the operators above, so ExpressionNode.cs's comparison nodes can pass an
+    // explicit MethodInfo into Expression.Equal/NotEqual/LessThan/etc. instead of relying on those
+    // factories' by-name operator-method search (GetUserDefinedBinaryOperator), which throws under
+    // NativeAOT once trimming removes an operator that's otherwise only reachable via reflection.
+    // Calling the operators here directly (a == b, a < b, ...) also keeps them reachable for the
+    // trimmer, since this is now a normal static call site rather than a reflection-only one.
+    internal static bool AreEqual(LiteralValueUnion left, LiteralValueUnion right) => left == right;
+    internal static bool AreNotEqual(LiteralValueUnion left, LiteralValueUnion right) => left != right;
+    internal static bool IsLessThan(LiteralValueUnion left, LiteralValueUnion right) => left < right;
+    internal static bool IsGreaterThan(LiteralValueUnion left, LiteralValueUnion right) => left > right;
+    internal static bool IsLessThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left <= right;
+    internal static bool IsGreaterThanOrEqual(LiteralValueUnion left, LiteralValueUnion right) => left >= right;
+}

--- a/src/Valtuutus.Core/Lang/SchemaReaders/SchemaFunctionReader.cs
+++ b/src/Valtuutus.Core/Lang/SchemaReaders/SchemaFunctionReader.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq.Expressions;
 using Valtuutus.Core.Schemas;
 using Valtuutus.Lang;
@@ -7,7 +7,7 @@ namespace Valtuutus.Core.Lang.SchemaReaders;
 
 internal class SchemaFunctionReader(
     SchemaReader schemaReader,
-    IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
+    IReadOnlyDictionary<string, FunctionExecutor>? compiledFunctions = null)
 {
     public Function Parse(ValtuutusParser.FunctionDefinitionContext funcCtx)
     {
@@ -41,19 +41,23 @@ internal class SchemaFunctionReader(
         }
 
         var tree = ParseFunctionExpression(
-            parameters.ToDictionary(x => x.ParamName, x => x.ParamType),
+            parameters.ToDictionary(x => x.ParamName),
             funcCtx.functionBody().functionExpression()
         );
 
-        var parameter = Expression.Parameter(typeof(IDictionary<string, object?>), "args");
+        var parameter = Expression.Parameter(typeof(ReadOnlySpan<LiteralValueUnion>), "args");
         var expression = tree.GetExpression(parameter);
 
         schemaReader.AddSymbol(new FunctionSymbol(functionName, funcCtx.Start.Line, funcCtx.Start.Column, parameters));
 
-        return new Function(functionName, parameters, expression.Compile());
+        // expression.Compile() returns FunctionNodeExecutor<bool>, a distinct-but-signature-identical
+        // delegate type from FunctionExecutor -- the explicit `new FunctionExecutor(...)` conversion
+        // is a standard C# delegate-to-delegate conversion (verified during the #275 spike), not a
+        // wrapper allocation cost beyond the usual delegate object.
+        return new Function(functionName, parameters, new FunctionExecutor(expression.Compile()));
     }
 
-    private FunctionNode<bool> ParseFunctionExpression(IDictionary<string, LangType> args,
+    private FunctionNode<bool> ParseFunctionExpression(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.FunctionExpressionContext exprCtx)
     {
         return exprCtx switch
@@ -75,7 +79,7 @@ internal class SchemaFunctionReader(
         };
     }
 
-    private FunctionNode<LiteralValueUnion> ParseLiteralExpression(IDictionary<string, LangType> args,
+    private FunctionNode<LiteralValueUnion> ParseLiteralExpression(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.FunctionExpressionContext exprCtx)
     {
         return exprCtx switch
@@ -87,7 +91,7 @@ internal class SchemaFunctionReader(
         };
     }
 
-    private FunctionNode<bool> CreateAndExpressionNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> CreateAndExpressionNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.AndExpressionContext andCtx)
     {
         return new AndExpressionFnNode
@@ -97,7 +101,7 @@ internal class SchemaFunctionReader(
         };
     }
 
-    private FunctionNode<bool> CreateOrExpressionNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> CreateOrExpressionNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.OrExpressionContext orCtx)
     {
         return new OrExpressionFnNode
@@ -107,7 +111,7 @@ internal class SchemaFunctionReader(
         };
     }
 
-    private FunctionNode<bool> CreateComparisonExpressionNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> CreateComparisonExpressionNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.FunctionExpressionContext ctx)
     {
         BinaryFunctionNode<bool, LiteralValueUnion> node = ctx switch
@@ -155,7 +159,7 @@ internal class SchemaFunctionReader(
         return node;
     }
 
-    private FunctionNode<bool> CreateParenthesisExpressionNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> CreateParenthesisExpressionNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.ParenthesisExpressionContext parenCtx)
     {
         var node = new ParenthesisExpressionFnNode
@@ -166,7 +170,7 @@ internal class SchemaFunctionReader(
         return node;
     }
 
-    private FunctionNode<bool> CreateNotExpressionNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> CreateNotExpressionNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.NotExpressionContext notCtx)
     {
         var node = new NotExpressionFnNode { Child = ParseFunctionExpression(args, notCtx.functionExpression()) };
@@ -174,7 +178,7 @@ internal class SchemaFunctionReader(
         return node;
     }
 
-    private FunctionNode<bool> TryHandleBooleanIdOrParamNode(IDictionary<string, LangType> args,
+    private FunctionNode<bool> TryHandleBooleanIdOrParamNode(IDictionary<string, FunctionParameter> args,
         ValtuutusParser.FunctionExpressionContext exprCtx)
     {
         var handleLiteralNode = (ValtuutusParser.LiteralExpressionContext litCtx) =>
@@ -219,18 +223,18 @@ internal class SchemaFunctionReader(
     }
 
     private FunctionNode<LiteralValueUnion> CreateParameterIdFnNode(
-        IDictionary<string, LangType> args,
+        IDictionary<string, FunctionParameter> args,
         ValtuutusParser.IdentifierExpressionContext idCtx
     )
     {
         var id = idCtx.ID().GetText();
-        if (!args.TryGetValue(id, out var type))
+        if (!args.TryGetValue(id, out var parameter))
         {
             throw new LangException($"{idCtx.ID().GetText()} is not defined in the function context.", idCtx.Start.Line,
                 idCtx.Start.Column);
         }
 
-        return new ParameterIdFnNode() { ParameterType = type, ParameterName = id };
+        return new ParameterIdFnNode() { ParameterType = parameter.ParamType, ParameterName = id, ParameterOrder = parameter.ParamOrder };
     }
 
     private FunctionNode<LiteralValueUnion> ParseLiteralFnNode(ValtuutusParser.LiteralContext literalCtx)

--- a/src/Valtuutus.Core/Lang/SchemaReaders/SchemaReader.cs
+++ b/src/Valtuutus.Core/Lang/SchemaReaders/SchemaReader.cs
@@ -13,7 +13,7 @@ internal class SchemaReader
     private readonly SchemaAttributeReader _schemaAttributeReader;
     private readonly SchemaPermissionReader _schemaPermissionReader;
 
-    public SchemaReader(IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>>? compiledFunctions = null)
+    public SchemaReader(IReadOnlyDictionary<string, FunctionExecutor>? compiledFunctions = null)
     {
         _schemaFunctionReader = new SchemaFunctionReader(this, compiledFunctions);
         _schemaAttributeReader = new SchemaAttributeReader(this);

--- a/src/Valtuutus.Core/Pools/LiteralValueArrayPool.cs
+++ b/src/Valtuutus.Core/Pools/LiteralValueArrayPool.cs
@@ -1,0 +1,28 @@
+using System.Buffers;
+using Valtuutus.Core.Lang;
+
+namespace Valtuutus.Core.Pools;
+
+/// <summary>
+/// ArrayPool-backed buffer for a function call's positional LiteralValueUnion arguments. Not a
+/// stackalloc Span because LiteralValueUnion carries a `string?` field, making it a managed type
+/// -- stackalloc is illegal for managed types (confirmed via CS0208 during the #275 spike).
+/// </summary>
+internal readonly struct PooledLiteralValueArray : IDisposable
+{
+    private readonly LiteralValueUnion[] _array;
+    private readonly int _length;
+
+    private PooledLiteralValueArray(LiteralValueUnion[] array, int length)
+    {
+        _array = array;
+        _length = length;
+    }
+
+    public Span<LiteralValueUnion> Span => _array.AsSpan(0, _length);
+
+    public static PooledLiteralValueArray Rent(int length) =>
+        new(ArrayPool<LiteralValueUnion>.Shared.Rent(length), length);
+
+    public void Dispose() => ArrayPool<LiteralValueUnion>.Shared.Return(_array, clearArray: true);
+}

--- a/src/Valtuutus.Core/Schemas/Function.cs
+++ b/src/Valtuutus.Core/Schemas/Function.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Valtuutus.Core.Lang;
 using Valtuutus.Core.Pools;
 
@@ -15,79 +15,57 @@ public record Function
 {
     public string Name { get; init; }
     public List<FunctionParameter> Parameters { get; init; }
-    internal Func<IDictionary<string, object?>, bool> Lambda { get; init; }
-    
-    internal Function(string name, List<FunctionParameter> parameters, Func<IDictionary<string, object?>, bool> lambda)
+    internal FunctionExecutor Lambda { get; init; }
+
+    internal Function(string name, List<FunctionParameter> parameters, FunctionExecutor lambda)
     {
         Name = name;
         Parameters = parameters;
         Lambda = lambda;
     }
-    
-    internal PooledDictionary<FunctionParameter, PermissionNodeExpArgument> CreateParamToArgMap(IList<PermissionNodeExpArgument> args)
-    {
-        var pooled = PooledDictionary<FunctionParameter, PermissionNodeExpArgument>.Rent();
-        foreach (var parameter in Parameters)
-            pooled.Dictionary[parameter] = args[parameter.ParamOrder];
-        return pooled;
-    }
 
-    public bool Execute(IDictionary<string, object?> arguments)
-    {
-        return Lambda(arguments);
-    }
-}
+    public bool Execute(ReadOnlySpan<LiteralValueUnion> arguments) => Lambda(arguments);
 
-internal static class ParamToArgMapExtensions
-{
-    public static PooledDictionary<string, object?> ToLambdaArgs(
-        this PooledDictionary<FunctionParameter, PermissionNodeExpArgument> map,
-        Func<PermissionNodeExpArgumentAttribute, object?> attrValueMapper,
-        IDictionary<string, object> context)
-    {
-        var pooled = PooledDictionary<string, object?>.Rent();
-
-        foreach (var pair in map.Dictionary)
-        {
-            object? value = pair.Value switch
-            {
-                PermissionNodeExpArgumentAttribute arg => attrValueMapper(arg),
-                PermissionNodeExpArgumentStringLiteral arg => arg.Value,
-                PermissionNodeExpArgumentIntLiteral arg => arg.Value,
-                PermissionNodeExpArgumentDecimalLiteral arg => arg.Value,
-                PermissionNodeExpArgumentContextAccess arg => context[arg.ContextPropertyName],
-                _ => throw new NotSupportedException("Unsupported argument type.")
-            };
-
-            pooled.Dictionary[pair.Key.ParamName] = value;
-        }
-
-        return pooled;
-    }
-
-    public static PooledDictionary<string, object?> ToLambdaArgs<TState>(
-        this PooledDictionary<FunctionParameter, PermissionNodeExpArgument> map,
-        Func<PermissionNodeExpArgumentAttribute, TState, object?> attrValueMapper,
+    /// <summary>
+    /// Builds this function's positional argument buffer directly from Parameters' ParamOrder --
+    /// replaces the old two-step CreateParamToArgMap (FunctionParameter -&gt; PermissionNodeExpArgument
+    /// pooled dict) + ToLambdaArgs (string-keyed, object?-boxing pooled dict) pipeline with one pass
+    /// into an ArrayPool-backed buffer. Caller disposes the returned PooledLiteralValueArray and
+    /// passes its Span to Lambda.
+    /// </summary>
+    internal PooledLiteralValueArray BuildArgs<TState>(
+        IList<PermissionNodeExpArgument> args,
+        Func<PermissionNodeExpArgumentAttribute, LangType, TState, LiteralValueUnion> attrValueMapper,
         TState state,
         IDictionary<string, object> context)
     {
-        var pooled = PooledDictionary<string, object?>.Rent();
+        var pooled = PooledLiteralValueArray.Rent(Parameters.Count);
+        var span = pooled.Span;
 
-        foreach (var pair in map.Dictionary)
+        foreach (var parameter in Parameters)
         {
-            object? value = pair.Value switch
+            var arg = args[parameter.ParamOrder];
+            span[parameter.ParamOrder] = arg switch
             {
-                PermissionNodeExpArgumentAttribute arg => attrValueMapper(arg, state),
-                PermissionNodeExpArgumentStringLiteral arg => arg.Value,
-                PermissionNodeExpArgumentIntLiteral arg => arg.Value,
-                PermissionNodeExpArgumentDecimalLiteral arg => arg.Value,
-                PermissionNodeExpArgumentContextAccess arg => context[arg.ContextPropertyName],
+                PermissionNodeExpArgumentAttribute a => attrValueMapper(a, parameter.ParamType, state),
+                PermissionNodeExpArgumentStringLiteral s => new LiteralValueUnion { LiteralType = LangType.String, StringValue = s.Value },
+                PermissionNodeExpArgumentIntLiteral i => new LiteralValueUnion { LiteralType = LangType.Int, IntValue = i.Value },
+                PermissionNodeExpArgumentDecimalLiteral d => new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = d.Value },
+                PermissionNodeExpArgumentBooleanLiteral b => new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = b.Value },
+                PermissionNodeExpArgumentContextAccess c => FromContextValue(context[c.ContextPropertyName], parameter.ParamType),
                 _ => throw new NotSupportedException("Unsupported argument type.")
             };
-
-            pooled.Dictionary[pair.Key.ParamName] = value;
         }
 
         return pooled;
     }
+
+    private static LiteralValueUnion FromContextValue(object value, LangType type) => type switch
+    {
+        LangType.String => new LiteralValueUnion { LiteralType = LangType.String, StringValue = (string)value },
+        LangType.Int => new LiteralValueUnion { LiteralType = LangType.Int, IntValue = (int)value },
+        LangType.Decimal => new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = (decimal)value },
+        LangType.Boolean => new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = (bool)value },
+        _ => throw new NotSupportedException("Unsupported type for LiteralValueUnion")
+    };
 }

--- a/src/Valtuutus.Lang.SourceGen/SchemaFunctionsEmitter.cs
+++ b/src/Valtuutus.Lang.SourceGen/SchemaFunctionsEmitter.cs
@@ -58,13 +58,14 @@ public static class SchemaFunctionsEmitter
                 continue;
             }
 
-            methods.AppendLine($"\tpublic static bool {methodName}(IDictionary<string, object?> args)");
+            methods.AppendLine($"\tpublic static bool {methodName}(ReadOnlySpan<LiteralValueUnion> args)");
             methods.AppendLine("\t{");
-            foreach (var p in result.Parameters)
+            for (int i = 0; i < result.Parameters.Count; i++)
             {
+                var p = result.Parameters[i];
                 // Verbatim-escape the local var name unconditionally, mirroring FunctionExpressionTranspiler's
                 // parameter references, since either may be a C# reserved keyword (e.g. "class").
-                methods.AppendLine($"\t\tvar @{p.Name} = {CastExpression(p.Type)}args[\"{p.Name}\"];");
+                methods.AppendLine($"\t\tvar @{p.Name} = args[{i}].{FieldName(p.Type)};");
             }
             methods.AppendLine($"\t\treturn {result.BodyExpression};");
             methods.AppendLine("\t}");
@@ -77,6 +78,7 @@ public static class SchemaFunctionsEmitter
         sb.AppendLine("#nullable enable");
         sb.AppendLine("using System;");
         sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("using Valtuutus.Core.Lang;");
         sb.AppendLine();
         sb.AppendLine("namespace Valtuutus.Lang;");
         sb.AppendLine();
@@ -86,7 +88,7 @@ public static class SchemaFunctionsEmitter
         sb.AppendLine("public static class SchemaFunctionsGen");
         sb.AppendLine("{");
         sb.Append(methods);
-        sb.AppendLine("\tpublic static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>");
+        sb.AppendLine("\tpublic static readonly IReadOnlyDictionary<string, FunctionExecutor> All = new Dictionary<string, FunctionExecutor>");
         sb.AppendLine("\t{");
         sb.Append(dictionaryEntries);
         sb.AppendLine("\t};");
@@ -121,12 +123,12 @@ public static class SchemaFunctionsEmitter
         return sb.ToString();
     }
 
-    private static string CastExpression(FunctionParamType type) => type switch
+    private static string FieldName(FunctionParamType type) => type switch
     {
-        FunctionParamType.Int => "(int?)",
-        FunctionParamType.String => "(string?)",
-        FunctionParamType.Decimal => "(decimal?)",
-        FunctionParamType.Boolean => "(bool?)",
+        FunctionParamType.Int => "IntValue",
+        FunctionParamType.String => "StringValue",
+        FunctionParamType.Decimal => "DecimalValue",
+        FunctionParamType.Boolean => "BooleanValue",
         _ => throw new ArgumentOutOfRangeException(nameof(type))
     };
 }

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.DotNet9_0.verified.txt
@@ -11,7 +11,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -33,8 +33,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -435,6 +435,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -456,6 +457,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -508,7 +522,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet10_0.verified.txt
@@ -11,7 +11,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -33,8 +33,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -435,6 +435,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -456,6 +457,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -508,7 +522,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.DotNet9_0.verified.txt
@@ -11,7 +11,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -33,8 +33,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -435,6 +435,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -456,6 +457,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -508,7 +522,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet11_0.verified.txt
@@ -11,7 +11,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -33,8 +33,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -435,6 +435,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -456,6 +457,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -508,7 +522,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet8_0.verified.txt
@@ -10,7 +10,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -32,8 +32,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -434,6 +434,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -455,6 +456,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -507,7 +521,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
+++ b/tests/Valtuutus.Api.Tests/verify/ApiSpecs.ApproveCore.DotNet9_0.verified.txt
@@ -10,7 +10,7 @@ namespace Valtuutus.Core
         public string EntityId { get; }
         public string EntityType { get; }
         public System.Text.Json.Nodes.JsonValue Value { get; }
-        public object? GetValue(System.Type type) { }
+        public Valtuutus.Core.Lang.LiteralValueUnion GetValue(System.Type type) { }
     }
     public readonly struct RelationTuple : System.IEquatable<Valtuutus.Core.RelationTuple>
     {
@@ -32,8 +32,8 @@ namespace Valtuutus.Core.Configuration
     }
     public static class ConfigureSchema
     {
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, System.Func<System.Collections.Generic.IDictionary<string, object?>, bool>>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IO.Stream stream, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddValtuutusCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string schemaText, System.Collections.Generic.IReadOnlyDictionary<string, Valtuutus.Core.Lang.FunctionExecutor>? compiledFunctions = null) { }
     }
 }
 namespace Valtuutus.Core.Data
@@ -434,6 +434,7 @@ namespace Valtuutus.Core.Engines.LookupSubject
 }
 namespace Valtuutus.Core.Lang
 {
+    public delegate bool FunctionExecutor(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> args);
     public class LangError : System.IEquatable<Valtuutus.Core.Lang.LangError>
     {
         public LangError() { }
@@ -455,6 +456,19 @@ namespace Valtuutus.Core.Lang
         String = 1,
         Decimal = 2,
         Boolean = 3,
+    }
+    public struct LiteralValueUnion : System.IComparable<Valtuutus.Core.Lang.LiteralValueUnion>, System.IEquatable<Valtuutus.Core.Lang.LiteralValueUnion>
+    {
+        public bool? BooleanValue { get; set; }
+        public decimal? DecimalValue { get; set; }
+        public int? IntValue { get; set; }
+        public Valtuutus.Core.Lang.LangType LiteralType { get; set; }
+        public string? StringValue { get; set; }
+        public int CompareTo(Valtuutus.Core.Lang.LiteralValueUnion other) { }
+        public static bool operator <(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator <=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
+        public static bool operator >=(Valtuutus.Core.Lang.LiteralValueUnion left, Valtuutus.Core.Lang.LiteralValueUnion right) { }
     }
 }
 namespace Valtuutus.Core.Observability
@@ -507,7 +521,7 @@ namespace Valtuutus.Core.Schemas
     {
         public string Name { get; init; }
         public System.Collections.Generic.List<Valtuutus.Core.Schemas.FunctionParameter> Parameters { get; init; }
-        public bool Execute(System.Collections.Generic.IDictionary<string, object?> arguments) { }
+        public bool Execute(System.ReadOnlySpan<Valtuutus.Core.Lang.LiteralValueUnion> arguments) { }
     }
     public class FunctionParameter : System.IEquatable<Valtuutus.Core.Schemas.FunctionParameter>
     {

--- a/tests/Valtuutus.Lang.SourceGen.IntegrationTests/GeneratedSchemaFunctionsSpecs.cs
+++ b/tests/Valtuutus.Lang.SourceGen.IntegrationTests/GeneratedSchemaFunctionsSpecs.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Valtuutus.Core.Lang;
 
 namespace Valtuutus.Lang.SourceGen.IntegrationTests;
 
@@ -7,10 +8,10 @@ public class GeneratedSchemaFunctionsSpecs
     [Fact]
     public void ShouldExposeCompiledFunctionMethod()
     {
-        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = 1 })
+        SchemaFunctionsGen.IsActiveStatus([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeTrue();
 
-        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = 2 })
+        SchemaFunctionsGen.IsActiveStatus([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 2 }])
             .Should().BeFalse();
     }
 
@@ -19,24 +20,24 @@ public class GeneratedSchemaFunctionsSpecs
     {
         SchemaFunctionsGen.All.Should().ContainKey("isActiveStatus");
 
-        SchemaFunctionsGen.All["isActiveStatus"](new Dictionary<string, object?> { ["status"] = 1 })
+        SchemaFunctionsGen.All["isActiveStatus"]([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeTrue();
     }
 
     [Fact]
     public void ShouldHandleNullAttributeValueWithoutThrowing()
     {
-        SchemaFunctionsGen.IsActiveStatus(new Dictionary<string, object?> { ["status"] = null })
+        SchemaFunctionsGen.IsActiveStatus([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = null }])
             .Should().BeFalse();
     }
 
     [Fact]
     public void ShouldCompileAndExecuteFunctionWithKeywordParameterName()
     {
-        SchemaFunctionsGen.CheckClass(new Dictionary<string, object?> { ["class"] = "admin" })
+        SchemaFunctionsGen.CheckClass([new LiteralValueUnion { LiteralType = LangType.String, StringValue = "admin" }])
             .Should().BeTrue();
 
-        SchemaFunctionsGen.CheckClass(new Dictionary<string, object?> { ["class"] = "guest" })
+        SchemaFunctionsGen.CheckClass([new LiteralValueUnion { LiteralType = LangType.String, StringValue = "guest" }])
             .Should().BeFalse();
     }
 }

--- a/tests/Valtuutus.Lang.SourceGen.IntegrationTests/Valtuutus.Lang.SourceGen.IntegrationTests.csproj
+++ b/tests/Valtuutus.Lang.SourceGen.IntegrationTests/Valtuutus.Lang.SourceGen.IntegrationTests.csproj
@@ -24,6 +24,7 @@
     
     <ItemGroup>
         <ProjectReference Include="..\..\src\Valtuutus.Lang.SourceGen\Valtuutus.Lang.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"  />
+        <ProjectReference Include="..\..\src\Valtuutus.Core\Valtuutus.Core.csproj" />
     </ItemGroup>
     
     

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SchemaFunctionsEmitterSpecs.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SchemaFunctionsEmitterSpecs.cs
@@ -15,8 +15,8 @@ public class SchemaFunctionsEmitterSpecs
             diagnostics.Add);
 
         Assert.Empty(diagnostics);
-        Assert.Contains("public static bool IsActiveStatus(IDictionary<string, object?> args)", source);
-        Assert.Contains("var @status = (int?)args[\"status\"];", source);
+        Assert.Contains("public static bool IsActiveStatus(ReadOnlySpan<LiteralValueUnion> args)", source);
+        Assert.Contains("var @status = args[0].IntValue;", source);
         Assert.Contains("return (@status) == (1);", source);
         Assert.Contains("[\"isActiveStatus\"] = IsActiveStatus,", source);
     }
@@ -42,7 +42,7 @@ public class SchemaFunctionsEmitterSpecs
 
         Assert.Single(diagnostics);
         Assert.DoesNotContain("Broken", source);
-        Assert.Contains("public static bool Ok(IDictionary<string, object?> args)", source);
+        Assert.Contains("public static bool Ok(ReadOnlySpan<LiteralValueUnion> args)", source);
         Assert.DoesNotContain("[\"broken\"]", source);
         Assert.Contains("[\"ok\"] = Ok,", source);
     }
@@ -56,7 +56,7 @@ public class SchemaFunctionsEmitterSpecs
             diagnostics.Add);
 
         Assert.Empty(diagnostics);
-        Assert.Contains("public static bool IsActiveStatus(IDictionary<string, object?> args)", source);
+        Assert.Contains("public static bool IsActiveStatus(ReadOnlySpan<LiteralValueUnion> args)", source);
         Assert.Contains("[\"is_active_status\"] = IsActiveStatus,", source);
     }
 
@@ -69,7 +69,7 @@ public class SchemaFunctionsEmitterSpecs
             diagnostics.Add);
 
         Assert.Single(diagnostics);
-        Assert.Contains("public static bool IsActive(IDictionary<string, object?> args)", source);
+        Assert.Contains("public static bool IsActive(ReadOnlySpan<LiteralValueUnion> args)", source);
         Assert.Contains("[\"isActive\"] = IsActive,", source);
         Assert.DoesNotContain("[\"is_active\"]", source);
     }
@@ -83,7 +83,7 @@ public class SchemaFunctionsEmitterSpecs
             diagnostics.Add);
 
         Assert.Empty(diagnostics);
-        Assert.Contains("var @class = (string?)args[\"class\"];", source);
+        Assert.Contains("var @class = args[0].StringValue;", source);
         Assert.Contains("return (@class) == (\"admin\");", source);
     }
 }

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema1.vtt#SchemaFunctions.g.verified.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema1.vtt#SchemaFunctions.g.verified.cs
@@ -2,6 +2,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using Valtuutus.Core.Lang;
 
 namespace Valtuutus.Lang;
 
@@ -10,13 +11,13 @@ namespace Valtuutus.Lang;
 /// </summary>
 public static class SchemaFunctionsGen
 {
-	public static bool IsActiveStatus(IDictionary<string, object?> args)
+	public static bool IsActiveStatus(ReadOnlySpan<LiteralValueUnion> args)
 	{
-		var @status = (int?)args["status"];
+		var @status = args[0].IntValue;
 		return (@status) == (1);
 	}
 
-	public static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+	public static readonly IReadOnlyDictionary<string, FunctionExecutor> All = new Dictionary<string, FunctionExecutor>
 	{
 		["isActiveStatus"] = IsActiveStatus,
 	};

--- a/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema2.vtt#SchemaFunctions.g.verified.cs
+++ b/tests/Valtuutus.Lang.SourceGen.Tests/SourceGenSpecs.TestSchemaGen_fileName=schema2.vtt#SchemaFunctions.g.verified.cs
@@ -2,6 +2,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using Valtuutus.Core.Lang;
 
 namespace Valtuutus.Lang;
 
@@ -10,7 +11,7 @@ namespace Valtuutus.Lang;
 /// </summary>
 public static class SchemaFunctionsGen
 {
-	public static readonly IReadOnlyDictionary<string, Func<IDictionary<string, object?>, bool>> All = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+	public static readonly IReadOnlyDictionary<string, FunctionExecutor> All = new Dictionary<string, FunctionExecutor>
 	{
 	};
 }

--- a/tests/Valtuutus.Lang.Tests/CompiledFunctionsSpecs.cs
+++ b/tests/Valtuutus.Lang.Tests/CompiledFunctionsSpecs.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Lang.SchemaReaders;
 
 namespace Valtuutus.Lang.Tests;
@@ -8,7 +9,7 @@ public class CompiledFunctionsSpecs
     [Fact]
     public void Should_use_compiled_function_delegate_when_name_matches()
     {
-        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        var compiledFunctions = new Dictionary<string, FunctionExecutor>
         {
             // Deliberately returns the opposite of what the DSL body says, to prove
             // the compiled delegate is what actually executes, not the Expression-tree fallback.
@@ -21,14 +22,14 @@ public class CompiledFunctionsSpecs
 
         schema.Should().NotBeNull();
         schema.AsT0.Functions["isActiveStatus"]
-            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeFalse();
     }
 
     [Fact]
     public void Should_fall_back_to_expression_compile_when_name_not_in_map()
     {
-        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        var compiledFunctions = new Dictionary<string, FunctionExecutor>
         {
             ["someOtherFunction"] = _ => false
         };
@@ -39,7 +40,7 @@ public class CompiledFunctionsSpecs
 
         schema.Should().NotBeNull();
         schema.AsT0.Functions["isActiveStatus"]
-            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeTrue();
     }
 
@@ -52,7 +53,7 @@ public class CompiledFunctionsSpecs
 
         schema.Should().NotBeNull();
         schema.AsT0.Functions["isActiveStatus"]
-            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeTrue();
     }
 }

--- a/tests/Valtuutus.Lang.Tests/ConfigureSchemaSpecs.cs
+++ b/tests/Valtuutus.Lang.Tests/ConfigureSchemaSpecs.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Valtuutus.Core.Configuration;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Schemas;
 
 namespace Valtuutus.Lang.Tests;
@@ -10,7 +11,7 @@ public class ConfigureSchemaSpecs
     [Fact]
     public void Should_use_compiled_function_when_registered_via_AddValtuutusCore()
     {
-        var compiledFunctions = new Dictionary<string, Func<IDictionary<string, object?>, bool>>
+        var compiledFunctions = new Dictionary<string, FunctionExecutor>
         {
             // Deliberately returns the opposite of what the DSL body (`status == 1`) would produce,
             // to prove the compiled delegate registered via AddValtuutusCore is what actually executes.
@@ -31,7 +32,7 @@ public class ConfigureSchemaSpecs
         var schema = provider.GetRequiredService<Schema>();
 
         schema.Functions["isActiveStatus"]
-            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeFalse();
     }
 
@@ -52,7 +53,7 @@ public class ConfigureSchemaSpecs
         var schema = provider.GetRequiredService<Schema>();
 
         schema.Functions["isActiveStatus"]
-            .Execute(new Dictionary<string, object?> { ["status"] = 1 })
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1 }])
             .Should().BeTrue();
     }
 }

--- a/tests/Valtuutus.Lang.Tests/FunctionExpressionsSpecs.cs
+++ b/tests/Valtuutus.Lang.Tests/FunctionExpressionsSpecs.cs
@@ -1,5 +1,6 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Valtuutus.Core.Engines;
+using Valtuutus.Core.Lang;
 using Valtuutus.Core.Lang.SchemaReaders;
 using Valtuutus.Core.Schemas;
 
@@ -16,7 +17,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute balance int;
 
                 permission withdraw := check_balance(context.amount, balance) and owner;
@@ -28,10 +29,11 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_balance"].Execute(new Dictionary<string, object?>()
-            {
-                ["balance"] = 5000, ["amount"] = 5000
-            }).Should()
+        // fn check_balance(amount int, balance int) -- positional order: amount, balance
+        schema.AsT0.Functions["check_balance"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 5000 },
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 5000 },
+            ]).Should()
             .BeTrue();
     }
 
@@ -44,7 +46,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute balance int;
 
                 permission withdraw := check_balance(context.amount, balance) and owner;
@@ -55,10 +57,11 @@ public class FunctionExpressionsSpecs
         ");
 
         schema.Should().NotBeNull();
-        schema.AsT0.Functions["check_balance"].Execute(new Dictionary<string, object?>()
-            {
-                ["balance"] = null, ["amount"] = 500
-            }).Should()
+        // amount=500, balance=null
+        schema.AsT0.Functions["check_balance"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 500 },
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = null },
+            ]).Should()
             .BeFalse();
     }
 
@@ -71,7 +74,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute balance int;
 
                 permission withdraw := check_balance(context.amount, balance) and owner;
@@ -83,10 +86,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_balance"].Execute(new Dictionary<string, object?>()
-            {
-                ["balance"] = 5000, ["amount"] = 5000
-            }).Should()
+        schema.AsT0.Functions["check_balance"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 5000 },
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 5000 },
+            ]).Should()
             .BeTrue();
     }
 
@@ -99,7 +102,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute balance int;
 
                 permission withdraw := check_balance(context.amount, balance) and owner;
@@ -111,10 +114,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_balance"].Execute(new Dictionary<string, object?>()
-            {
-                ["balance"] = null, ["amount"] = 500
-            }).Should()
+        schema.AsT0.Functions["check_balance"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 500 },
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = null },
+            ]).Should()
             .BeFalse();
     }
 
@@ -127,7 +130,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute is_active bool;
 
                 permission access := check_active(is_active);
@@ -139,7 +142,8 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_active"].Execute(new Dictionary<string, object?>() { ["is_active"] = true })
+        schema.AsT0.Functions["check_active"]
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true }])
             .Should()
             .BeTrue();
     }
@@ -153,7 +157,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute is_active bool;
 
                 permission access := not_check_active(is_active);
@@ -165,7 +169,8 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["not_check_active"].Execute(new Dictionary<string, object?>() { ["is_active"] = true })
+        schema.AsT0.Functions["not_check_active"]
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true }])
             .Should()
             .BeFalse();
     }
@@ -179,7 +184,7 @@ public class FunctionExpressionsSpecs
             entity account {
 
                 relation owner @user;
-                
+
                 attribute is_active bool;
 
                 permission access := check_active(is_active);
@@ -191,7 +196,8 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_active"].Execute(new Dictionary<string, object?>() { ["is_active"] = true })
+        schema.AsT0.Functions["check_active"]
+            .Execute([new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true }])
             .Should()
             .BeTrue();
     }
@@ -205,7 +211,7 @@ public class FunctionExpressionsSpecs
             entity document {
 
                 relation owner @user;
-                
+
                 attribute title string;
 
                 permission view := check_title(title, ""Confidential"");
@@ -217,10 +223,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_title"].Execute(new Dictionary<string, object?>()
-            {
-                ["title"] = "Confidential", ["requiredTitle"] = "Confidential"
-            }).Should()
+        schema.AsT0.Functions["check_title"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.String, StringValue = "Confidential" },
+                new LiteralValueUnion { LiteralType = LangType.String, StringValue = "Confidential" },
+            ]).Should()
             .BeTrue();
     }
 
@@ -233,7 +239,7 @@ public class FunctionExpressionsSpecs
             entity product {
 
                 relation owner @user;
-                
+
                 attribute price decimal;
 
                 permission purchase := check_price(price, 99.99);
@@ -245,10 +251,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_price"].Execute(new Dictionary<string, object?>()
-            {
-                ["price"] = 99.99m, ["maxPrice"] = 99.99m
-            }).Should()
+        schema.AsT0.Functions["check_price"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = 99.99m },
+                new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = 99.99m },
+            ]).Should()
             .BeTrue();
     }
 
@@ -261,7 +267,7 @@ public class FunctionExpressionsSpecs
             entity transaction {
 
                 relation owner @user;
-                
+
                 attribute amount int;
                 attribute is_verified bool;
                 attribute note string;
@@ -276,10 +282,13 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_transaction"].Execute(new Dictionary<string, object?>()
-            {
-                ["amount"] = 200, ["is_verified"] = true, ["note"] = "Valid", ["fee"] = 5.00m
-            }).Should()
+        // fn check_transaction(amount int, is_verified bool, note string, fee decimal)
+        schema.AsT0.Functions["check_transaction"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 200 },
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true },
+                new LiteralValueUnion { LiteralType = LangType.String, StringValue = "Valid" },
+                new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = 5.00m },
+            ]).Should()
             .BeTrue();
     }
 
@@ -292,7 +301,7 @@ public class FunctionExpressionsSpecs
             entity transaction {
 
                 relation owner @user;
-                
+
                 attribute amount int;
                 attribute is_verified bool;
                 attribute note string;
@@ -307,10 +316,12 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_transaction"].Execute(new Dictionary<string, object?>()
-            {
-                ["amount"] = 50, ["is_verified"] = false, ["note"] = "Invalid", ["fee"] = 15.00m
-            }).Should()
+        schema.AsT0.Functions["check_transaction"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 50 },
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = false },
+                new LiteralValueUnion { LiteralType = LangType.String, StringValue = "Invalid" },
+                new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = 15.00m },
+            ]).Should()
             .BeFalse();
     }
 
@@ -323,7 +334,7 @@ public class FunctionExpressionsSpecs
             entity transaction {
 
                 relation owner @user;
-                
+
                 attribute amount int;
                 attribute is_verified bool;
                 attribute note string;
@@ -338,10 +349,12 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_transaction"].Execute(new Dictionary<string, object?>()
-            {
-                ["amount"] = 200, ["is_verified"] = false, ["note"] = "Valid", ["fee"] = 5.00m
-            }).Should()
+        schema.AsT0.Functions["check_transaction"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 200 },
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = false },
+                new LiteralValueUnion { LiteralType = LangType.String, StringValue = "Valid" },
+                new LiteralValueUnion { LiteralType = LangType.Decimal, DecimalValue = 5.00m },
+            ]).Should()
             .BeFalse();
     }
 
@@ -367,10 +380,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_transaction"].Execute(new Dictionary<string, object?>()
-            {
-                ["is_verified"] = false, ["is_public"] = true
-            }).Should()
+        schema.AsT0.Functions["check_transaction"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = false },
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true },
+            ]).Should()
             .BeTrue();
     }
 
@@ -396,10 +409,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["check_transaction"].Execute(new Dictionary<string, object?>()
-            {
-                ["is_verified"] = false, ["is_public"] = true
-            }).Should()
+        schema.AsT0.Functions["check_transaction"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = false },
+                new LiteralValueUnion { LiteralType = LangType.Boolean, BooleanValue = true },
+            ]).Should()
             .BeTrue();
     }
 
@@ -413,7 +426,8 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["not_deleted"].Execute(new Dictionary<string, object?>() { ["status"] = "deleted", })
+        schema.AsT0.Functions["not_deleted"]
+            .Execute([new LiteralValueUnion { LiteralType = LangType.String, StringValue = "deleted" }])
             .Should()
             .BeFalse();
     }
@@ -428,10 +442,10 @@ public class FunctionExpressionsSpecs
 
         schema.Should().NotBeNull();
 
-        schema.AsT0.Functions["within_threshold"].Execute(new Dictionary<string, object?>()
-            {
-                ["value"] = 100, ["threshold"] = 1000,
-            }).Should()
+        schema.AsT0.Functions["within_threshold"].Execute([
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 100 },
+                new LiteralValueUnion { LiteralType = LangType.Int, IntValue = 1000 },
+            ]).Should()
             .BeTrue();
     }
 


### PR DESCRIPTION
## Summary

- `Function.Lambda`'s calling convention changes from `Func<IDictionary<string, object?>, bool>` to a positional, allocation-free `FunctionExecutor(ReadOnlySpan<LiteralValueUnion> args)` delegate, reusing the existing `LiteralValueUnion` tagged-union struct (now public) as the function-call argument representation.
- Both function-construction paths (source-gen'd `SchemaFunctionsGen.All` and the Expression-tree-compiled fallback) and all 4 call sites (V1 `CheckEngine`, V2 `AttributeExpressionEvaluator`, `LookupEntityEngine`, `LookupSubjectEngine`) are updated.
- `Function.CreateParamToArgMap`/`ToLambdaArgs`'s two pooled dictionaries are replaced by one `ArrayPool`-backed `PooledLiteralValueArray` built directly from positional `ParamOrder`.
- **Breaking public API change (deliberate, no compat shim)**: `AddValtuutusCore`'s `compiledFunctions` parameter and `SchemaFunctionsGen.All`'s value type change to `FunctionExecutor`; `AttributeTuple.GetValue(Type)` now returns `LiteralValueUnion` instead of boxing to `object?`.

## Why

Decision from the #275 spike: kills boxing at the function-argument boundary with a much smaller diff than full per-signature codegen, at the same implementation cost as a struct-valued-dict alternative but without leaving dict/string-hash CPU overhead on data that's already positional end-to-end.

## Benchmark (InMemory, `VALTUUTUS_CHECK_V2=1`, net10.0)

Isolated the function-specific cost via `Check_Complex` minus `Check_Simple` (which has no function call and is unaffected — 408 B in both before/after runs, confirming nothing outside the function path moved):

| | Check_Simple | Check_Complex | Function-attributable Δ |
|---|---|---|---|
| Before | 408 B | 504 B | 96 B |
| After | 408 B | 480 B | 72 B |

24 B/call reduction, matching exactly one `AttributeTuple.GetValue` box removed. No measurable latency change — function execution was never the bottleneck (dominated by attribute-fetch I/O); the payoff is reduced GC pressure under sustained load and in `LookupEntity`/`LookupSubject` fan-out, not single-check latency.

## Test plan

- [x] `dotnet build Valtuutus.slnx -c Release` — 0 errors
- [x] `CI=true dotnet test Valtuutus.slnx -c Release` — full suite green across all TFMs (net8/9/10/11), including regenerated Verify snapshots (`Api.Tests` public-API approval, source-gen output)
- [x] Benchmark before/after comparison (above)

Resolves #290